### PR TITLE
Search for symbol synchronization over the whole period.

### DIFF
--- a/src/acquire.c
+++ b/src/acquire.c
@@ -28,7 +28,7 @@ void acquire_process(acquire_t *st)
     float complex max_v = 0;
     float angle, max_mag = -1.0f;
     unsigned int samperr = 0, i, j;
-    unsigned int mink = 0, maxk = FFT;
+    unsigned int mink = 0, maxk = FFTCP;
 
     if (st->idx != FFTCP * (M + 1))
         return;
@@ -170,7 +170,7 @@ void acquire_init(acquire_t *st, input_t *input)
 
     st->input = input;
     st->buffer = malloc(sizeof(float complex) * FFTCP * (M + 1));
-    st->sums = malloc(sizeof(float complex) * FFTCP);
+    st->sums = malloc(sizeof(float complex) * (FFTCP + CP));
     st->idx = 0;
     st->ready = 0;
     st->samperr = 0;


### PR DESCRIPTION
OFDM timing synchronization fails about 5% of the time, because it only searches for the start of a symbol over the range 0-2047, even though it could occur at any sample offset from 0 to 2159. Running the following command demonstrates the problem:
```
xz -d < ../support/sample.xz | tail -c +561 | src/nrsc5 -r - 0
```
To fix this, I've expanded the search window to include the entire range (i.e. the duration of one symbol, including cyclic prefix).