### PR TITLE
Fix cfo_idx integer overflow.

### DIFF
--- a/src/input.c
+++ b/src/input.c
@@ -95,6 +95,7 @@ static void input_push_to_acquire(input_t *st)
     // CFO is modified in sync, and is expected to be "immediately" applied
     for (unsigned int j = st->used + st->cfo_used; j < st->avail; j++)
         st->buffer[j] *= st->cfo_tbl[st->cfo_idx++ % FFT];
+    st->cfo_idx %= FFT;
 
     if (st->skip)
     {


### PR DESCRIPTION
Fixes #51 (and hopefully also #53).

I tracked down the reason the receiver stops after 48 minutes. It's because `cfo_idx` (a 32-bit signed integer) overflows, wrapping around to a negative number, at which point `st->cfo_idx++ % FFT` becomes negative, causing out-of-bounds accesses to `st->cfo_tbl` here:

https://github.com/theori-io/nrsc5/blob/b9acf8eb439e8a1ba783065aa9dd7c991d5bac12/src/input.c#L97

I've solved this by reducing `cfo_idx` mod `FFT` after the loop.

/cc @classicjazz