### PR TITLE
Reduce CFO search window size to 76 subcarriers.

### DIFF
--- a/src/sync.c
+++ b/src/sync.c
@@ -251,7 +251,7 @@ void sync_process(sync_t *st, float complex *buffer)
         }
         else if (st->cfo_wait == 0)
         {
-            for (i = -300; i < 300; ++i)
+            for (i = -38; i < 38; ++i)
             {
                 int offset2;
                 adjust_ref(buffer, st->phases, LB_START + i + P1_BAND_LENGTH - 1);


### PR DESCRIPTION
This brings back the other change I had proposed in #22.

Searching a window wider than 76 subcarriers is likely to select the wrong subcarrier, at least in primary modes 11, 5 and 6 (which have four extra reference subcarriers towards the middle).

This still allows for a ppm error as high as +/- 125.