### PR TITLE
Invert spectrum to simplify receiver.

### DIFF
--- a/src/decode.c
+++ b/src/decode.c
@@ -89,8 +89,7 @@ void decode_process(decode_t *st)
         int k = i / (J * B);
         int row = (k * 11) % 32;
         int column = (k * 11 + k / (32*9)) % C;
-        // row bits are reveresed, hence the 719 - x
-        st->viterbi[out++] = st->buffer[(block * 32 + row) * 720 + 719 - (partition * C + column)];
+        st->viterbi[out++] = st->buffer[(block * 32 + row) * 720 + partition * C + column];
         if ((out % 6) == 5) // depuncture, [1, 1, 1, 1, 1, 0]
             st->viterbi[out++] = 0;
     }

--- a/src/input.c
+++ b/src/input.c
@@ -279,9 +279,9 @@ void input_cb(uint8_t *buf, uint32_t len, void *arg)
         cint16_t x[2], y;
 
         x[0].r = U8_Q15(buf[i * 4 + 0]);
-        x[0].i = U8_Q15(buf[i * 4 + 1]);
+        x[0].i = -U8_Q15(buf[i * 4 + 1]);
         x[1].r = U8_Q15(buf[i * 4 + 2]);
-        x[1].i = U8_Q15(buf[i * 4 + 3]);
+        x[1].i = -U8_Q15(buf[i * 4 + 3]);
 
         firdecim_q15_execute(st->filter, x, &y);
         resamp_q15_execute(st->resamp, &y, &st->buffer[new_avail], &nw);


### PR DESCRIPTION
Section 14.2.2 of http://www.nrscstandards.org/SG/NRSC-5-C/1011sG.pdf specifies that the transmitter's output signal is conjugated, inverting the frequency spectrum. Doing the same in the receiver eliminates the need to read out the bits in reverse order.