### PR TITLE
Improve frequency tracking.

### DIFF
--- a/src/acquire.c
+++ b/src/acquire.c
@@ -26,7 +26,7 @@
 void acquire_process(acquire_t *st)
 {
     float complex max_v = 0;
-    float angle, max_mag = -1.0f;
+    float angle, angle_diff, angle_factor, max_mag = -1.0f;
     unsigned int samperr = 0, i, j, keep;
     unsigned int mink = 0, maxk = FFTCP;
 
@@ -63,16 +63,9 @@ void acquire_process(acquire_t *st)
         }
     }
 
-    // limited to (-pi, pi)
-    angle = cargf(max_v);
-    if (st->prev_angle)
-    {
-        if (st->prev_angle > M_PI*15/16 && angle < -M_PI*15/16)
-            angle += M_PI * 2;
-        else if (st->prev_angle < -M_PI*15/16 && angle > M_PI*15/16)
-            angle -= M_PI * 2;
-        angle = 0.5 * st->prev_angle + 0.5 * angle;
-    }
+    angle_diff = cargf(max_v * cexpf(I * -st->prev_angle));
+    angle_factor = (st->prev_angle) ? 0.1 : 1.0;
+    angle = st->prev_angle + (angle_diff * angle_factor);
     st->prev_angle = angle;
 
     for (i = 0; i < M; ++i)

--- a/src/acquire.c
+++ b/src/acquire.c
@@ -64,7 +64,7 @@ void acquire_process(acquire_t *st)
     }
 
     angle_diff = cargf(max_v * cexpf(I * -st->prev_angle));
-    angle_factor = (st->prev_angle) ? 0.1 : 1.0;
+    angle_factor = (st->prev_angle) ? 0.25 : 1.0;
     angle = st->prev_angle + (angle_diff * angle_factor);
     st->prev_angle = angle;
 


### PR DESCRIPTION
Cheaper RTL-SDR dongles that lack a TCXO can drift quite a bit (~10 ppm) in frequency as they warm up. Currently nrsc5 doesn't account for this; it expects the frequency offset to remain nearly constant.

To fix this, I've changed the frequency tracking code to calculate the difference between the angles of `max_v` and `cexpf(I * st->prev_angle)` and adjust the angle using that value. That allows the angle to wrap around the full circle multiple times if necessary to track the drift of the RTL-SDR's oscillator.

Also I changed the smoothing factor from 0.5 to 0.1 as this made a significant improvement to the BER of the 15 recordings I use for tests.