### PR TITLE
Log audio bit rate.

### DIFF
--- a/src/output.c
+++ b/src/output.c
@@ -111,6 +111,14 @@ void output_reset_buffers(output_t *st)
 
 void output_push(output_t *st, uint8_t *pkt, unsigned int len)
 {
+    st->audio_packets++;
+    st->audio_bytes += len;
+    if (st->audio_packets >= 32) {
+        log_debug("Audio bit rate: %.1f kbps", (float)st->audio_bytes * 8 * 44100 / 2048 / st->audio_packets / 1000);
+        st->audio_packets = 0;
+        st->audio_bytes = 0;
+    }
+
     if (st->method == OUTPUT_ADTS)
     {
         dump_adts(st->outfp, pkt, len);
@@ -216,6 +224,8 @@ static void *output_worker(void *arg)
 void output_reset(output_t *st)
 {
     memset(st->ports, 0, sizeof(st->ports));
+    st->audio_packets = 0;
+    st->audio_bytes = 0;
 
 #ifdef USE_FAAD2
     if (st->method == OUTPUT_ADTS || st->method == OUTPUT_HDC)

--- a/src/output.h
+++ b/src/output.h
@@ -67,6 +67,8 @@ typedef struct
 
     char *aas_files_path;
     aas_port_t ports[32];
+    unsigned int audio_packets;
+    unsigned int audio_bytes;
 } output_t;
 
 void output_push(output_t *st, uint8_t *pkt, unsigned int len);


### PR DESCRIPTION
Implements #44, a log message showing the audio bit rate (averaged over the last 32 audio packets).

Sample output:
```
$ src/nrsc5 98.1 1 2>&1 | grep bit
15:13:55 DEBUG output.c:117: Audio bit rate: 31.1 kbps
15:13:56 DEBUG output.c:117: Audio bit rate: 30.6 kbps
15:13:58 DEBUG output.c:117: Audio bit rate: 30.4 kbps
15:13:59 DEBUG output.c:117: Audio bit rate: 30.3 kbps
15:14:01 DEBUG output.c:117: Audio bit rate: 31.4 kbps
```

@pclov3r