### PR TITLE
Wait for P3 interleaver internal matrix to fill up.

### DIFF
--- a/src/decode.c
+++ b/src/decode.c
@@ -148,11 +148,17 @@ void decode_process_p3(decode_t *st)
         st->internal_p3[st->i_p3] = st->buffer_px1[i];
         (st->i_p3)++;
     }
-    st->i_p3 = st->i_p3 % N;
-
-    nrsc5_conv_decode_p3(st->viterbi_p3, st->scrambler_p3);
-    descramble(st->scrambler_p3, P3_FRAME_LEN);
-    frame_push(&st->input->frame, st->scrambler_p3, P3_FRAME_LEN);
+    if (st->ready_p3)
+    {
+        nrsc5_conv_decode_p3(st->viterbi_p3, st->scrambler_p3);
+        descramble(st->scrambler_p3, P3_FRAME_LEN);
+        frame_push(&st->input->frame, st->scrambler_p3, P3_FRAME_LEN);
+    }
+    if (st->i_p3 == N)
+    {
+        st->i_p3 = 0;
+        st->ready_p3 = 1;
+    }
 }
 
 void decode_reset(decode_t *st)
@@ -160,6 +166,7 @@ void decode_reset(decode_t *st)
     st->idx_pm = 0;
     st->idx_px1 = 0;
     st->i_p3 = 0;
+    st->ready_p3 = 0;
     memset(st->pt_p3, 0, sizeof(unsigned int) * 4);
     pids_init(&st->pids);
 }

--- a/src/decode.h
+++ b/src/decode.h
@@ -18,6 +18,7 @@ typedef struct
     uint8_t *scrambler_pids;
     int8_t *internal_p3;
     unsigned int i_p3;
+    int ready_p3;
     unsigned int pt_p3[4];
     int8_t *viterbi_p3;
     uint8_t *scrambler_p3;


### PR DESCRIPTION
The convolutional encoder for P3 doesn't start producing valid output until it's seen two full frames of input. To account for this, I've modified `decode_process_p3` so it only starts producing output once the interleaver's internal matrix is filled up. This should reduce the risk of crashes or other bad behaviour during startup.