### PR TITLE
Add support for grabbing samples over a pipe.

### DIFF
--- a/include/nrsc5.h
+++ b/include/nrsc5.h
@@ -155,7 +155,8 @@ typedef struct nrsc5_t nrsc5_t;
  * Public functions. All functions return void or an error code (0 == success).
  */
 int nrsc5_open(nrsc5_t **, int device_index, int ppm_error);
-int nrsc5_open_iq(nrsc5_t **, const char *path);
+int nrsc5_open_fd(nrsc5_t **, int fd);
+int nrsc5_open_pipe(nrsc5_t **);
 void nrsc5_close(nrsc5_t *);
 void nrsc5_start(nrsc5_t *);
 void nrsc5_stop(nrsc5_t *);
@@ -165,5 +166,6 @@ void nrsc5_get_gain(nrsc5_t *, float *gain);
 int nrsc5_set_gain(nrsc5_t *, float gain);
 void nrsc5_set_auto_gain(nrsc5_t *, int enabled);
 void nrsc5_set_callback(nrsc5_t *, nrsc5_callback_t callback, void *opaque);
+int nrsc5_pipe_samples(nrsc5_t *, uint8_t *samples, unsigned int length);
 
 #endif /* NRSC5_H_ */

--- a/src/defines.h
+++ b/src/defines.h
@@ -3,7 +3,6 @@
 #include "config.h"
 
 #include <stdint.h>
-#include <stdio.h>
 #include <stdlib.h>
 #include <complex.h>
 #include <math.h>

--- a/src/input.h
+++ b/src/input.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include <stdint.h>
-#include <stdio.h>
 #include <complex.h>
 
 #include <nrsc5.h>

--- a/src/main.c
+++ b/src/main.c
@@ -14,10 +14,12 @@
  */
 
 #include <ao/ao.h>
+#include <fcntl.h>
 #include <getopt.h>
 #include <nrsc5.h>
 #include <pthread.h>
 #include <sys/time.h>
+#include <unistd.h>
 
 #include <assert.h>
 #include <stdio.h>
@@ -472,7 +474,13 @@ int main(int argc, char *argv[])
 
     if (st->input_name)
     {
-        if (nrsc5_open_iq(&radio, st->input_name) != 0)
+        int fd = strcmp(st->input_name, "-") == 0 ? dup(STDIN_FILENO) : open(st->input_name, O_RDONLY);
+        if (fd < 0)
+        {
+            log_fatal("Open IQ file failed.");
+            return 1;
+        }
+        if (nrsc5_open_fd(&radio, fd) != 0)
         {
             log_fatal("Open IQ failed.");
             return 1;

--- a/src/private.h
+++ b/src/private.h
@@ -2,7 +2,6 @@
 
 #include <pthread.h>
 #include <rtl-sdr.h>
-#include <stdio.h>
 
 #include <nrsc5.h>
 
@@ -14,7 +13,8 @@
 struct nrsc5_t
 {
     rtlsdr_dev_t *dev;
-    FILE *iq_file;
+    int iq_fd;
+    int pipe_fd;
     uint8_t samples_buf[128 * 256];
     float freq;
     int gain;


### PR DESCRIPTION
This adds two new functions: nrsc5_open_pipe and nrsc5_pipe_samples. It also
replaces nrsc5_open_iq with nrsc5_open_fd. As part of this change, we no longer
use stdio functions but open, read and write.