### PR TITLE
Fix MER calculation for primary mode 3.

### DIFF
--- a/src/defines.h
+++ b/src/defines.h
@@ -20,10 +20,6 @@
 #define FFTCP (FFT + CP)
 // OFDM symbols per L1 block
 #define BLKSZ 32
-// number of data subcarriers per sideband
-#define P1_DATA_PER_BAND 180
-// number of subcarriers per sideband
-#define P1_BAND_LENGTH (11 + P1_DATA_PER_BAND)
 // index of first lower sideband subcarrier
 #define LB_START (1024 - 546)
 // index of last upper sideband subcarrier

--- a/src/defines.h
+++ b/src/defines.h
@@ -20,6 +20,8 @@
 #define FFTCP (FFT + CP)
 // OFDM symbols per L1 block
 #define BLKSZ 32
+// number of primary main partitions
+#define PM_PARTITIONS 10
 // index of first lower sideband subcarrier
 #define LB_START (1024 - 546)
 // index of last upper sideband subcarrier

--- a/src/sync.c
+++ b/src/sync.c
@@ -245,13 +245,13 @@ void sync_process(sync_t *st, float complex *buffer)
             for (i = -38; i < 38; ++i)
             {
                 int offset2;
-                adjust_ref(buffer, st->phases, LB_START + 190 + i);
-                offset = find_ref(buffer, LB_START + 190 + i, 0);
+                adjust_ref(buffer, st->phases, LB_START + (PM_PARTITIONS * 19) + i);
+                offset = find_ref(buffer, LB_START + (PM_PARTITIONS * 19) + i, 0);
                 if (offset < 0)
                     continue;
                 // We think we found the start. Check upperband to confirm.
-                adjust_ref(buffer, st->phases, UB_END - 190 + i);
-                offset2 = find_ref(buffer, UB_END - 190 + i, 0);
+                adjust_ref(buffer, st->phases, UB_END - (PM_PARTITIONS * 19) + i);
+                offset2 = find_ref(buffer, UB_END - (PM_PARTITIONS * 19) + i, 0);
                 if (offset2 == offset)
                 {
                     // The offsets matched, so 'i' is likely the CFO.
@@ -328,7 +328,7 @@ void sync_process(sync_t *st, float complex *buffer)
         for (int n = 0; n < BLKSZ; n++)
         {
             float complex c;
-            for (i = LB_START; i < LB_START + 190; i += 19)
+            for (i = LB_START; i < LB_START + (PM_PARTITIONS * 19); i += 19)
             {
                 unsigned int j;
                 for (j = 1; j < 19; j++)
@@ -338,7 +338,7 @@ void sync_process(sync_t *st, float complex *buffer)
                     decode_push_pm(&st->input->decode, DEMOD(cimagf(c)) * mult_lb);
                 }
             }
-            for (i = UB_END - 190; i < UB_END; i += 19)
+            for (i = UB_END - (PM_PARTITIONS * 19); i < UB_END; i += 19)
             {
                 unsigned int j;
                 for (j = 1; j < 19; j++)
@@ -349,7 +349,7 @@ void sync_process(sync_t *st, float complex *buffer)
                 }
             }
             if (psmi == 3) {
-                for (i = LB_START + 190; i < LB_START + 190 + 38; i += 19)
+                for (i = LB_START + (PM_PARTITIONS * 19); i < LB_START + (PM_PARTITIONS * 19) + 38; i += 19)
                 {
                     unsigned int j;
                     for (j = 1; j < 19; j++)
@@ -359,7 +359,7 @@ void sync_process(sync_t *st, float complex *buffer)
                         decode_push_px1(&st->input->decode, DEMOD(cimagf(c)) * mult_lb);
                     }
                 }
-                for (i = UB_END - 190 - 38; i < UB_END - 190; i += 19)
+                for (i = UB_END - (PM_PARTITIONS * 19) - 38; i < UB_END - (PM_PARTITIONS * 19); i += 19)
                 {
                     unsigned int j;
                     for (j = 1; j < 19; j++)

--- a/src/sync.c
+++ b/src/sync.c
@@ -245,13 +245,13 @@ void sync_process(sync_t *st, float complex *buffer)
             for (i = -38; i < 38; ++i)
             {
                 int offset2;
-                adjust_ref(buffer, st->phases, LB_START + i + P1_BAND_LENGTH - 1);
-                offset = find_ref(buffer, LB_START + i + P1_BAND_LENGTH - 1, 0);
+                adjust_ref(buffer, st->phases, LB_START + 190 + i);
+                offset = find_ref(buffer, LB_START + 190 + i, 0);
                 if (offset < 0)
                     continue;
                 // We think we found the start. Check upperband to confirm.
-                adjust_ref(buffer, st->phases, UB_END + i - P1_BAND_LENGTH + 1);
-                offset2 = find_ref(buffer, UB_END + i - P1_BAND_LENGTH + 1, 0);
+                adjust_ref(buffer, st->phases, UB_END - 190 + i);
+                offset2 = find_ref(buffer, UB_END - 190 + i, 0);
                 if (offset2 == offset)
                 {
                     // The offsets matched, so 'i' is likely the CFO.
@@ -309,18 +309,18 @@ void sync_process(sync_t *st, float complex *buffer)
         // Display average MER for each sideband
         if (++st->mer_cnt == 16)
         {
-            float signal = 2 * BLKSZ * P1_DATA_PER_BAND * st->mer_cnt;
+            float signal = 2 * BLKSZ * (partitions_per_band * 18) * st->mer_cnt;
             float mer_db_lb = 10 * log10f(signal / st->error_lb);
             float mer_db_ub = 10 * log10f(signal / st->error_ub);
-            log_info("MER: %f dB (lower), %f dB (upper)", mer_db_lb, mer_db_ub);
+            log_info("MER: %.1f dB (lower), %.1f dB (upper)", mer_db_lb, mer_db_ub);
             st->mer_cnt = 0;
             st->error_lb = 0;
             st->error_ub = 0;
         }
 
         // Soft demod based on MER for each sideband
-        float mer_lb = 2 * BLKSZ * P1_DATA_PER_BAND / error_lb;
-        float mer_ub = 2 * BLKSZ * P1_DATA_PER_BAND / error_ub;
+        float mer_lb = 2 * BLKSZ * (partitions_per_band * 18) / error_lb;
+        float mer_ub = 2 * BLKSZ * (partitions_per_band * 18) / error_ub;
         float mult_lb = fmaxf(fminf(mer_lb * 10, 127), 1);
         float mult_ub = fmaxf(fminf(mer_ub * 10, 127), 1);
 


### PR DESCRIPTION
I noticed that the reported MER is 0.8 dB low for stations using primary mode 3, because the signal is assumed to come from only 10 partitions, whereas the noise is summed from all 12. I corrected this simply by changing `P1_DATA_PER_BAND` to `partitions_per_band * 18`.

Since `P1_DATA_PER_BAND` was no longer used, I removed it from defines.h, and I also got rid of `P1_BAND_LENGTH` (which was barely used).

Finally, I changed the MER display to include only one decimal place. (Previously it showed the default six.)

Here's an example for a recording of my local station. Before:
```
08:31:27 INFO  sync.c:315: MER: 10.645880 dB (lower), 10.632761 dB (upper)
08:31:28 INFO  sync.c:315: MER: 10.610696 dB (lower), 10.569898 dB (upper)
08:31:28 INFO  sync.c:315: MER: 10.646533 dB (lower), 10.668467 dB (upper)
08:31:29 INFO  sync.c:315: MER: 10.632702 dB (lower), 10.736723 dB (upper)
08:31:31 INFO  sync.c:315: MER: 10.763515 dB (lower), 10.707469 dB (upper)
```
After:
```
08:31:43 INFO  sync.c:315: MER: 11.4 dB (lower), 11.4 dB (upper)
08:31:44 INFO  sync.c:315: MER: 11.4 dB (lower), 11.4 dB (upper)
08:31:44 INFO  sync.c:315: MER: 11.4 dB (lower), 11.5 dB (upper)
08:31:45 INFO  sync.c:315: MER: 11.4 dB (lower), 11.5 dB (upper)
08:31:47 INFO  sync.c:315: MER: 11.6 dB (lower), 11.5 dB (upper)
```
The values are unchanged for stations using primary mode 1.