### PR TITLE
improved XHDR decoding

### DIFF
--- a/src/output.c
+++ b/src/output.c
@@ -453,6 +453,23 @@ static void output_id3(uint8_t *buf, unsigned int len)
                           price, until, url, seller, desc, received_as);
             }
         }
+        else if (memcmp(buf + off, "XHDR", 4) == 0)
+        {
+            int xhdr_length;
+            log_debug("XHDR MIME hash = %02X %02X %02X %02X", buf[off+10], buf[off+11], buf[off+12], buf[off+13]);
+            log_debug("XHDR Parameter ID = %02X", buf[off+14]);
+            xhdr_length = buf[off + 15];
+            if (xhdr_length > 0 && xhdr_length <= frame_len - 6) {
+                int i;
+                char *hex = malloc(3 * xhdr_length + 1);
+                for (i = 0; i < xhdr_length; i++) {
+                    sprintf(hex + (3 * i), "%02X ", buf[off + 16 + i]);
+                }
+                hex[3 * i - 1] = 0;
+                log_debug("XHDR Value = %s", hex);
+                free(hex);
+            }
+        }
         else
         {
             int i;
@@ -461,6 +478,7 @@ static void output_id3(uint8_t *buf, unsigned int len)
                 sprintf(hex + (3 * i), "%02X ", buf[off + 10 + i]);
             hex[3 * i - 1] = 0;
             log_debug("%c%c%c%c tag: %s", buf[off], buf[off+1], buf[off+2], buf[off+3], hex);
+            free(hex);
         }
 
         off += 10 + frame_len;


### PR DESCRIPTION
Decode the XHDR ID3 field according to information found online and experimentation. "MIME hash" appears to be a function of what is being transmitted (album art, logo, etc.), and is constant across multiple stations. "Parameter ID" is used to control what should be displayed -- "0" means "album art", "1" means either "blank screen" or "display the station logo". "Value" is currently opaque -- my theory is that it's correlated to the file to be displayed (either its name, or possibly some metadata), but I haven't been able to decode it further.