### PR TITLE
Support character encodings in SIS and PSD.

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -29,6 +29,7 @@ add_library (
     galois.c
 
     log.c
+    unicode.c
 
     strndup.c
 )

--- a/src/main.c
+++ b/src/main.c
@@ -23,6 +23,10 @@
 #include <stdio.h>
 #include <string.h>
 
+#ifdef __MINGW32__
+#include <windows.h>
+#endif
+
 #include "bitwriter.h"
 #include "log.h"
 
@@ -460,6 +464,10 @@ int main(int argc, char *argv[])
     pthread_mutex_t log_mutex;
     nrsc5_t *radio = NULL;
     state_t *st = calloc(1, sizeof(state_t));
+
+#ifdef __MINGW32__
+    SetConsoleOutputCP(CP_UTF8);
+#endif
 
     pthread_mutex_init(&log_mutex, NULL);
     log_set_lock(log_lock);

--- a/src/output.c
+++ b/src/output.c
@@ -24,6 +24,7 @@
 #include "defines.h"
 #include "output.h"
 #include "private.h"
+#include "unicode.h"
 
 void output_push(output_t *st, uint8_t *pkt, unsigned int len, unsigned int program)
 {
@@ -130,19 +131,19 @@ static char *id3_text(uint8_t *buf, unsigned int frame_len)
 {
     char *text;
 
-    if (frame_len == 0)
+    if (frame_len > 0)
     {
-        text = (char *) malloc(1);
-        text[0] = 0;
-        return text;
+        if (buf[0] == 0)
+            return iso_8859_1_to_utf_8(buf + 1, frame_len - 1);
+        else if (buf[0] == 1)
+            return ucs_2_to_utf_8(buf + 1, frame_len - 1);
+        else
+            log_warn("Invalid encoding: %d", buf[0]);
     }
-    else
-    {
-        text = (char *) malloc(frame_len);
-        memcpy(text, buf + 1, frame_len - 1);
-        text[frame_len - 1] = 0;
-        return text;
-    }
+
+    text = malloc(1);
+    text[0] = 0;
+    return text;
 }
 
 static void output_id3(output_t *st, unsigned int program, uint8_t *buf, unsigned int len)

--- a/src/unicode.c
+++ b/src/unicode.c
@@ -1,0 +1,78 @@
+#include <stdlib.h>
+
+#include "unicode.h"
+
+char *iso_8859_1_to_utf_8(uint8_t *buf, unsigned int len)
+{
+    unsigned int i, j;
+    char *out = malloc(len * 2 + 1);
+
+    j = 0;
+    for (i = 0; i < len; i++)
+    {
+        uint8_t ch = buf[i];
+
+        if (ch < 0x80)
+        {
+            out[j++] = ch;
+        }
+        else
+        {
+            out[j++] = 0xc0 | (ch >> 6);
+            out[j++] = 0x80 | (ch & 0x3f);
+        }
+    }
+
+    out[j] = 0;
+    return out;
+}
+
+char *ucs_2_to_utf_8(uint8_t *buf, unsigned int len)
+{
+    unsigned int i = 0, j = 0;
+    unsigned int big_endian = 0;
+    char *out = malloc((len / 2) * 3 + 1);
+
+    if (len >= 2)
+    {
+        if ((buf[0] == 0xfe) && (buf[1] == 0xff))
+        {
+            big_endian = 1;
+            i += 2;
+        }
+        else if ((buf[0] == 0xff) && (buf[1] == 0xfe))
+        {
+            big_endian = 0;
+            i += 2;
+        }
+    }
+
+    for (; i < len; i += 2)
+    {
+        uint16_t ch;
+
+        if (big_endian)
+            ch = (buf[i] << 8) | buf[i+1];
+        else
+            ch = buf[i] | (buf[i+1] << 8);
+
+        if (ch < 0x80)
+        {
+            out[j++] = ch;
+        }
+        else if (ch < 0x800)
+        {
+            out[j++] = 0xc0 | (ch >> 6);
+            out[j++] = 0x80 | (ch & 0x3f);
+        }
+        else
+        {
+            out[j++] = 0xe0 | (ch >> 12);
+            out[j++] = 0x80 | ((ch >> 6) & 0x3f);
+            out[j++] = 0x80 | (ch & 0x3f);
+        }
+    }
+
+    out[j] = 0;
+    return out;
+}

--- a/src/unicode.h
+++ b/src/unicode.h
@@ -1,0 +1,6 @@
+#pragma once
+
+#include <stdint.h>
+
+char *iso_8859_1_to_utf_8(uint8_t *buf, unsigned int len);
+char *ucs_2_to_utf_8(uint8_t *buf, unsigned int len);


### PR DESCRIPTION
Both SIS messages and ID3 tags in PSD have a character encoding associated with them, either ISO-8859-1 or UCS-2. So far nrsc5 has been ignoring the coding and printing out the raw bytes. This PR adds functions to convert from these encodings to UTF-8, and calls them where appropriate.

I was able to test ISO-8859-1 in ID3 directly because a local station sometimes uses non-ASCII characters. For the other cases I was only able to verify that ASCII messages were still displayed correctly. I haven't observed any stations using UCS-2.

I tested the `iso_8859_1_to_utf_8` and `ucs_2_to_utf_8` in a stand-alone program to verify that they work properly.

The `ucs_2_to_utf_8` function assumes little-endian when there is no Byte Order Mark since SIS specifies little-endian for UCS-2. ID3 can use big-endian or little-endian for UCS-2, but the Byte Order Mark is mandatory there.