### PR TITLE
Add script to cross-compile for Windows.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,6 @@
 /build/
+/build-win32/
+/build-win64/
 
 # Swap
 [._]*.s[a-v][a-z]

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,8 @@ os:
   - linux
   - osx
 
+dist: xenial
+
 compiler:
   - gcc
   - clang
@@ -13,7 +15,7 @@ before_install:
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; fi
 
 install:
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get install -y libao-dev libfftw3-dev librtlsdr-dev; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get install -y libao-dev libfftw3-dev librtlsdr-dev mingw-w64; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install libao fftw librtlsdr xz; fi
 
 before_script:
@@ -23,6 +25,8 @@ before_script:
   - make
   - sudo make install
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo ldconfig; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]] && [[ "$TRAVIS_COMPILER" == "gcc" ]]; then CC= ../support/win-cross-compile 32; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]] && [[ "$TRAVIS_COMPILER" == "gcc" ]]; then CC= ../support/win-cross-compile 64; fi
 
 script:
   - xz -d < ../support/sample.xz | nrsc5 -r - -o sample.wav 0 2> sample.log

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,7 @@ option (USE_COLOR "Colorize log output")
 option (USE_NEON "Use NEON instructions")
 option (USE_SSE "Use SSE3 instructions")
 option (USE_FAAD2 "AAC decoding with FAAD2" ON)
+set (FAAD2_CONFIGURE_ARGS "" CACHE STRING "Extra arguments for FAAD2 configure command")
 
 find_program (AUTOCONF autoconf)
 if (NOT AUTOCONF)
@@ -67,7 +68,7 @@ if (USE_FAAD2)
         PATCH_COMMAND patch -p1 -Ni "${CMAKE_SOURCE_DIR}/support/faad2-hdc-support.patch" || exit 0
         COMMAND sh ./bootstrap
 
-        CONFIGURE_COMMAND ${FAAD2_PREFIX}/src/faad2_external/configure --prefix=${FAAD2_PREFIX} --with-hdc "CFLAGS=-O3 -fPIC ${CMAKE_C_FLAGS}"
+        CONFIGURE_COMMAND ${FAAD2_PREFIX}/src/faad2_external/configure ${FAAD2_CONFIGURE_ARGS} --prefix=${FAAD2_PREFIX} --with-hdc "CFLAGS=-O3 -fPIC ${CMAKE_C_FLAGS}"
 
         BUILD_COMMAND make
     )

--- a/support/win-cross-compile
+++ b/support/win-cross-compile
@@ -76,4 +76,9 @@ C_INCLUDE_PATH=${prefix}/include make
 make install
 
 cp /usr/${host}/lib/libwinpthread-1.dll ${prefix}/bin
