### PR TITLE
Fix coarse carrier frequency offset correction.

### DIFF
--- a/src/sync.c
+++ b/src/sync.c
@@ -148,6 +148,18 @@ static int find_ref (float complex *buf, unsigned int ref, unsigned int rsid)
         }
         if (i == sizeof(needle))
             return n;
+        for (i = 0; i < sizeof(needle); i++)
+        {
+            // first bit of data may be wrong, so ignore
+            if ((n + i) % BLKSZ == 0) continue;
+            // ignore don't care bits
+            if (needle[i] < 0) continue;
+            // test if bit is correct
+            if (needle[i] == data[(n + i) % BLKSZ])
+                break;
+        }
+        if (i == sizeof(needle))
+            return n;
     }
     return -1;
 }
@@ -225,7 +237,7 @@ void sync_process(sync_t *st, float complex *buffer)
         }
         else if (st->cfo_wait == 0)
         {
-            for (i = -300; i < 300; ++i)
+            for (i = -38; i < 38; ++i)
             {
                 int offset2;
                 adjust_ref(buffer, st->phases, LB_START + i + BAND_LENGTH - 1);


### PR DESCRIPTION
The `find_ref` function does not take phase ambiguity into account, so it only detects reference subcarriers half the time. After I added a check for the other phase, the coarse carrier frequency offset correction went from working half the time to all the time.

I also reduced the search window to 76 subcarriers. Since there are only four possible reference subcarrier id's, it seems that the standard was only designed to account for that much frequency offset (approximately +/- 128 ppm at the upper end of the FM band).  A larger search window could result in the wrong reference subcarrier being detected (at least if the station is transmitting in the extended hybrid mode). I imagine +/- 128 ppm is sufficient for RTL-SDR dongles. The worst one I had was off by 100 ppm.