### PR TITLE
Compensate for sample clock error in post-FFT sync.

### DIFF
--- a/src/acquire.c
+++ b/src/acquire.c
@@ -20,9 +20,6 @@
 #include "defines.h"
 #include "input.h"
 
-#define SYMBOLS 2
-#define M (BLKSZ * SYMBOLS)
-
 void acquire_process(acquire_t *st)
 {
     float complex max_v = 0, phase_increment;
@@ -31,7 +28,7 @@ void acquire_process(acquire_t *st)
     unsigned int i, j, keep;
     unsigned int mink = 0, maxk = FFTCP;
 
-    if (st->idx != FFTCP * (M + 1))
+    if (st->idx != FFTCP * (ACQUIRE_SYMBOLS + 1))
         return;
 
     if (st->input->sync.ready)
@@ -49,7 +46,7 @@ void acquire_process(acquire_t *st)
         memset(st->sums, 0, sizeof(float complex) * FFTCP);
         for (i = mink; i < maxk + CP; ++i)
         {
-            for (j = 0; j < M; ++j)
+            for (j = 0; j < ACQUIRE_SYMBOLS; ++j)
                 st->sums[i] += st->buffer[i + j * FFTCP] * conjf(st->buffer[i + j * FFTCP + FFT]);
         }
 
@@ -79,7 +76,7 @@ void acquire_process(acquire_t *st)
     sync_adjust(&st->input->sync, angle_diff);
 
     phase_increment = cexpf(angle / FFT * I);
-    for (i = 0; i < M; ++i)
+    for (i = 0; i < ACQUIRE_SYMBOLS; ++i)
     {
         int j;
         for (j = 0; j < FFTCP; ++j)
@@ -126,7 +123,7 @@ void acquire_init(acquire_t *st, input_t *input)
     int i;
 
     st->input = input;
-    st->buffer = malloc(sizeof(float complex) * FFTCP * (M + 1));
+    st->buffer = malloc(sizeof(float complex) * FFTCP * (ACQUIRE_SYMBOLS + 1));
     st->sums = malloc(sizeof(float complex) * (FFTCP + CP));
     st->idx = 0;
     st->prev_angle = 0;

--- a/src/defines.h
+++ b/src/defines.h
@@ -20,6 +20,8 @@
 #define FFTCP (FFT + CP)
 // OFDM symbols per L1 block
 #define BLKSZ 32
+// symbols processed by each invocation of acquire_process
+#define ACQUIRE_SYMBOLS (BLKSZ * 2)
 // number of primary main partitions
 #define PM_PARTITIONS 10
 // index of first lower sideband subcarrier


### PR DESCRIPTION
This fixes a regression observed by @awesie in https://github.com/theori-io/nrsc5/pull/108#issuecomment-344143640

The new post-FFT synchronization code was performing sub-optimally for non-TCXO dongles, because it assumed the sample clock error to be zero. To correct this, I've added code to estimate the sample clock error and add a corresponding amount to the symbol timing error (`samperr`) to compensate. This accounts for the number of samples that will be gained or lost between invocations of `acquire_process`.

The sample clock error is estimated by performing a linear regression on the `prev_slope` values. The slope gives the sample clock error, while the intercept (already computed as `angle`) gives the frequency error.

After this change, the bit error rate either improved (in some cases, significantly) or stayed approximately the same for all of the 40 recordings I now test with.