### PR TITLE
Don't display CFO PPM when reading from file.

### DIFF
--- a/src/acquire.c
+++ b/src/acquire.c
@@ -155,12 +155,18 @@ void acquire_process(acquire_t *st)
 
 void acquire_cfo_adjust(acquire_t *st, int cfo)
 {
+    float hz;
+
     if (cfo == 0)
         return;
 
     st->cfo += cfo;
-    float hz = st->cfo * 744187.5 / FFT;
-    log_info("CFO: %f Hz (%d ppm)", hz, (int)round(hz * 1000000.0 / st->input->center));
+    hz = st->cfo * 744187.5 / FFT;
+
+    if (st->input->center)
+        log_info("CFO: %f Hz (%d ppm)", hz, (int)round(hz * 1e6 / st->input->center));
+    else
+        log_info("CFO: %f Hz", hz);
 }
 
 unsigned int acquire_push(acquire_t *st, cint16_t *buf, unsigned int length)


### PR DESCRIPTION
When reading from a file, the center frequency is not set, which results in an invalid PPM value being printed:
```
10:19:25 INFO  acquire.c:163: CFO: 3997.100830 Hz (-2147483648 ppm)
```
This PR removes the PPM part of the message when the center frequency is not set.