### PR TITLE
Switch back to stdio for file reading.

### DIFF
--- a/include/nrsc5.h
+++ b/include/nrsc5.h
@@ -6,6 +6,7 @@
  */
 #include <stdint.h>
 #include <stdlib.h>
+#include <stdio.h>
 
 /*
  * Definitions.
@@ -155,7 +156,7 @@ typedef struct nrsc5_t nrsc5_t;
  * Public functions. All functions return void or an error code (0 == success).
  */
 int nrsc5_open(nrsc5_t **, int device_index, int ppm_error);
-int nrsc5_open_fd(nrsc5_t **, int fd);
+int nrsc5_open_file(nrsc5_t **, FILE *fp);
 int nrsc5_open_pipe(nrsc5_t **);
 void nrsc5_close(nrsc5_t *);
 void nrsc5_start(nrsc5_t *);

--- a/src/main.c
+++ b/src/main.c
@@ -14,12 +14,10 @@
  */
 
 #include <ao/ao.h>
-#include <fcntl.h>
 #include <getopt.h>
 #include <nrsc5.h>
 #include <pthread.h>
 #include <sys/time.h>
-#include <unistd.h>
 
 #include <assert.h>
 #include <stdio.h>
@@ -474,13 +472,13 @@ int main(int argc, char *argv[])
 
     if (st->input_name)
     {
-        int fd = strcmp(st->input_name, "-") == 0 ? dup(STDIN_FILENO) : open(st->input_name, O_RDONLY);
-        if (fd < 0)
+        FILE *fp = strcmp(st->input_name, "-") == 0 ? stdin : fopen(st->input_name, "rb");
+        if (fp == NULL)
         {
             log_fatal("Open IQ file failed.");
             return 1;
         }
-        if (nrsc5_open_fd(&radio, fd) != 0)
+        if (nrsc5_open_file(&radio, fp) != 0)
         {
             log_fatal("Open IQ failed.");
             return 1;

--- a/src/private.h
+++ b/src/private.h
@@ -2,6 +2,7 @@
 
 #include <pthread.h>
 #include <rtl-sdr.h>
+#include <stdio.h>
 
 #include <nrsc5.h>
 
@@ -13,8 +14,7 @@
 struct nrsc5_t
 {
     rtlsdr_dev_t *dev;
-    int iq_fd;
-    int pipe_fd;
+    FILE *iq_file;
     uint8_t samples_buf[128 * 256];
     float freq;
     int gain;


### PR DESCRIPTION
Fixes #160. Fixes #161.

This change switches from POSIX calls back to the standard C library for file input. I changed the API to accept a file pointer instead of a file descriptor. Things appear to be working well on Windows now, and I tested to make sure "pipe" input is still working.

Getting rid of the pipe also saves us an ifdef (from #156) and eliminates system calls.

I guess it's worth considering whether `nrsc5_open_pipe` and `nrsc5_pipe_samples` are still sensible names, since the underlying pipe was just an implementation detail. I guess they do still let you pipe in samples, in some sense.