### PR TITLE
Go back to the old gain selection method.

### DIFF
--- a/src/defines.h
+++ b/src/defines.h
@@ -11,6 +11,8 @@
 
 #define FATAL_EXIT(x,...) do { log_fatal(x, ##__VA_ARGS__); exit(1); } while (0)
 
+#define SNR_FFT_COUNT 256
+
 // FFT length in samples
 #define FFT 2048
 // cyclic preflex length in samples

--- a/src/input.c
+++ b/src/input.c
@@ -198,7 +198,7 @@ static void measure_snr(input_t *st, uint8_t *buf, uint32_t len)
         st->snr_cnt++;
     }
 
-    if (st->snr_cnt > 2048)
+    if (st->snr_cnt >= SNR_FFT_COUNT)
     {
         // noise bands are the frequncies near our signal
         float noise_lo = 0;

--- a/src/input.c
+++ b/src/input.c
@@ -181,21 +181,54 @@ void input_wait(input_t *st, int flush)
 #endif
 }
 
-static void measure_power(input_t *st, uint8_t *buf, uint32_t len)
+static void measure_snr(input_t *st, uint8_t *buf, uint32_t len)
 {
-    unsigned int i;
+    unsigned int i, j;
 
-    for (i = 0; i < len; i += 2)
-        st->agc_power += normf(CMPLXF(U8_F(buf[i]), U8_F(buf[i + 1])));
-    st->agc_cnt += len;
-
-    if (st->agc_cnt >= 32768)
+    // use a small FFT to calculate magnitude of frequency ranges
+    for (j = 64; j <= len / 2; j += 64)
     {
-        if (st->agc_cb(st->agc_cb_arg, st->agc_power / st->agc_cnt) == 0)
-            st->agc_cb = NULL;
+        for (i = 0; i < 64; i++)
+            st->snr_fft_in[i] = CMPLXF(U8_F(buf[(i+j-64) * 2 + 0]), U8_F(buf[(i+j-64) * 2 + 1])) * pow(sinf(M_PI*i/63),2);
+        fftwf_execute(st->snr_fft);
+        fftshift(st->snr_fft_out, 64);
 
-        st->agc_cnt = 0;
-        st->agc_power = 0;
+        for (i = 0; i < 64; i++)
+            st->snr_power[i] += normf(st->snr_fft_out[i]);
+        st->snr_cnt++;
+    }
+
+    if (st->snr_cnt > 2048)
+    {
+        // noise bands are the frequncies near our signal
+        float noise_lo = 0;
+        for (i = 19; i < 23; i++)
+            noise_lo += st->snr_power[i];
+        noise_lo /= 4;
+        float noise_hi = 0;
+        for (i = 41; i < 45; i++)
+            noise_hi += st->snr_power[i];
+        noise_hi /= 4;
+        // signal bands are the frequencies in our signal
+        float signal_lo = (st->snr_power[24] + st->snr_power[25]) / 2;
+        float signal_hi = (st->snr_power[39] + st->snr_power[40]) / 2;
+
+        #if 0
+        float snr_lo = noise_lo == 0 ? 0 : signal_lo / noise_lo;
+        float snr_hi = noise_hi == 0 ? 0 : signal_hi / noise_hi;
+        log_debug("%f %f (SNR: %f) %f %f (SNR: %f)", signal_lo, noise_lo, snr_lo, signal_hi, noise_hi, snr_hi);
+        #endif
+
+        float signal = (signal_lo + signal_hi) / 2 / st->snr_cnt;
+        float noise = (noise_lo + noise_hi) / 2 / st->snr_cnt;
+        float snr = signal / noise;
+
+        if (st->snr_cb(st->snr_cb_arg, snr, signal, noise) == 0)
+            st->snr_cb = NULL;
+
+        st->snr_cnt = 0;
+        for (i = 0; i < 64; ++i)
+            st->snr_power[i] = 0;
     }
 }
 
@@ -207,9 +240,9 @@ void input_cb(uint8_t *buf, uint32_t len, void *arg)
     if (st->outfp)
         fwrite(buf, 1, len, st->outfp);
 
-    if (st->agc_cb)
+    if (st->snr_cb)
     {
-        measure_power(st, buf, len);
+        measure_snr(st, buf, len);
         return;
     }
 
@@ -274,10 +307,10 @@ void input_cb(uint8_t *buf, uint32_t len, void *arg)
 #endif
 }
 
-void input_set_agc_callback(input_t *st, input_agc_cb_t cb, void *arg)
+void input_set_snr_callback(input_t *st, input_snr_cb_t cb, void *arg)
 {
-    st->agc_cb = cb;
-    st->agc_cb_arg = arg;
+    st->snr_cb = cb;
+    st->snr_cb_arg = arg;
 }
 
 void input_reset(input_t *st)
@@ -291,8 +324,9 @@ void input_reset(input_t *st)
     st->cfo_used = 0;
     for (int i = 0; i < FFT; ++i)
         st->cfo_tbl[i] = 1;
-    st->agc_power = 0;
-    st->agc_cnt = 0;
+    for (int i = 0; i < 64; ++i)
+        st->snr_power[i] = 0;
+    st->snr_cnt = 0;
 }
 
 void input_init(input_t *st, output_t *output, double center, unsigned int program, FILE *outfp)
