### PR TITLE
Fix off-by-one in calc_cber.

### DIFF
--- a/src/decode.c
+++ b/src/decode.c
@@ -25,7 +25,7 @@ static float calc_cber(int8_t *coded, uint8_t *decoded)
 
     // tail biting
     for (i = 0; i < 6; i++)
-        r = (r >> 1) | (decoded[FRAME_LEN - 7 + i] << 6);
+        r = (r >> 1) | (decoded[FRAME_LEN - 6 + i] << 6);
 
     for (i = 0, j = 0; i < FRAME_LEN; i++)
     {


### PR DESCRIPTION
The tail-biting portion of `calc_cber` takes the wrong bits from the end of the decoded message, so errors are reported when none are present. After this change, I now see a BER of 0.000000 when receiving a strong signal instead of ~0.000022.