### PR TITLE
Add a build script for MSYS2.

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,53 +88,16 @@ The only build environment that has been tested on Windows is MSYS2 with MinGW. 
 
 ### Building with [MSYS2](http://www.msys2.org)
 
-Install MSYS2. Open a terminal using the "MSYS2 MinGW 32-bit" shortcut.
+Install MSYS2. Open a terminal using the "MSYS2 MinGW 32-bit" shortcut. (Or use the 64-bit shortcut if you prefer a 64-bit build.)
 
      $ pacman -Syu
 
 If this is the first time running pacman, you will be told to close the terminal window. After doing so, reopen using the same shortcut as before.
 
      $ pacman -Su
-     $ pacman -S autoconf automake git gzip make mingw-w64-i686-gcc mingw-w64-i686-cmake mingw-w64-i686-libtool patch tar xz
-
-Download and install fftw:
-
-     $ cd ~
-     $ curl -L http://www.fftw.org/fftw-3.3.7.tar.gz | tar xvz
-     $ cd fftw-3.3.7
-     $ ./configure --enable-float --enable-sse2 --with-our-malloc && make && make install
-
-Download and install libao:
-
-     $ cd ~
-     $ git clone https://git.xiph.org/libao.git
-     $ cd libao
-     $ ./autogen.sh
-     $ LDFLAGS=-lksuser ./configure && make && make install
-
-Download and install libusb:
-
-     $ cd ~
-     $ git clone https://github.com/libusb/libusb.git
-     $ cd libusb
-     $ ./autogen.sh
-     $ make && make install
-
-Download and install rtl-sdr:
-
-     $ cd ~
-     $ git clone git://git.osmocom.org/rtl-sdr.git
-     $ mkdir rtl-sdr/build && cd rtl-sdr/build
-     $ cmake -G "MSYS Makefiles" -D LIBUSB_FOUND=1 -D LIBUSB_INCLUDE_DIR=/mingw32/include/libusb-1.0 -D "LIBUSB_LIBRARIES=-L/mingw32/lib -lusb-1.0" -D THREADS_PTHREADS_WIN32_LIBRARY=/mingw32/i686-w64-mingw32/lib/libpthread.a -D THREADS_PTHREADS_INCLUDE_DIR=/mingw32/i686-w64-mingw32/include -D CMAKE_INSTALL_PREFIX=/mingw32 ..
-     $ make && make install
-
-Download and install nrsc5:
-
-     $ cd ~
-     $ git clone https://github.com/theori-io/nrsc5
-     $ mkdir nrsc5/build && cd nrsc5/build
-     $ cmake -G "MSYS Makefiles" -DUSE_COLOR=OFF -DUSE_SSE=ON -DCMAKE_INSTALL_PREFIX=/mingw32 ..
-     $ make && make install
+     $ pacman -S git
+     $ git clone https://github.com/theori-io/nrsc5.git
+     $ nrsc5/support/msys2-build
 
 You can test your installation using the included sample file:
 
@@ -146,7 +109,7 @@ If the sample file does not work, make sure you followed all of the instructions
 
 ### Packaging
 
-Once everything is built, you can run nrsc5 independently of MSYS2. Copy the following files from your MSYS2/mingw32 directory (e.g. C:\msys64\mingw32\bin):
+Once everything is built, you can run nrsc5 independently of MSYS2. Copy the following files from your MSYS2/mingw32 directory (e.g. C:\\msys64\\mingw32\\bin):
 
  * libao-4.dll
  * libgcc\_s\_dw2-1.dll

--- a/support/msys2-build
+++ b/support/msys2-build
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+
+set -e
+
+fftw_version=3.3.8
+libao_version=1.2.2
+libusb_version=v1.0.22
+rtlsdr_version=0.6.0
+
+pacman -Su
+pacman -S --needed autoconf automake git gzip make ${MINGW_PACKAGE_PREFIX}-gcc ${MINGW_PACKAGE_PREFIX}-cmake ${MINGW_PACKAGE_PREFIX}-libtool patch tar xz
+
+cd ~
+if [ ! -d fftw-${fftw_version} ]; then
+    curl -L http://www.fftw.org/fftw-${fftw_version}.tar.gz | tar xvz
+fi
+if [ ! -e ${MINGW_PREFIX}/lib/libfftw3f.a ]; then
+    cd fftw-${fftw_version}
+    ./configure --enable-float --enable-sse2 --with-our-malloc
+    make
+    make install
+fi
+
+cd ~
+if [ ! -d libao ]; then
+    git clone https://git.xiph.org/libao.git
+fi
+if [ ! -e ${MINGW_PREFIX}/bin/libao-4.dll ]; then
+    cd libao
+    git checkout ${libao_version}
+    ./autogen.sh
+    LDFLAGS=-lksuser ./configure
+    make
+    make install
+fi
+
+cd ~
+if [ ! -d libusb ]; then
+    git clone https://github.com/libusb/libusb.git
+fi
+if [ ! -e ${MINGW_PREFIX}/bin/libusb-1.0.dll ]; then
+    cd libusb
+    git checkout ${libusb_version}
+    ./autogen.sh
+    make
+    make install
+fi
+
+cd ~
+if [ ! -d rtl-sdr ]; then
+    git clone git://git.osmocom.org/rtl-sdr.git
+fi
+if [ ! -e ${MINGW_PREFIX}/bin/librtlsdr.dll ]; then
+    mkdir -p rtl-sdr/build
+    cd rtl-sdr/build
+    git checkout ${rtlsdr_version}
+    cmake -G "MSYS Makefiles" -D LIBUSB_FOUND=1 -D LIBUSB_INCLUDE_DIR=${MINGW_PREFIX}/include/libusb-1.0 -D "LIBUSB_LIBRARIES=-L${MINGW_PREFIX}/lib -lusb-1.0" -D THREADS_PTHREADS_WIN32_LIBRARY=${MINGW_PREFIX}/${MINGW_CHOST}/lib/libpthread.a -D THREADS_PTHREADS_INCLUDE_DIR=${MINGW_PREFIX}/${MINGW_CHOST}/include -D CMAKE_INSTALL_PREFIX=${MINGW_PREFIX} ..
+    make
+    make install
+fi
+
+cd ~
+if [ ! -d nrsc5 ]; then
+    git clone https://github.com/theori-io/nrsc5
+else
+    cd nrsc5
+    git pull
+    cd ~
+fi
+mkdir -p nrsc5/build
+cd nrsc5/build
+cmake -G "MSYS Makefiles" -D USE_COLOR=OFF -D USE_SSE=ON -D CMAKE_INSTALL_PREFIX=${MINGW_PREFIX} ..
+make
+make install


### PR DESCRIPTION
Following the build instructions for Windows is tedious. To simplify the process, I moved as much as I could into a bash script. The script also makes a couple improvements:

* The MinGW environment variables are used to determine which compiler & prefix should be used. This allows both 32-bit and 64-bit builds.
* FFTW is updated to version 3.3.8.
* For dependencies fetched from git, the latest release tag is used (instead of the master branch), which hopefully will reduce the likelihood of bugs.

The script tries to avoid repeating work by checking whether the dependencies are already downloaded or installed.