### PR TITLE
Enable AVX when building FFTW on Windows.

### DIFF
--- a/support/msys2-build
+++ b/support/msys2-build
@@ -16,7 +16,7 @@ if [ ! -d fftw-${fftw_version} ]; then
 fi
 if [ ! -e ${MINGW_PREFIX}/lib/libfftw3f.a ]; then
     cd fftw-${fftw_version}
-    ./configure --enable-float --enable-sse2 --with-our-malloc
+    ./configure --enable-float --enable-sse2 --enable-avx --with-our-malloc
     make
     make install
 fi

--- a/support/win-cross-compile
+++ b/support/win-cross-compile
@@ -27,7 +27,7 @@ if [ ! -d fftw-${fftw_version} ]; then
 fi
 if [ ! -e ${prefix}/lib/libfftw3f.a ]; then
     cd fftw-${fftw_version}
-    ./configure --host=${host} --prefix=${prefix} --enable-float --enable-sse2 --with-our-malloc
+    ./configure --host=${host} --prefix=${prefix} --enable-float --enable-sse2 --enable-avx --with-our-malloc
     make
     make install
 fi


### PR DESCRIPTION
As @pclov3r suggested in https://github.com/theori-io/nrsc5/pull/159, I've added the `--enable-avx` option to FFTW when building it for Windows. I did some timings with PowerShell's `Measure-Command` and it seems to give a speedup of around 3% on my laptop. Debian also compiles its FFTW package with `--enable-avx` so that's another good indication it's safe to use.