### PR TITLE
Use _pipe instead of pipe on Windows.

### DIFF
--- a/src/nrsc5.c
+++ b/src/nrsc5.c
@@ -5,6 +5,11 @@
 
 #include "private.h"
 
+#ifdef __MINGW32__
+#include <fcntl.h>
+#define pipe(fds) _pipe(fds, 65536, _O_BINARY)
+#endif
+
 static int snr_callback(void *arg, float snr)
 {
     nrsc5_t *st = arg;


### PR DESCRIPTION
MinGW doesn't have a `pipe` function, so nrsc5 fails to build on Windows. Using `_pipe` solves the problem. If there's a better way to do this, please let me know.

I tested the API in Python to verify that pipe input works.