@@ -301,11 +335,12 @@ void input_init(input_t *st, output_t *output, double center, unsigned int progr
     st->output = output;
     st->outfp = outfp;
     st->center = center;
-    st->agc_cb = NULL;
-    st->agc_cb_arg = NULL;
+    st->snr_cb = NULL;
+    st->snr_cb_arg = NULL;
 
     st->filter = firdecim_q15_create(2, filter_taps, sizeof(filter_taps) / sizeof(filter_taps[0]));
     st->resamp = resamp_q15_create(RESAMP_NUM_TAPS / 2, 0.45f, 60.0f, 16);
+    st->snr_fft = fftwf_plan_dft_1d(64, st->snr_fft_in, st->snr_fft_out, FFTW_FORWARD, 0);
 
     input_reset(st);
 

--- a/src/input.h
+++ b/src/input.h
@@ -16,7 +16,7 @@
 #include "resamp_q15.h"
 #include "sync.h"
 
-typedef int (*input_agc_cb_t) (void *, float);
+typedef int (*input_snr_cb_t) (void *, float, float, float);
 
 typedef struct input_t
 {
@@ -32,10 +32,13 @@ typedef struct input_t
     int cfo, cfo_idx, cfo_used;
     float complex cfo_tbl[FFT];
 
-    float agc_power;
-    int agc_cnt;
-    input_agc_cb_t agc_cb;
-    void *agc_cb_arg;
+    fftwf_plan snr_fft;
+    float complex snr_fft_in[64];
+    float complex snr_fft_out[64];
+    float snr_power[64];
+    int snr_cnt;
+    input_snr_cb_t snr_cb;
+    void *snr_cb_arg;
 
 #ifdef USE_THREADS
     pthread_t worker_thread;
@@ -51,7 +54,7 @@ typedef struct input_t
 
 void input_init(input_t *st, output_t *output, double center, unsigned int program, FILE *outfp);
 void input_cb(uint8_t *, uint32_t, void *);
-void input_set_agc_callback(input_t *st, input_agc_cb_t cb, void *);
+void input_set_snr_callback(input_t *st, input_snr_cb_t cb, void *);
 void input_rate_adjust(input_t *st, float adj);
 void input_cfo_adjust(input_t *st, int cfo);
 void input_set_skip(input_t *st, unsigned int skip);

--- a/src/main.c
+++ b/src/main.c
@@ -291,7 +291,7 @@ int main(int argc, char *argv[])
     }
     else
     {
-        uint8_t *buf = malloc(128 * 1024);
+        uint8_t *buf = malloc(128 * SNR_FFT_COUNT);
         rtlsdr_dev_t *dev;
 
         err = rtlsdr_open(&dev, 0);
@@ -332,7 +332,7 @@ int main(int argc, char *argv[])
         while (gain_count)
         {
             // use a smaller buffer during auto gain
-            int len = 128 * 1024;
+            int len = 128 * SNR_FFT_COUNT;
 
 #ifdef USE_THREADS
             pthread_mutex_lock(&rtlsdr_usb_mutex);

--- a/src/main.c
+++ b/src/main.c
@@ -45,23 +45,29 @@ pthread_mutex_t rtlsdr_usb_mutex;
 #endif
 
 // signal and noise are squared magnitudes
-static int agc_callback(void *arg, float power)
+static int snr_callback(void *arg, float snr, float signal, float noise)
 {
+    static int best_gain;
+    static float best_snr;
     int result = 0;
     rtlsdr_dev_t *dev = arg;
 
     if (gain_count == 0)
         return result;
 
-    log_info("Gain: %0.1f dB, Power: %f dBFS", gain_list[gain_index] / 10.0, 10 * log10f(power));
-
-    if (power > 0.1)
+    // choose the best gain level
+    if (snr >= best_snr)
     {
-        if (gain_index > 0) gain_index--;
-        gain_count = 0;
+        best_gain = gain_index;
+        best_snr = snr;
     }
-    else if (gain_index + 1 >= gain_count)
+
+    log_info("Gain: %0.1f dB, CNR: %f dB", gain_list[gain_index] / 10.0, 10 * log10f(snr));
+
+    if (gain_index + 1 >= gain_count || snr < best_snr * 0.5)
     {
+        log_debug("Best gain: %d", gain_list[best_gain]);
+        gain_index = best_gain;
         gain_count = 0;
     }
     else
@@ -70,9 +76,6 @@ static int agc_callback(void *arg, float power)
         // continue searching
         result = 1;
     }
-
-    if (gain_count == 0)
-        log_debug("Best gain: %d", gain_list[gain_index]);
 
 #ifdef USE_THREADS
     pthread_mutex_lock(&rtlsdr_usb_mutex);
@@ -307,7 +310,7 @@ int main(int argc, char *argv[])
             gain_count = rtlsdr_get_tuner_gains(dev, gain_list);
             if (gain_count > 0)
             {
-                input_set_agc_callback(&input, agc_callback, dev);
+                input_set_snr_callback(&input, snr_callback, dev);
                 err = rtlsdr_set_tuner_gain(dev, gain_list[0]);
                 if (err) FATAL_EXIT("rtlsdr_set_tuner_gain error: %d", err);
             }
@@ -329,7 +332,7 @@ int main(int argc, char *argv[])
         while (gain_count)
         {
             // use a smaller buffer during auto gain
-            int len = 32768;
+            int len = 128 * 1024;
 
 #ifdef USE_THREADS
             pthread_mutex_lock(&rtlsdr_usb_mutex);


### PR DESCRIPTION
It's apparent from @pclov3r's report #81 that the new automatic gain selection method doesn't always work well. This PR reverts the change, but also reduces the number of FFTs performed by the automatic gain selection from 3072 to 256, so it should be just as fast as it was after my change.

@pclov3r How does this work for you?