### PR TITLE
Only log SIS messages when there's a change.

### DIFF
--- a/src/decode.c
+++ b/src/decode.c
@@ -125,7 +125,7 @@ void decode_process_pids(decode_t *st)
 
     nrsc5_conv_decode_pids(st->viterbi_pids, st->scrambler_pids);
     descramble(st->scrambler_pids, PIDS_FRAME_LEN);
-    pids_frame_push(st->scrambler_pids);
+    pids_frame_push(&st->pids, st->scrambler_pids);
 }
 
 void decode_process_p3(decode_t *st)
@@ -161,6 +161,7 @@ void decode_reset(decode_t *st)
     st->idx_px1 = 0;
     st->i_p3 = 0;
     memset(st->pt_p3, 0, sizeof(unsigned int) * 4);
+    pids_init(&st->pids);
 }
 
 void decode_init(decode_t *st, struct input_t *input)

--- a/src/decode.h
+++ b/src/decode.h
@@ -2,6 +2,7 @@
 
 #include <stdint.h>
 #include "defines.h"
+#include "pids.h"
 
 typedef struct
 {
@@ -20,6 +21,8 @@ typedef struct
     unsigned int pt_p3[4];
     int8_t *viterbi_p3;
     uint8_t *scrambler_p3;
+
+    pids_t pids;
 } decode_t;
 
 void decode_process_p1(decode_t *st);

--- a/src/pids.h
+++ b/src/pids.h
@@ -2,4 +2,12 @@
 
 #include <stdint.h>
 
-void pids_frame_push(uint8_t *bits);
+typedef struct
+{
+    char country_code[3];
+    int fcc_facility_id;
+    char short_name[8];
+} pids_t;
+
+void pids_frame_push(pids_t *st, uint8_t *bits);
+void pids_init(pids_t *st);


### PR DESCRIPTION
Fixes #43.

Currently SIS logging is very noisy. To solve this, I'm proposing to log only when a PDU contains new values.

/cc @pclov3r @itdaniher