### PR TITLE
Delay processing of AAS PDUs until first HDLC flag is seen.

### DIFF
--- a/src/frame.h
+++ b/src/frame.h
@@ -8,7 +8,7 @@ typedef struct
     uint16_t length;
     unsigned int block_idx;
     uint8_t *blocks;
-    unsigned int idx;
+    int idx;
     uint8_t *data;
 } fixed_subchannel_t;
 
@@ -22,7 +22,7 @@ typedef struct
     int ready;
     unsigned int program;
     uint8_t *psd_buf;
-    unsigned int psd_idx;
+    int psd_idx;
 
     unsigned int sync_width;
     unsigned int sync_count;


### PR DESCRIPTION
Currently, when nrsc5 starts receiving it logs several "psd crc mismatch" messages. This occurs because neither `parse_psd` nor `process_fixed_block` waits for an HDLC flag (0x7E) before starting up. As a result, they pass partial PDUs to `aas_push`.

To correct this problem, I've changed them both to use an index of -1 to indicate that the first HDLC flag has not yet been seen. Once an HDLC flag is seen, they set their index to 0 and carry on with normal processing.

It's a bit easier to see what I've changed with whitespace changes excluded: https://github.com/theori-io/nrsc5/compare/fix-aas-start?w=1