### PR TITLE
Implement post-FFT synchronization.

### DIFF
--- a/src/acquire.h
+++ b/src/acquire.h
@@ -15,6 +15,7 @@ typedef struct
 
     unsigned int idx;
     float prev_angle;
+    float complex phase;
 } acquire_t;
 
 void acquire_process(acquire_t *st);

--- a/src/input.h
+++ b/src/input.h
@@ -3,9 +3,6 @@
 #include <stdint.h>
 #include <stdio.h>
 #include <complex.h>
-#ifdef USE_THREADS
-#include <pthread.h>
-#endif
 
 #include "acquire.h"
 #include "decode.h"
@@ -37,12 +34,6 @@ typedef struct input_t
     input_snr_cb_t snr_cb;
     void *snr_cb_arg;
 
-#ifdef USE_THREADS
-    pthread_t worker_thread;
-    pthread_cond_t cond;
-    pthread_mutex_t mutex;
-#endif
-
     acquire_t acq;
     decode_t decode;
     frame_t frame;
@@ -54,6 +45,5 @@ void input_cb(uint8_t *, uint32_t, void *);
 void input_set_snr_callback(input_t *st, input_snr_cb_t cb, void *);
 void input_cfo_adjust(input_t *st, int cfo);
 void input_set_skip(input_t *st, unsigned int skip);
-void input_wait(input_t *st, int flush);
 void input_pdu_push(input_t *st, uint8_t *pdu, unsigned int len, unsigned int program);
 void input_aas_push(input_t *st, uint8_t *psd, unsigned int len);

--- a/src/sync.c
+++ b/src/sync.c
@@ -49,8 +49,7 @@ static void adjust_ref(sync_t *st, float complex *buf, unsigned int ref)
     slope = cargf(sum) * 0.5;
 
     if (st->ready)
-        slope = slope * 0.1 + st->prev_slope[ref] * 0.9;
-    slope += st->angle_adj;
+        slope = slope * 0.1 + (st->prev_slope[ref] + st->angle_adj) * 0.9;
     st->prev_slope[ref] = slope;
 
     sum = 0;

--- a/src/sync.h
+++ b/src/sync.h
@@ -18,6 +18,7 @@ typedef struct
     int samperr;
     float angle;
     float angle_adj;
+    float prev_slope[FFT];
 
     int mer_cnt;
     float error_lb;

--- a/src/sync.h
+++ b/src/sync.h
@@ -3,9 +3,6 @@
 #include "config.h"
 
 #include <complex.h>
-#ifdef USE_THREADS
-#include <pthread.h>
-#endif
 
 typedef struct
 {
@@ -22,14 +19,7 @@ typedef struct
     int mer_cnt;
     float error_lb;
     float error_ub;
-
-#ifdef USE_THREADS
-    pthread_t worker_thread;
-    pthread_cond_t cond;
-    pthread_mutex_t mutex;
-#endif
 } sync_t;
 
 void sync_push(sync_t *st, float complex *fft);
-void sync_wait(sync_t *st);
 void sync_init(sync_t *st, struct input_t *input);

--- a/src/sync.h
+++ b/src/sync.h
@@ -15,11 +15,15 @@ typedef struct
     unsigned int used;
     int ready;
     int cfo_wait;
+    int samperr;
+    float angle;
+    float angle_adj;
 
     int mer_cnt;
     float error_lb;
     float error_ub;
 } sync_t;
 
+void sync_adjust(sync_t *st, float angle_adj);
 void sync_push(sync_t *st, float complex *fft);
 void sync_init(sync_t *st, struct input_t *input);


### PR DESCRIPTION
Most OFDM receivers use pre-FFT synchronization only during acquisition, then switch to post-FFT synchronization. This PR adds post-FFT synchronization to nrsc5. The change improves the bit error rate across all recordings I tested with.

Since post-FFT synchronization requires feedback to pass from `sync.c` back to `acquire.c` (preferably immediately) I decided to remove the input and sync threads. I believe they were only added to make reception possible on multi-core ARM processors, but performance has since been improved in other ways. (The output thread is still useful so that signal processing can continue even when audio output is blocked, so I left it in place.)

I also managed a significant speedup (especially on ARM) by replacing the complex exponentiation in `acquire_process` with a multiplication. CPU utilization on a Raspberry Pi 3 is now around 55%, compared to 160% previously.