### PR TITLE
Fix the CNR calculation, and only display one decimal place.

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -58,7 +58,7 @@ static int snr_callback(void *arg, float snr, float signal, float noise)
         best_snr = snr;
     }
 
-    log_info("Gain: %0.1f dB, CNR: %f dB", gain_list[gain_index] / 10.0, 10 * log10f(snr));
+    log_info("Gain: %.1f dB, CNR: %.1f dB", gain_list[gain_index] / 10.0, 20 * log10f(snr));
 
     if (gain_index + 1 >= gain_count || snr < best_snr * 0.5)
     {


### PR DESCRIPTION
The CNR value displayed during automatic gain selection is off by a factor of two.

I also changed the display to include only a single decimal place.

Gain selection now looks like so:
```
22:23:36 INFO  main.c:61: Gain: 0.0 dB, CNR: 21.5 dB
22:23:36 INFO  main.c:61: Gain: 0.9 dB, CNR: 25.4 dB
22:23:36 INFO  main.c:61: Gain: 1.4 dB, CNR: 26.3 dB
22:23:36 INFO  main.c:61: Gain: 2.7 dB, CNR: 28.9 dB
22:23:36 INFO  main.c:61: Gain: 3.7 dB, CNR: 28.8 dB
22:23:36 INFO  main.c:61: Gain: 7.7 dB, CNR: 29.8 dB
22:23:37 INFO  main.c:61: Gain: 8.7 dB, CNR: 30.5 dB
22:23:37 INFO  main.c:61: Gain: 12.5 dB, CNR: 30.0 dB
22:23:37 INFO  main.c:61: Gain: 14.4 dB, CNR: 30.0 dB
22:23:37 INFO  main.c:61: Gain: 15.7 dB, CNR: 30.2 dB
22:23:37 INFO  main.c:61: Gain: 16.6 dB, CNR: 30.7 dB
22:23:37 INFO  main.c:61: Gain: 19.7 dB, CNR: 30.3 dB
22:23:37 INFO  main.c:61: Gain: 20.7 dB, CNR: 30.5 dB
22:23:37 INFO  main.c:61: Gain: 22.9 dB, CNR: 30.9 dB
22:23:37 INFO  main.c:61: Gain: 25.4 dB, CNR: 30.2 dB
22:23:37 INFO  main.c:61: Gain: 28.0 dB, CNR: 24.1 dB
22:23:37 DEBUG main.c:65: Best gain: 229
```