### PR TITLE
Handle PDUs that don't have a Header Expansion Field.

### DIFF
--- a/src/frame.c
+++ b/src/frame.c
@@ -227,6 +227,11 @@ static int find_program(uint8_t *buf, int program, size_t length)
             if (((buf[i] >> 4) & 7) == 1 && program == ((buf[i] >> 1) & 7))
                 return start;
         }
+        else
+        {
+            if (program == 0)
+                return start;
+        }
 
         // skip remaining bytes using last location
         i = start + parse_location(buf + start, lc_bits, hdr.nop - 1) + 1;

--- a/src/frame.c
+++ b/src/frame.c
@@ -228,10 +228,6 @@ static int find_program(uint8_t *buf, int program, size_t length)
                 return start;
         }
 
-        // bail-out in case of no program id flag
-        if (program == 0 && start == 0)
-            return start;
-
         // skip remaining bytes using last location
         i = start + parse_location(buf + start, lc_bits, hdr.nop - 1) + 1;
     }


### PR DESCRIPTION
Some stations (e.g. KQRT in Las Vegas) don't include a Header Expansion Field. Currently `find_program` returns -1 in this case, because it doesn't know what to do when the Header Expansion Flag is 0.

In that case there is only one program (number 0), so we should just check whether the user asked for program number 0.