### PR TITLE
Accept frequency in MHz or Hz.

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ This was designed for use with an RTL-SDR dongle since that was our testing plat
 
 Options:
 
-       frequency                       rtl-sdr center frequency
+       frequency                       rtl-sdr center frequency in MHz or Hz
                                          (do not provide frequency when reading from file)
        program                         audio program to decode
                                          (0, 1, 2, or 3)
@@ -60,8 +60,8 @@ Options:
 
 Examples:
 
-     $ nrsc5 -p 63 -g 490 -w samples1071 107100000 0
+     $ nrsc5 -p 63 -g 490 -w samples1071 107.1 0
 
      $ nrsc5 -r samples1071 0
 
-     $ nrsc5 -o - -f adts 90500000 0 | mplayer -
+     $ nrsc5 -o - -f adts 90.5 0 | mplayer -

--- a/src/main.c
+++ b/src/main.c
@@ -99,6 +99,13 @@ static void log_lock(void *udata, int lock)
 }
 #endif
 
+unsigned int parse_freq(char *s)
+{
+    double d = strtod(s, NULL);
+    if (d < 10000) d *= 1e6;
+    return (unsigned int) d;
+}
+
 static void help(const char *progname)
 {
     fprintf(stderr, "Usage: %s [-q] [-l log-level] [-d device-index] [-g gain] [-p ppm-error] [-r samples-input] [-w samples-output] [-o audio-output -f adts|hdc|wav] [--dump-aas-files directory] frequency program\n", progname);
@@ -171,7 +178,7 @@ int main(int argc, char *argv[])
             help(argv[0]);
             return 0;
         }
-        frequency = strtoul(argv[optind], NULL, 0);
+        frequency = parse_freq(argv[optind]);
         program = strtoul(argv[optind+1], NULL, 0);
 
         count = rtlsdr_get_device_count();


### PR DESCRIPTION
Fixes #50.

This change allows the frequency to be specified either in MHz or Hz. If the number is greater than 10,000 it will be interpreted as Hz, otherwise as MHz. I chose that threshold because the RTL-SDR can't tune that high (in MHz) or that low (in Hz).

If the frequency is entered as `107.1M` (like `rtl_fm`) then the trailing `M` is simply ignored and it's interpreted as 107.1 MHz.