### PR TITLE
Add git tag for id3v2lib.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -77,6 +77,7 @@ if (USE_ID3V2LIB)
     ExternalProject_Add (
         id3v2lib_external
         GIT_REPOSITORY "https://github.com/larsbs/id3v2lib.git"
+        GIT_TAG 9bca1c33b8cd8037ee59de927bda057c9ac7043d
         PREFIX ${ID3V2LIB_PREFIX}
 
         INSTALL_COMMAND ""


### PR DESCRIPTION
Currently it's not possible to rebuild the project without a network connection because github needs to be checked for updates. Adding a `GIT_TAG` for id3v2lib solves the problem.