### PR TITLE
Only write album art & station logo for the current program.

### DIFF
--- a/src/output.h
+++ b/src/output.h
@@ -34,6 +34,8 @@ typedef struct
     uint16_t port;
     uint16_t pkt_size;
     uint8_t type;
+    unsigned int service_data_type;
+    unsigned int program;
 
     union
     {


### PR DESCRIPTION
Hopefully this solves #115.

This change does a few things:

* log the port number for files
* store the service data type and program number for each port
* for files with service data type 0x40, only write when the program number matches the current one

Traffic & weather files will still be written out regardless of the current program number.

This code is based on my reverse engineering assumptions from #115. Testing would be appreciated @cmnybo.