### PR TITLE
Correct the pulse shaping window function.

### DIFF
--- a/src/acquire.c
+++ b/src/acquire.c
@@ -180,15 +180,13 @@ void acquire_init(acquire_t *st, input_t *input)
     st->shape = malloc(sizeof(float) * FFTCP);
     for (i = 0; i < FFTCP; ++i)
     {
-        // The first CP samples overlap with last CP samples. Due to ISI, we
-        // don't want to use the samples on the edges of our symbol.
-        // We use the identity: sin^2 x + cos^2 x = 1.
+        // Pulse shaping window function
         if (i < CP)
-            st->shape[i] = powf(sinf(M_PI / 2 * i / CP), 2);
+            st->shape[i] = sinf(M_PI / 2 * i / CP);
         else if (i < FFT)
             st->shape[i] = 1;
         else
-            st->shape[i] = powf(cosf(M_PI / 2 * (i - FFT) / CP), 2);
+            st->shape[i] = cosf(M_PI / 2 * (i - FFT) / CP);
     }
 
     st->history_size = 0;


### PR DESCRIPTION
The current pulse shaping window function is raised to the power 2. The one specified in http://www.nrscstandards.org/SG/NRSC-5-C/2646s02.pdf Appendix A is not squared. I don't believe the squaring is necessary, because the transmitter also has its own pulse shaping window function (http://www.nrscstandards.org/SG/NRSC-5-C/1011sG.pdf section 13.2) and the combined effect of the two filters produces the desired squaring.

I tested this against my nrsc-5 transmitter and removing the extra squaring improved the MER by about 1 dB from ~21 to ~22 dB.