### PR TITLE
Address compiler warnings.

### DIFF
--- a/src/conv_dec.c
+++ b/src/conv_dec.c
@@ -166,7 +166,7 @@ static void gen_rec_state_info(const struct lte_conv_code *code,
 	/* Compute recursive input value (not the value shifted into register) */
 	rec = (reg >> (code->k - 2)) & 0x01;
 
-	if (PARITY(prev & code->rgen) == rec)
+	if ((unsigned int) PARITY(prev & code->rgen) == rec)
 		*val = 0;
 	else
 		*val = 1;
@@ -393,7 +393,7 @@ fail:
  * accumulated path metric sums and path selections are stored. Normalize on
  * the interval specified by the decoder.
  */
-static void _conv_decode(struct vdecoder *dec, const int8_t *seq, int len)
+static void _conv_decode(struct vdecoder *dec, const int8_t *seq)
 {
 	int i;
 	struct vtrellis *trellis = dec->trellis;
@@ -425,10 +425,10 @@ int nrsc5_conv_decode_p1(const int8_t *in, uint8_t *out)
 	reset_decoder(vdec, code.term);
 
 	/* Propagate through the trellis with interval normalization */
-	_conv_decode(vdec, in, code.len);
+	_conv_decode(vdec, in);
 
 	if (code.term == CONV_TERM_TAIL_BITING)
-		_conv_decode(vdec, in, code.len);
+		_conv_decode(vdec, in);
 
 	rc = traceback(vdec, out, code.term, code.len);
 
@@ -454,10 +454,10 @@ int nrsc5_conv_decode_pids(const int8_t *in, uint8_t *out)
 	reset_decoder(vdec, code.term);
 
 	/* Propagate through the trellis with interval normalization */
-	_conv_decode(vdec, in, code.len);
+	_conv_decode(vdec, in);
 
 	if (code.term == CONV_TERM_TAIL_BITING)
-		_conv_decode(vdec, in, code.len);
+		_conv_decode(vdec, in);
 
 	rc = traceback(vdec, out, code.term, code.len);
 
@@ -483,10 +483,10 @@ int nrsc5_conv_decode_p3(const int8_t *in, uint8_t *out)
 	reset_decoder(vdec, code.term);
 
 	/* Propagate through the trellis with interval normalization */
-	_conv_decode(vdec, in, code.len);
+	_conv_decode(vdec, in);
 
 	if (code.term == CONV_TERM_TAIL_BITING)
-		_conv_decode(vdec, in, code.len);
+		_conv_decode(vdec, in);
 
 	rc = traceback(vdec, out, code.term, code.len);
 

--- a/src/conv_gen.h
+++ b/src/conv_gen.h
@@ -1,5 +1,5 @@
 /*
- * Viterbi decoder for convolutional codes 
+ * Viterbi decoder for convolutional codes
  *
  * Copyright (C) 2015 Ettus Research LLC
  *
@@ -61,18 +61,6 @@ static void acs_butterfly(int state, int num_states,
 	}
 }
 
-/* Branch metrics unit N=2 */
-static void _gen_branch_metrics_n2(int num_states, const int8_t *seq,
-			    const int16_t *out, int16_t *metrics)
-{
-	int i;
-
-	for (i = 0; i < num_states / 2; i++) {
-		metrics[i] = seq[0] * out[2 * i + 0] +
-			     seq[1] * out[2 * i + 1];
-	}
-}
-
 /* Branch metrics unit N=3 */
 static void _gen_branch_metrics_n3(int num_states, const int8_t *seq,
 			    const int16_t *out, int16_t *metrics)
@@ -83,19 +71,6 @@ static void _gen_branch_metrics_n3(int num_states, const int8_t *seq,
 		metrics[i] = seq[0] * out[4 * i + 0] +
 			     seq[1] * out[4 * i + 1] +
 			     seq[2] * out[4 * i + 2];
-}
-
-/* Branch metrics unit N=4 */
-static void _gen_branch_metrics_n4(int num_states, const int8_t *seq,
-			    const int16_t *out, int16_t *metrics)
-{
-	int i;
-
-	for (i = 0; i < num_states / 2; i++)
-		metrics[i] = seq[0] * out[4 * i + 0] +
-			     seq[1] * out[4 * i + 1] +
-			     seq[2] * out[4 * i + 2] +
-			     seq[3] * out[4 * i + 3];
 }
 
 /* Path metric unit */
@@ -125,47 +100,6 @@ static void _gen_path_metrics(int num_states, int16_t *sums,
 	memcpy(sums, new_sums, num_states * sizeof(int16_t));
 }
 
-/* 16-state branch-path metrics units (K=5) */
-static void gen_metrics_k5_n2(const int8_t *seq, const int16_t *out,
-		       int16_t *sums, int16_t *paths, int norm)
-{
-	int16_t metrics[8];
-
-	_gen_branch_metrics_n2(16, seq, out, metrics);
-	_gen_path_metrics(16, sums, metrics, paths, norm);
-}
-
-static void gen_metrics_k5_n3(const int8_t *seq, const int16_t *out,
-		       int16_t *sums, int16_t *paths, int norm)
-{
-	int16_t metrics[8];
-
-	_gen_branch_metrics_n3(16, seq, out, metrics);
-	_gen_path_metrics(16, sums, metrics, paths, norm);
-
-}
-
-static void gen_metrics_k5_n4(const int8_t *seq, const int16_t *out,
-		       int16_t *sums, int16_t *paths, int norm)
-{
-	int16_t metrics[8];
-
-	_gen_branch_metrics_n4(16, seq, out, metrics);
-	_gen_path_metrics(16, sums, metrics, paths, norm);
-
-}
-
-/* 64-state branch-path metrics units (K=7) */
-static void gen_metrics_k7_n2(const int8_t *seq, const int16_t *out,
-		       int16_t *sums, int16_t *paths, int norm)
-{
-	int16_t metrics[32];
-
-	_gen_branch_metrics_n2(64, seq, out, metrics);
-	_gen_path_metrics(64, sums, metrics, paths, norm);
-
-}
-
 static void gen_metrics_k7_n3(const int8_t *seq, const int16_t *out,
 		       int16_t *sums, int16_t *paths, int norm)
 {
@@ -174,13 +108,4 @@ static void gen_metrics_k7_n3(const int8_t *seq, const int16_t *out,
 	_gen_branch_metrics_n3(64, seq, out, metrics);
 	_gen_path_metrics(64, sums, metrics, paths, norm);
 
-}
-
-static void gen_metrics_k7_n4(const int8_t *seq, const int16_t *out,
-		       int16_t *sums, int16_t *paths, int norm)
-{
-	int16_t metrics[32];
-
-	_gen_branch_metrics_n4(64, seq, out, metrics);
-	_gen_path_metrics(64, sums, metrics, paths, norm);
 }

--- a/src/decode.c
+++ b/src/decode.c
@@ -130,9 +130,9 @@ void decode_process_pids(decode_t *st)
 
 void decode_process_p3(decode_t *st)
 {
-    const int J = 4, B = 32, C = 36, M = 2, N = 147456;
-    const int bk_bits = 32 * C;
-    const int bk_adj = 32 * C - 1;
+    const unsigned int J = 4, B = 32, C = 36, M = 2, N = 147456;
+    const unsigned int bk_bits = 32 * C;
+    const unsigned int bk_adj = 32 * C - 1;
     unsigned int i, out = 0;
     for (i = 0; i < 9216; i++)
     {

--- a/src/defines.h
+++ b/src/defines.h
@@ -9,7 +9,7 @@
 #include <math.h>
 #include "log.h"
 
-#define FATAL_EXIT(x,...) do { log_fatal(x, ##__VA_ARGS__); exit(1); } while (0)
+#define FATAL_EXIT(...) do { log_fatal(__VA_ARGS__); exit(1); } while (0)
 
 #define SNR_FFT_COUNT 256
 

--- a/src/firdecim_q15.c
+++ b/src/firdecim_q15.c
@@ -34,7 +34,7 @@ firdecim_q15 firdecim_q15_create(const float * taps, unsigned int ntaps)
 
     // reverse order so we can push into the window
     // duplicate for neon
-    for (int i = 0; i < ntaps; ++i)
+    for (unsigned int i = 0; i < ntaps; ++i)
     {
         q->taps[i*2] = taps[ntaps - 1 - i] * 32767.0f;
         q->taps[i*2+1] = taps[ntaps - 1 - i] * 32767.0f;
@@ -54,7 +54,7 @@ static void push(firdecim_q15 q, cint16_t x)
 {
     if (q->idx == WINDOW_SIZE)
     {
-        for (int i = 0; i < q->ntaps - 1; i++)
+        for (unsigned int i = 0; i < q->ntaps - 1; i++)
             q->window[i] = q->window[q->idx - q->ntaps + 1 + i];
         q->idx = q->ntaps - 1;
     }

--- a/src/frame.c
+++ b/src/frame.c
@@ -293,7 +293,7 @@ static int unescape_hdlc(uint8_t *data, int length)
     return p - data;
 }
 
-static void aas_push(frame_t *st, uint8_t* psd, int length)
+static void aas_push(frame_t *st, uint8_t* psd, unsigned int length)
 {
     length = unescape_hdlc(psd, length);
 
@@ -316,7 +316,7 @@ static void aas_push(frame_t *st, uint8_t* psd, int length)
     }
 }
 
-static void parse_hdlc(frame_t *st, void (*process)(frame_t *, uint8_t *, int), uint8_t *buffer, int *bufidx, int bufsz, uint8_t *input, size_t inlen)
+static void parse_hdlc(frame_t *st, void (*process)(frame_t *, uint8_t *, unsigned int), uint8_t *buffer, int *bufidx, int bufsz, uint8_t *input, size_t inlen)
 {
     for (size_t i = 0; i < inlen; i++)
     {
@@ -340,7 +340,7 @@ static void parse_hdlc(frame_t *st, void (*process)(frame_t *, uint8_t *, int), 
     }
 }
 
-static void process_fixed_ccc(frame_t *st, uint8_t *buf, int buflen)
+static void process_fixed_ccc(frame_t *st, uint8_t *buf, unsigned int buflen)
 {
     buflen = unescape_hdlc(buf, buflen);
 
@@ -450,7 +450,7 @@ static void process_fixed_data(frame_t *st)
 
 void frame_process(frame_t *st, size_t length)
 {
-    int offset = 0;
+    unsigned int offset = 0;
 
     if (has_fixed(st))
         process_fixed_data(st);

--- a/src/output.c
+++ b/src/output.c
@@ -512,12 +512,12 @@ static void output_id3(uint8_t *buf, unsigned int len)
         }
         else if (memcmp(buf + off, "XHDR", 4) == 0)
         {
-            int xhdr_length;
+            unsigned int xhdr_length;
             log_debug("XHDR MIME hash = %02X %02X %02X %02X", buf[off+10], buf[off+11], buf[off+12], buf[off+13]);
             log_debug("XHDR Parameter ID = %02X", buf[off+14]);
             xhdr_length = buf[off + 15];
             if (xhdr_length > 0 && xhdr_length <= frame_len - 6) {
-                int i;
+                unsigned int i;
                 char *hex = malloc(3 * xhdr_length + 1);
                 for (i = 0; i < xhdr_length; i++) {
                     sprintf(hex + (3 * i), "%02X ", buf[off + 16 + i]);
@@ -529,7 +529,7 @@ static void output_id3(uint8_t *buf, unsigned int len)
         }
         else
         {
-            int i;
+            unsigned int i;
             char *hex = malloc(3 * frame_len + 1);
             for (i = 0; i < frame_len; i++)
                 sprintf(hex + (3 * i), "%02X ", buf[off + 10 + i]);

--- a/src/pids.c
+++ b/src/pids.c
@@ -56,7 +56,7 @@ int check_crc12(uint8_t *bits)
     return expected_crc == crc12(bits);
 }
 
-unsigned int decode_int(uint8_t *bits, int *off, int length)
+unsigned int decode_int(uint8_t *bits, int *off, unsigned int length)
 {
     unsigned int i, result = 0;
     for (i = 0; i < length; i++)
@@ -67,7 +67,7 @@ unsigned int decode_int(uint8_t *bits, int *off, int length)
     return result;
 }
 
-int decode_signed_int(uint8_t *bits, int *off, int length)
+int decode_signed_int(uint8_t *bits, int *off, unsigned int length)
 {
     int result = (int) decode_int(bits, off, length);
     return (result & (1 << (length - 1))) ? result - (1 << length) : result;

--- a/src/sync.c
+++ b/src/sync.c
@@ -74,7 +74,7 @@ static void decode_dbpsk(const float complex *buf, unsigned char *data, int size
     }
 }
 
-static int fuzzy_match(const signed char *needle, int needle_size, const unsigned char *data, int size)
+static int fuzzy_match(const signed char *needle, unsigned int needle_size, const unsigned char *data, int size)
 {
     for (int n = 0; n < size; n++)
     {
@@ -162,7 +162,7 @@ float phase_diff(float a, float b)
 
 void sync_process(sync_t *st)
 {
-    int i;
+    unsigned int i;
     static int psmi = 1;
     unsigned int partitions_per_band;
 


### PR DESCRIPTION
I turned on `-Wall -Wextra -Wpedantic` to see what was lurking and fixed everything that came up: unused arguments and functions, signed/unsigned comparisons, and use of GNU extensions.