### PR TITLE
Play audio packets immediately; don't wait for number 0.

### DIFF
--- a/src/frame.h
+++ b/src/frame.h
@@ -21,7 +21,6 @@ typedef struct
     uint8_t *pdu[MAX_PROGRAMS];
     unsigned int pdu_idx[MAX_PROGRAMS];
     unsigned int pci;
-    int ready;
     unsigned int program;
     uint8_t *psd_buf[MAX_PROGRAMS];
     int psd_idx[MAX_PROGRAMS];


### PR DESCRIPTION
Currently `frame_process` waits for an audio packet with sequence number 0 to come along before it starts passing audio packets along for decoding. This can add up to a couple seconds to the start-up time.

As far as I know, the sequence numbers are simply indexes into a 64-frame circular buffer that a player could use. There's nothing special about sequence number 0, so I don't see any reason to wait for it to arrive. Everything seems to work fine after this change.

When combined with #95 this brings the acquisition time down pretty close to the theoretical minimum.