### PR TITLE
Decrease gain of U8_Q15 to mitigate clipping.

### DIFF
--- a/src/defines.h
+++ b/src/defines.h
@@ -34,7 +34,7 @@
 #define FRAME_LEN 146176
 
 #define U8_F(x) ( (((float)(x)) - 127) / 128 )
-#define U8_Q15(x) ( ((int16_t)(x) - 127) << 8 )
+#define U8_Q15(x) ( ((int16_t)(x) - 127) << 7 )
 
 typedef struct {
     int16_t r, i;


### PR DESCRIPTION
The current `U8_Q15` macro causes a couple problems when the input signal level approaches or exceeds full scale. First, an input sample of 255 is mapped to (255-127)<<8 which wraps to -32768, introducing distortion. Second, the `firdecim_q15` filter produces an output signal that has a higher maximum amplitude than the input signal, and so it needs some breathing room. Both problems can be solved by lowering the gain of `U8_Q15`. After this change, I was able to successfully receive even when the `-g` parameter was set a bit too high.