### PR TITLE
Read the input file four bytes at a time.

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -279,9 +279,9 @@ int main(int argc, char *argv[])
         {
             uint8_t tmp[RADIO_BUFFER];
             size_t cnt;
-            cnt = fread(tmp, 1, sizeof(tmp), infp);
+            cnt = fread(tmp, 4, sizeof(tmp) / 4, infp);
             if (cnt > 0)
-                input_cb(tmp, cnt, &input);
+                input_cb(tmp, cnt * 4, &input);
             input_wait(&input, 0);
         }
         input_wait(&input, 1);


### PR DESCRIPTION
If the input file is not a multiple of four bytes (which is often the case for files produced by my [gr-nrsc5 project](https://github.com/argilo/gr-nrsc5)) then nrsc5 exits with an assertion failure. That's because the `input_cb` function requires its input to be a multiple of four bytes:
https://github.com/theori-io/nrsc5/blob/1bd3f793abadf9645c7bb54c65178001f27a307c/src/input.c#L277
To make sure that requirement is always satisfied, I've changed the `fread` to read four bytes at a time.