### PR TITLE
Implement Service Information Message.

### DIFF
--- a/src/pids.h
+++ b/src/pids.h
@@ -4,6 +4,7 @@
 
 #define MAX_AUDIO_SERVICES 8
 #define MAX_DATA_SERVICES 16
+#define NUM_PARAMETERS 12
 
 typedef struct
 {
@@ -45,6 +46,8 @@ typedef struct
 
     asd_t audio_services[MAX_AUDIO_SERVICES];
     dsd_t data_services[MAX_DATA_SERVICES];
+
+    int parameters[NUM_PARAMETERS];
 
     char slogan[96];
     uint8_t slogan_have_frame[16];

--- a/src/pids.h
+++ b/src/pids.h
@@ -2,9 +2,17 @@
 
 #include <stdint.h>
 
+#define MAX_LONG_NAME_LEN 56
+#define MAX_LONG_NAME_FRAMES 8
+#define MAX_MESSAGE_LEN 190
+#define MAX_MESSAGE_FRAMES 32
 #define MAX_AUDIO_SERVICES 8
 #define MAX_DATA_SERVICES 16
 #define NUM_PARAMETERS 12
+#define MAX_SLOGAN_LEN 95
+#define MAX_SLOGAN_FRAMES 16
+#define MAX_ALERT_LEN 381
+#define MAX_ALERT_FRAMES 64
 
 typedef struct
 {
@@ -27,8 +35,8 @@ typedef struct
 
     char short_name[8];
 
-    char long_name[57];
-    uint8_t long_name_have_frame[8];
+    char long_name[MAX_LONG_NAME_LEN + 1];
+    uint8_t long_name_have_frame[MAX_LONG_NAME_FRAMES];
     int long_name_seq;
     int long_name_displayed;
 
@@ -36,8 +44,8 @@ typedef struct
     float longitude;
     int altitude;
 
-    char message[192];
-    uint8_t message_have_frame[32];
+    char message[MAX_MESSAGE_LEN + 1];
+    uint8_t message_have_frame[MAX_MESSAGE_FRAMES];
     int message_seq;
     int message_priority;
     int message_encoding;
@@ -49,14 +57,14 @@ typedef struct
 
     int parameters[NUM_PARAMETERS];
 
-    char slogan[96];
-    uint8_t slogan_have_frame[16];
+    char slogan[MAX_SLOGAN_LEN + 1];
+    uint8_t slogan_have_frame[MAX_SLOGAN_FRAMES];
     int slogan_encoding;
     int slogan_len;
     int slogan_displayed;
 
-    char alert[382];
-    uint8_t alert_have_frame[64];
+    char alert[MAX_ALERT_LEN + 1];
+    uint8_t alert_have_frame[MAX_ALERT_FRAMES];
     int alert_seq;
     int alert_encoding;
     int alert_len;

--- a/src/pids.h
+++ b/src/pids.h
@@ -2,6 +2,23 @@
 
 #include <stdint.h>
 
+#define MAX_AUDIO_SERVICES 8
+#define MAX_DATA_SERVICES 16
+
+typedef struct
+{
+    int access;
+    int type;
+    int sound_exp;
+} asd_t;
+
+typedef struct
+{
+    int access;
+    int type;
+    int mime_type;
+} dsd_t;
+
 typedef struct
 {
     char country_code[3];
@@ -25,6 +42,9 @@ typedef struct
     int message_encoding;
     int message_len;
     int message_displayed;
+
+    asd_t audio_services[MAX_AUDIO_SERVICES];
+    dsd_t data_services[MAX_DATA_SERVICES];
 
     char slogan[96];
     uint8_t slogan_have_frame[16];

--- a/src/pids.h
+++ b/src/pids.h
@@ -54,6 +54,14 @@ typedef struct
     int slogan_encoding;
     int slogan_len;
     int slogan_displayed;
+
+    char alert[382];
+    uint8_t alert_have_frame[64];
+    int alert_seq;
+    int alert_encoding;
+    int alert_len;
+    int alert_cnt_len;
+    int alert_displayed;
 } pids_t;
 
 void pids_frame_push(pids_t *st, uint8_t *bits);


### PR DESCRIPTION
This adds SIS message type 6, Service Information Message, which encodes information about the available audio and data services. For my local station it prints the following:
```
21:40:30 DEBUG pids.c:291: Data service: public, type 65, MIME type 5b6
21:40:30 DEBUG pids.c:291: Data service: public, type 259, MIME type eb2
21:40:30 DEBUG pids.c:291: Data service: public, type 259, MIME type 469
21:40:30 DEBUG pids.c:291: Data service: public, type 66, MIME type 2d7
21:40:30 DEBUG pids.c:291: Data service: public, type 66, MIME type e96
21:40:30 DEBUG pids.c:269: Audio program 0: public, type 8, sound experience 0
21:40:30 DEBUG pids.c:269: Audio program 1: public, type 4, sound experience 0
21:40:30 DEBUG pids.c:269: Audio program 2: public, type 3, sound experience 0
```
For details see http://www.nrscstandards.org/sg/nrsc-5-d-reference-docs/1020s.pdf section 4.6.

This gets closer to completing #38.