### PR TITLE
Integrate with Travis CI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,21 @@
+language: c
+
+os:
+  - linux
+  - osx
+
+compiler:
+  - gcc
+  - clang
+
+before_install:
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get -qq update; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get install -y libao-dev libfftw3-dev librtlsdr-dev; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install libao fftw librtlsdr xz; fi
+
+before_script:
+  - mkdir build
+  - cd build
+  - cmake ..
+
+script: make && xz -d < ../support/sample.xz | src/nrsc5 -r - -o sample.wav -f wav 0 2> sample.log && cat sample.log && grep -q "You're Listening to Q" sample.log


### PR DESCRIPTION
@awesie What do you think about adding Travis CI? I tried this in my fork, and it works well: https://travis-ci.org/argilo/nrsc5

I've configured it to build on Linux & OS X using both gcc and clang. The `script` also runs nrsc5 to make sure that it's able to decode your sample file. A more extensive test script could be added in the future.