### PR TITLE
Add length checks to frame_process.

### DIFF
--- a/src/frame.c
+++ b/src/frame.c
@@ -492,8 +492,12 @@ void frame_process(frame_t *st, size_t length)
     i = 14 + ((lc_bits * hdr.nop) + 4) / 8;
     // skip extended headers
     for (hef = hdr.hef; hef; ++i)
+    {
+        if (i >= length) return;
         hef = buf[i] >> 7;
+    }
 
+    if (hdr.la_location < i || hdr.la_location >= length) return;
     parse_psd(st, &buf[i], hdr.la_location-i+1);
     i = hdr.la_location + 1;
     seq = hdr.seq;


### PR DESCRIPTION
When the BER is high, the PDU header can be corrupted. This can result in a segfault when data is read past the end of the PDU buffer. I've corrected the problem by adding length checks before reading the Header Expansion and PSD bytes.

It's likely that this fixes #16.