### PR TITLE
Fix the length of a memmove.

### DIFF
--- a/src/acquire.c
+++ b/src/acquire.c
@@ -147,7 +147,7 @@ void acquire_process(acquire_t *st)
     }
 
     keep = FFTCP + (FFTCP / 2 - samperr);
-    memmove(&st->in_buffer[0], &st->in_buffer[st->idx - keep], sizeof(float complex) * keep);
+    memmove(&st->in_buffer[0], &st->in_buffer[st->idx - keep], sizeof(cint16_t) * keep);
     st->idx = keep;
 
     st->phase *= cexpf((FFTCP / 2 - samperr) * angle / FFT * I);


### PR DESCRIPTION
I just noticed I introduced a bug in #114. I forgot to update the length of the `memmove` in `acquire_process` when I changed the buffer to `cint16_t`.