-cp /usr/lib/gcc/${host}/*-win32/libgcc_s_*-1.dll ${prefix}/bin
+
+if [ "$1" == 32 ]; then
+    cp "$(${host}-gcc -print-file-name=libgcc_s_sjlj-1.dll)" "${prefix}/bin"
+elif [ "$1" == 64 ]; then
+    cp "$(${host}-gcc -print-file-name=libgcc_s_seh-1.dll)" "${prefix}/bin"
+fi

--- a/support/win-cross-compile
+++ b/support/win-cross-compile
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+
+set -e
+
+fftw_version=3.3.8
+libao_version=1.2.2
+libusb_version=v1.0.22
+rtlsdr_version=0.6.0
+
+root=`git rev-parse --show-toplevel`
+if [ "$1" == 32 ]; then
+    prefix=${root}/build-win32
+    host=i686-w64-mingw32
+elif [ "$1" == 64 ]; then
+    prefix=${root}/build-win64
+    host=x86_64-w64-mingw32
+else
+    echo "Usage: $0 (32|64)"
+    exit 1
+fi
+
+mkdir -p ${prefix}
+
+cd ${prefix}
+if [ ! -d fftw-${fftw_version} ]; then
+    curl -L http://www.fftw.org/fftw-${fftw_version}.tar.gz | tar xz
+fi
+if [ ! -e ${prefix}/lib/libfftw3f.a ]; then
+    cd fftw-${fftw_version}
+    ./configure --host=${host} --prefix=${prefix} --enable-float --enable-sse2 --with-our-malloc
+    make
+    make install
+fi
+
+cd ${prefix}
+if [ ! -d libao ]; then
+    git clone https://git.xiph.org/libao.git
+fi
+if [ ! -e ${prefix}/bin/libao-4.dll ]; then
+    cd libao
+    git checkout ${libao_version}
+    ./autogen.sh
+    LDFLAGS=-lksuser ./configure --host=${host} --prefix=${prefix} --enable-wmm --disable-pulse
+    make
+    make install
+fi
+
+cd ${prefix}
+if [ ! -d libusb ]; then
+    git clone https://github.com/libusb/libusb.git
+fi
+if [ ! -e ${prefix}/bin/libusb-1.0.dll ]; then
+    cd libusb
+    git checkout ${libusb_version}
+    ./autogen.sh --host=${host} --prefix=${prefix}
+    make
+    make install
+fi
+
+cd ${prefix}
+if [ ! -d rtl-sdr ]; then
+    git clone git://git.osmocom.org/rtl-sdr.git
+fi
+if [ ! -e ${prefix}/bin/librtlsdr.dll ]; then
+    mkdir -p rtl-sdr/build
+    cd rtl-sdr/build
+    git checkout ${rtlsdr_version}
+    cmake -D CMAKE_SYSTEM_NAME=Windows -D CMAKE_C_COMPILER=${host}-gcc -D LIBUSB_FOUND=1 -D LIBUSB_INCLUDE_DIR=${prefix}/include/libusb-1.0 -D "LIBUSB_LIBRARIES=-L${prefix}/lib -lusb-1.0" -D THREADS_PTHREADS_WIN32_LIBRARY=/usr/${host}/lib/libpthread.a -D THREADS_PTHREADS_INCLUDE_DIR=/usr/${host}/include -D CMAKE_INSTALL_PREFIX=${prefix} ..
+    make
+    make install
+fi
+
+cd ${prefix}
+cmake -D CMAKE_SYSTEM_NAME=Windows -D CMAKE_C_COMPILER=${host}-gcc -D CMAKE_LIBRARY_PATH=${prefix}/lib -D FAAD2_CONFIGURE_ARGS="--host=${host}" -D USE_COLOR=OFF -D USE_SSE=ON -D CMAKE_INSTALL_PREFIX=${prefix} ..
+C_INCLUDE_PATH=${prefix}/include make
+make install
+
+cp /usr/${host}/lib/libwinpthread-1.dll ${prefix}/bin
+cp /usr/lib/gcc/${host}/*-win32/libgcc_s_*-1.dll ${prefix}/bin

--- a/support/win-cross-compile
+++ b/support/win-cross-compile
@@ -75,7 +75,13 @@ cmake -D CMAKE_SYSTEM_NAME=Windows -D CMAKE_C_COMPILER=${host}-gcc -D CMAKE_LIBR
 C_INCLUDE_PATH=${prefix}/include make
 make install
 
-cp /usr/${host}/lib/libwinpthread-1.dll ${prefix}/bin
+# On MacOS, libwinpthread-1.dll is in /bin so we need to use -print-prog-name.
+# On Linux, libwinpthread-1.dll is in /lib so we need to use -print-file-name.
+LIBWINPTHREAD_PATH="$(${host}-gcc -print-prog-name=libwinpthread-1.dll)"
+if [ ! -e "${LIBWINPTHREAD_PATH}" ]; then
+    LIBWINPTHREAD_PATH="$(${host}-gcc -print-file-name=libwinpthread-1.dll)"
+fi
+cp "${LIBWINPTHREAD_PATH}" "${prefix}/bin"
 
 if [ "$1" == 32 ]; then
     cp "$(${host}-gcc -print-file-name=libgcc_s_sjlj-1.dll)" "${prefix}/bin"


### PR DESCRIPTION
I've put together a shell script (`support/win-cross-compile`) to cross-compile Windows binaries on Linux. This has the advantage of being much faster than MSYS2, and allows Windows builds to be tested in Travis CI, which should help catch bugs like https://github.com/theori-io/nrsc5/pull/156 earlier.

To run the script, first install the MinGW compiler with `sudo apt install mingw-w64`, then run `support/win-cross-compile 32` to build 32-bit binaries or `support/win-cross-compile 64` to build 64-bit binaries. The output files will be in `build-win32/bin` or `build-win64/bin`.

I've tested this on Ubuntu 16.04 (through Travis CI) and Ubuntu 18.04. @pclov3r I'd be interested to hear if this works on Debian for you.

I'll add some documentation to the readme soon.