### PR TITLE
Avoid stepping into fixed data when processing audio payload.

### DIFF
--- a/src/defines.h
+++ b/src/defines.h
@@ -38,7 +38,7 @@
 // bits per L2 PCI
 #define PCI_LEN 24
 // bytes per L2 PDU (max)
-#define PDU_LEN ((P1_FRAME_LEN - PCI_LEN) / 8)
+#define MAX_PDU_LEN ((P1_FRAME_LEN - PCI_LEN) / 8)
 // number of programs (max)
 #define MAX_PROGRAMS 8
 

--- a/src/frame.h
+++ b/src/frame.h
@@ -17,7 +17,7 @@ typedef struct
 typedef struct
 {
     struct input_t *input;
-    uint8_t buffer[PDU_LEN];
+    uint8_t buffer[MAX_PDU_LEN];
     uint8_t pdu[MAX_PROGRAMS][0x10000];
     unsigned int pdu_idx[MAX_PROGRAMS];
     unsigned int pci;


### PR DESCRIPTION
I noticed occasional "RS corrected 5 symbols" log messages even when listening to stations with a BER of zero, so I dug in to see what was going wrong. The problem is that the main loop in `frame_process` continues until it reaches the end of the PDU. If the PDU ends with fixed data, then the loop attempts to process it as if it was an audio packet. Usually this causes Reed-Solomon error correction to fail, but occasionally it succeeds and prints the "RS corrected 5 symbols" message. Audio packet processing then proceeds with bogus data.

To solve the problem I modified `process_fixed_data` to return the length of the PDU minus the amount of bytes it processed. Once it determines the lengths of the fixed data streams, the excess processing of audio packets stops.

Along the way I renamed `PDU_LEN` to `MAX_PDU_LEN` to better reflect its meaning, and added the PDU length as an argument to `process_fixed_data` rather than having it assume it's processing a PDU from the P1 channel.