### PR TITLE
Remove id3v2lib dependency.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,6 @@ option (USE_SSE "Use SSE3 instructions")
 option (USE_THREADS "Enable multithreading" ON)
 option (USE_FAST_MATH "Use unsafe math optimizations")
 option (USE_FAAD2 "AAC decoding with FAAD2" ON)
-option (USE_ID3V2LIB "ID3V2 decoding from PSD" ON)
 
 find_program (AUTOCONF autoconf)
 if (NOT AUTOCONF)
@@ -82,26 +81,6 @@ if (USE_FAAD2)
 
     set (FAAD2_LIBRARY faad2)
     add_definitions (-DHAVE_FAAD2)
-endif()
-
-if (USE_ID3V2LIB)
-    set (ID3V2LIB_PREFIX "${CMAKE_BINARY_DIR}/id3v2lib-prefix")
-    ExternalProject_Add (
-        id3v2lib_external
-        GIT_REPOSITORY "https://github.com/larsbs/id3v2lib.git"
-        GIT_TAG 9bca1c33b8cd8037ee59de927bda057c9ac7043d
-        PREFIX ${ID3V2LIB_PREFIX}
-
-        INSTALL_COMMAND ""
-    )
-
-    add_library (id3v2lib STATIC IMPORTED)
-    set_property (TARGET id3v2lib PROPERTY IMPORTED_LOCATION "${ID3V2LIB_PREFIX}/src/id3v2lib_external-build/src/libid3v2.a")
-    add_dependencies (id3v2lib id3v2lib_external)
-    include_directories ("${ID3V2LIB_PREFIX}/src/id3v2lib_external/include")
-
-    set (ID3V2LIB_LIBRARY id3v2lib)
-    add_definitions (-DHAVE_ID3V2LIB)
 endif()
 
 add_subdirectory (src)

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -48,7 +48,6 @@ target_link_libraries (
     ${AO_LIBRARY}
     ${FFTW3F_LIBRARY}
     ${RTL_SDR_LIBRARY}
-    ${ID3V2LIB_LIBRARY}
     m
 )
 install (

--- a/src/config.h.in
+++ b/src/config.h.in
@@ -1,7 +1,6 @@
 #pragma once
 
 #cmakedefine USE_FAAD2
-#cmakedefine USE_ID3V2LIB
 #cmakedefine USE_COLOR
 #cmakedefine USE_FAST_MATH
 #cmakedefine USE_THREADS

--- a/src/output.c
+++ b/src/output.c
@@ -320,15 +320,26 @@ void output_init_live(output_t *st)
 
 static unsigned int id3_length(uint8_t *buf)
 {
-    return (buf[0] << 21) | (buf[1] << 14) | (buf[2] << 7) | buf[3];
+    return ((buf[0] & 0x7f) << 21) | ((buf[1] & 0x7f) << 14) | ((buf[2] & 0x7f) << 7) | (buf[3] & 0x7f);
 }
 
 static char *id3_text(uint8_t *buf, unsigned int frame_len)
 {
-    char *text = (char *) malloc(frame_len);
-    memcpy(text, buf + 1, frame_len - 1);
-    text[frame_len - 1] = 0;
-    return text;
+    char *text;
+
+    if (frame_len == 0)
+    {
+        text = (char *) malloc(1);
+        text[0] = 0;
+        return text;
+    }
+    else
+    {
+        text = (char *) malloc(frame_len);
+        memcpy(text, buf + 1, frame_len - 1);
+        text[frame_len - 1] = 0;
+        return text;
+    }
 }
 
 static void output_id3(uint8_t *buf, unsigned int len)

--- a/src/output.c
+++ b/src/output.c
@@ -25,10 +25,6 @@
 #include "defines.h"
 #include "output.h"
 
-#ifdef USE_ID3V2LIB
-#include <id3v2lib.h>
-#endif
-
 #ifdef USE_FAAD2
 static ao_sample_format sample_format = {
     16,
@@ -322,65 +318,54 @@ void output_init_live(output_t *st)
 }
 #endif
 
-#ifdef USE_ID3V2LIB
-static void display_text_content(const char *header, ID3v2_frame *frame)
+static unsigned int id3_length(uint8_t *buf)
 {
-    if (frame == NULL)
-        return;
-
-    ID3v2_frame_text_content *content = parse_text_frame_content(frame);
-
-    char temp[content->size + 1];
-    memcpy(temp, content->data, content->size);
-    temp[content->size] = '\0';
-    log_info("%s: %s", header, temp);
-
-    free(content);
+    return (buf[0] << 21) | (buf[1] << 14) | (buf[2] << 7) | buf[3];
 }
 
-static void display_comment_content(const char *header, ID3v2_frame *frame)
+static char *id3_text(uint8_t *buf, unsigned int frame_len)
 {
-    if (frame == NULL)
-        return;
-
-    ID3v2_frame_comment_content *content = parse_comment_frame_content(frame);
-
-    char temp[content->text->size + 1];
-    memcpy(temp, content->text->data, content->text->size);
-    temp[content->text->size] = '\0';
-    log_info("%s: %s", header, temp);
-
-    free(content);
+    char *text = (char *) malloc(frame_len);
+    memcpy(text, buf + 1, frame_len - 1);
+    text[frame_len - 1] = 0;
+    return text;
 }
 
 static void output_id3(uint8_t *buf, unsigned int len)
 {
-    ID3v2_tag *tag = load_tag_with_buffer((char *)buf, len);
-    if (tag == NULL)
+    unsigned int off = 0, id3_len;
+    if (len < 10 || memcmp(buf + off, "ID3\x03\x00", 5) || buf[off+5]) return;
+    id3_len = id3_length(buf + 6) + 10;
+    if (id3_len > len) return;
+    off += 10;
+
+    while (off + 10 <= id3_len)
     {
-        log_info("invalid psd");
-        return;
+        unsigned int frame_len = id3_length(buf + off + 4);
+        if (off + 10 + frame_len > id3_len) return;
+
+        if (memcmp(buf + off, "TIT2", 4) == 0)
+        {
+            char *title = id3_text(buf + off + 10, frame_len);
+            log_debug("Title: %s", title);
+            free(title);
+        }
+        else if (memcmp(buf + off, "TPE1", 4) == 0)
+        {
+            char *artist = id3_text(buf + off + 10, frame_len);
+            log_debug("Artist: %s", artist);
+            free(artist);
+        }
+        else if (memcmp(buf + off, "TALB", 4) == 0)
+        {
+            char *album = id3_text(buf + off + 10, frame_len);
+            log_debug("Album: %s", album);
+            free(album);
+        }
+
+        off += 10 + frame_len;
     }
-
-    ID3v2_frame *title_frame = tag_get_title(tag);
-    display_text_content("Title", title_frame);
-    free(title_frame);
-
-    ID3v2_frame *artist_frame = tag_get_artist(tag);
-    display_text_content("Artist", artist_frame);
-    free(artist_frame);
-
-    ID3v2_frame *genre_frame = tag_get_genre(tag);
-    display_text_content("Genre", genre_frame);
-    free(genre_frame);
-
-    ID3v2_frame *comment_frame = tag_get_comment(tag);
-    display_comment_content("Comment", comment_frame);
-    free(comment_frame);
-
-    free(tag);
 }
-#endif
 
 static void parse_port_info(output_t *st, uint8_t *buf, unsigned int len)
 {
@@ -566,9 +551,7 @@ void output_aas_push(output_t *st, uint8_t *buf, unsigned int len)
     if (port == 0x5100 || (port >= 0x5201 && port <= 0x5207))
     {
         // PSD ports
-#ifdef USE_ID3V2LIB
         output_id3(buf + 4, len - 4);
-#endif
     }
     else if (port == 0x20)
     {


### PR DESCRIPTION
ID3v2 is not a complicated format, and HD Radio only uses a subset of it. So it seems like it's worth removing the id3v2lib dependency and implementing the parts of ID3v2 that are needed right in nrsc5. This PR implements enough to decode title, artist and album. I tested on a bunch of stations and it seems to work properly.

/cc @KeyserSoze1