### PR TITLE
Use a Costas loop for synchronization.

### DIFF
--- a/src/acquire.c
+++ b/src/acquire.c
@@ -120,8 +120,10 @@ void acquire_process(acquire_t *st)
     for (i = 0; i < FFTCP * (ACQUIRE_SYMBOLS + 1); i++)
         st->buffer[i] = cq15_to_cf(st->in_buffer[i]);
 
-    sync_adjust(&st->input->sync, angle_diff);
+    sync_adjust(&st->input->sync, FFTCP / 2 - samperr);
     angle -= 2 * M_PI * st->cfo;
+
+    st->phase *= cexpf(-(FFTCP / 2 - samperr) * angle / FFT * I);
 
     phase_increment = cexpf(angle / FFT * I);
     for (i = 0; i < ACQUIRE_SYMBOLS; ++i)
@@ -149,8 +151,6 @@ void acquire_process(acquire_t *st)
     keep = FFTCP + (FFTCP / 2 - samperr);
     memmove(&st->in_buffer[0], &st->in_buffer[st->idx - keep], sizeof(cint16_t) * keep);
     st->idx = keep;
-
-    st->phase *= cexpf((FFTCP / 2 - samperr) * angle / FFT * I);
 }
 
 void acquire_cfo_adjust(acquire_t *st, int cfo)

--- a/src/sync.h
+++ b/src/sync.h
@@ -17,14 +17,17 @@ typedef struct
     int cfo_wait;
     int samperr;
     float angle;
-    float angle_adj;
-    float prev_slope[FFT];
+
+    float alpha;
+    float beta;
+    float costas_freq[FFT];
+    float costas_phase[FFT];
 
     int mer_cnt;
     float error_lb;
     float error_ub;
 } sync_t;
 
-void sync_adjust(sync_t *st, float angle_adj);
+void sync_adjust(sync_t *st, int sample_adj);
 void sync_push(sync_t *st, float complex *fft);
 void sync_init(sync_t *st, struct input_t *input);


### PR DESCRIPTION
Currently nrsc5 uses an ad-hoc method for BPSK synchronization. Switching to a Costas loop improves the BER for all recordings I tested with. On average, the improvement is 21%.

Also, I added an extra `cfo` parameter to `adjust_ref` to compensate for the rotation introduced by the carrier frequency offset. This simplifies the Costas loop implementation, and removes the need to invert the data in `find_ref`.

The Costas loop processes symbols one at a time (rather than in blocks of 32), which should allow for some future simplifications (such as removing `input_set_skip`).

Testing would be appreciated @classicfm @classicjazz @tylert @pclov3r.