### PR TITLE
Prevent audio stutter by adding silence to start of live audio

### DIFF
--- a/src/decode.c
+++ b/src/decode.c
@@ -169,6 +169,7 @@ void decode_reset(decode_t *st)
     st->ready_p3 = 0;
     memset(st->pt_p3, 0, sizeof(unsigned int) * 4);
     pids_init(&st->pids);
+    output_begin(st->input->output);
 }
 
 void decode_init(decode_t *st, struct input_t *input)

--- a/src/output.h
+++ b/src/output.h
@@ -12,6 +12,7 @@
 #endif
 
 #define AUDIO_FRAME_BYTES 8192
+#define LATENCY_FRAMES 10
 #define MAX_PORTS 32
 
 typedef enum
@@ -67,11 +68,13 @@ typedef struct
 
     char *aas_files_path;
     aas_port_t ports[32];
+    unsigned int first_audio_packet;
     unsigned int audio_packets;
     unsigned int audio_bytes;
 } output_t;
 
 void output_push(output_t *st, uint8_t *pkt, unsigned int len);
+void output_begin(output_t *st);
 void output_reset(output_t *st);
 void output_init_adts(output_t *st, const char *name);
 void output_init_hdc(output_t *st, const char *name);


### PR DESCRIPTION
Audio stutter often occurs at the start of live audio playback, because NRSC-5's audio codec has a variable bit rate, but nrsc5 doesn't account for that.

To solve the problem, I've added 10 packets worth of silence to the beginning of the audio. I chose 10 because it's the maximum allowed elastic buffer depth. See http://www.nrscstandards.org/sg/nrsc-5-d-reference-docs/1017s.pdf section 4.3 for details.