### PR TITLE
Add missing include.

### DIFF
--- a/src/decode.c
+++ b/src/decode.c
@@ -13,6 +13,7 @@
  * along with this program.  If not, see <http://www.gnu.org/licenses/>.
  */
 
+#include <string.h>
 #include "conv.h"
 #include "decode.h"
 #include "input.h"


### PR DESCRIPTION
This fixes a warning caused by #29:

`src/decode.c:161:5: warning: implicit declaration of function ‘memset’`