### PR TITLE
Simplify and speed up automatic gain selection.

### DIFF
--- a/src/input.h
+++ b/src/input.h
@@ -16,7 +16,7 @@
 #include "resamp_q15.h"
 #include "sync.h"
 
-typedef int (*input_snr_cb_t) (void *, float, float, float);
+typedef int (*input_agc_cb_t) (void *, float);
 
 typedef struct input_t
 {
@@ -32,13 +32,10 @@ typedef struct input_t
     int cfo, cfo_idx, cfo_used;
     float complex cfo_tbl[FFT];
 
-    fftwf_plan snr_fft;
-    float complex snr_fft_in[64];
-    float complex snr_fft_out[64];
-    float snr_power[64];
-    int snr_cnt;
-    input_snr_cb_t snr_cb;
-    void *snr_cb_arg;
+    float agc_power;
+    int agc_cnt;
+    input_agc_cb_t agc_cb;
+    void *agc_cb_arg;
 
 #ifdef USE_THREADS
     pthread_t worker_thread;
@@ -54,7 +51,7 @@ typedef struct input_t
 
 void input_init(input_t *st, output_t *output, double center, unsigned int program, FILE *outfp);
 void input_cb(uint8_t *, uint32_t, void *);
-void input_set_snr_callback(input_t *st, input_snr_cb_t cb, void *);
+void input_set_agc_callback(input_t *st, input_agc_cb_t cb, void *);
 void input_rate_adjust(input_t *st, float adj);
 void input_cfo_adjust(input_t *st, int cfo);
 void input_set_skip(input_t *st, unsigned int skip);

--- a/src/main.c
+++ b/src/main.c
@@ -45,29 +45,23 @@ pthread_mutex_t rtlsdr_usb_mutex;
 #endif
 
 // signal and noise are squared magnitudes
-static int snr_callback(void *arg, float snr, float signal, float noise)
+static int agc_callback(void *arg, float power)
 {
-    static int best_gain;
-    static float best_snr;
     int result = 0;
     rtlsdr_dev_t *dev = arg;
 
     if (gain_count == 0)
         return result;
 
-    // choose the best gain level
-    if (snr >= best_snr)
+    log_info("Gain: %0.1f dB, Power: %f dBFS", gain_list[gain_index] / 10.0, 10 * log10f(power));
+
+    if (power > 0.1)
     {
-        best_gain = gain_index;
-        best_snr = snr;
+        if (gain_index > 0) gain_index--;
+        gain_count = 0;
     }
-
-    log_info("Gain: %0.1f dB, CNR: %f dB", gain_list[gain_index] / 10.0, 10 * log10f(snr));
-
-    if (gain_index + 1 >= gain_count || snr < best_snr * 0.5)
+    else if (gain_index + 1 >= gain_count)
     {
-        log_debug("Best gain: %d", gain_list[best_gain]);
-        gain_index = best_gain;
         gain_count = 0;
     }
     else
@@ -76,6 +70,9 @@ static int snr_callback(void *arg, float snr, float signal, float noise)
         // continue searching
         result = 1;
     }
+
+    if (gain_count == 0)
+        log_debug("Best gain: %d", gain_list[gain_index]);
 
 #ifdef USE_THREADS
     pthread_mutex_lock(&rtlsdr_usb_mutex);
@@ -307,7 +304,7 @@ int main(int argc, char *argv[])
             gain_count = rtlsdr_get_tuner_gains(dev, gain_list);
             if (gain_count > 0)
             {
-                input_set_snr_callback(&input, snr_callback, dev);
+                input_set_agc_callback(&input, agc_callback, dev);
                 err = rtlsdr_set_tuner_gain(dev, gain_list[0]);
                 if (err) FATAL_EXIT("rtlsdr_set_tuner_gain error: %d", err);
             }
@@ -329,7 +326,7 @@ int main(int argc, char *argv[])
         while (gain_count)
         {
             // use a smaller buffer during auto gain
-            int len = 128 * 1024;
+            int len = 32768;
 
 #ifdef USE_THREADS
             pthread_mutex_lock(&rtlsdr_usb_mutex);


### PR DESCRIPTION
Fixes #52.

The automatic gain selection code was slow, and seemed unnecessarily complicated. It used an FFT to compare the power of the digital sidebands to the power of the noise around them, and tried to maximize that ratio.

I've simplified it to just increase the input gain until the input power reaches 10 dB less than full scale. The extra 10 dB leaves some breathing room in case the signal strength increases after automatic gain selection finishes.

I also reduced the number of input samples used to make each measurement, which speeds up the time for automatic gain selection to just over one second in the worst case.

/cc @classicjazz