### PR TITLE
Build dependencies using CMake

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,13 +10,17 @@ compiler:
   - gcc
   - clang
 
+cache: ccache
+
 before_install:
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get -qq update; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew update; fi
 
 install:
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get install -y libao-dev libfftw3-dev librtlsdr-dev mingw-w64 python3-pyaudio; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install libao fftw librtlsdr xz mingw-w64 portaudio wine; fi
+  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo ln -s /usr/bin/ccache /usr/lib/ccache/i686-w64-mingw32-gcc; sudo ln -s /usr/bin/ccache /usr/lib/ccache/x86_64-w64-mingw32-gcc; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install libao fftw librtlsdr xz mingw-w64 portaudio wine ccache; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then export PATH="/usr/local/opt/ccache/libexec:$PATH"; ln -s /usr/local/bin/ccache /usr/local/opt/ccache/libexec/i686-w64-mingw32-gcc; ln -s /usr/local/bin/ccache /usr/local/opt/ccache/libexec/x86_64-w64-mingw32-gcc; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then pip3 install pyaudio; fi
 
 before_script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,7 +16,7 @@ before_install:
 
 install:
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get install -y libao-dev libfftw3-dev librtlsdr-dev mingw-w64 python3-pyaudio; fi
-  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install libao fftw librtlsdr xz mingw-w64 portaudio; fi
+  - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install libao fftw librtlsdr xz mingw-w64 portaudio wine; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then pip3 install pyaudio; fi
 
 before_script:
@@ -30,7 +30,13 @@ before_script:
   - if [[ "$TRAVIS_COMPILER" == "gcc" ]]; then CC= ../support/win-cross-compile 64; fi
 
 script:
-  - xz -d < ../support/sample.xz | nrsc5 -r - -o sample.wav 0 2> sample.log
+  - xz -d < ../support/sample.xz > sample
+  - nrsc5 -r sample -o sample.wav 0 2> sample.log
   - cat sample.log
   - grep -q "You're Listening to Q" sample.log
-  - xz -d < ../support/sample.xz | ../support/nrsc5.py -r - 0 0
+  - cat sample | nrsc5 -r - -o sample.wav 0 2> sample.log
+  - grep -q "You're Listening to Q" sample.log
+  - ../support/nrsc5.py -r sample 0 0
+  - cat sample | ../support/nrsc5.py -r - 0 0
+  - if [[ "TRAVIS_OS_NAME" == "osx" && "$TRAVIS_COMPILER" == "gcc" ]]; then wine ../build-win32/bin/nrsc5.exe -r sample -o sample.wav 0 2> sample.log && grep -q "You're Listening to Q" sample.log; fi
+  - if [[ "TRAVIS_OS_NAME" == "osx" && "$TRAVIS_COMPILER" == "gcc" ]]; then wine ../build-win64/bin/nrsc5.exe -r sample -o sample.wav 0 2> sample.log && grep -q "You're Listening to Q" sample.log; fi

--- a/.travis.yml
+++ b/.travis.yml
@@ -27,11 +27,11 @@ before_script:
   - mkdir build
   - cd build
   - cmake ..
-  - make
+  - make -j3
   - sudo make install
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo ldconfig; fi
-  - if [[ "$TRAVIS_COMPILER" == "gcc" ]]; then CC= ../support/win-cross-compile 32; fi
-  - if [[ "$TRAVIS_COMPILER" == "gcc" ]]; then CC= ../support/win-cross-compile 64; fi
+  - if [[ "$TRAVIS_COMPILER" == "gcc" ]]; then CC= ../support/win-cross-compile 32 -j3; fi
+  - if [[ "$TRAVIS_COMPILER" == "gcc" ]]; then CC= ../support/win-cross-compile 64 -j3; fi
 
 script:
   - xz -d < ../support/sample.xz > sample

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,11 +4,24 @@ include (CheckSymbolExists)
 include (ExternalProject)
 project (nrsc5 C)
 
+execute_process (COMMAND ${CMAKE_C_COMPILER} -dumpmachine OUTPUT_VARIABLE HOST_TRIPLE_DEFAULT OUTPUT_STRIP_TRAILING_WHITESPACE)
+
 option (USE_COLOR "Colorize log output")
 option (USE_NEON "Use NEON instructions")
 option (USE_SSE "Use SSE3 instructions")
 option (USE_FAAD2 "AAC decoding with FAAD2" ON)
+option (USE_STATIC "Link with static libraries")
+option (USE_SYSTEM_FFTW "Use system provided fftw" ON)
+option (USE_SYSTEM_RTLSDR "Use system provided rtl-sdr" ON)
+option (USE_SYSTEM_LIBUSB "Use system provided libusb" ON)
+option (USE_SYSTEM_LIBAO "Use system provided libao" ON)
 set (FAAD2_CONFIGURE_ARGS "" CACHE STRING "Extra arguments for FAAD2 configure command")
+set (HOST_TRIPLE "${HOST_TRIPLE_DEFAULT}" CACHE STRING "Override default host triple")
+if (HOST_TRIPLE)
+    set (HOST_TRIPLE_ARG "--host=${HOST_TRIPLE}")
+endif()
+
+message (STATUS "Building for ${HOST_TRIPLE}")
 
 find_program (AUTOCONF autoconf)
 if (NOT AUTOCONF)
@@ -30,19 +43,45 @@ if (NOT PATCH)
     message (FATAL_ERROR "Missing patch. Install patch package and try again.")
 endif()
 
-find_library (FFTW3F_LIBRARY fftw3f)
-find_library (RTL_SDR_LIBRARY rtlsdr)
+if (USE_SYSTEM_FFTW)
+    find_library (FFTW3F_LIBRARY fftw3f)
+    if (NOT FFTW3F_LIBRARY)
+        message (WARNING "libfftw3f not found. Building from source.")
+        set (USE_SYSTEM_FFTW OFF)
+    endif ()
+endif ()
+if (USE_SYSTEM_RTLSDR)
+    find_library (RTL_SDR_LIBRARY rtlsdr)
+    if (NOT RTL_SDR_LIBRARY)
+        message (WARNING "librtlsdr not found. Building from source.")
+        set (USE_SYSTEM_RTLSDR OFF)
+    endif ()
+endif ()
+if (USE_SYSTEM_LIBUSB)
+    find_library (LIBUSB_LIBRARY usb-1.0)
+    if (NOT LIBUSB_LIBRARY)
+        message (WARNING "libusb-1.0 not found. Building from source.")
+        set (USE_SYSTEM_LIBUSB OFF)
+    endif ()
+endif ()
+if (USE_SYSTEM_LIBAO)
+    find_library (AO_LIBRARY ao)
+    if (NOT AO_LIBRARY)
+        message (WARNING "librtlsdr not found. Building from source.")
+        set (USE_SYSTEM_LIBAO OFF)
+    endif ()
+endif ()
 
 if (CMAKE_SYSTEM_PROCESSOR MATCHES "arm.*")
     if (USE_NEON)
-        set (CMAKE_C_FLAGS "-mcpu=cortex-a7 -mfloat-abi=hard -mfpu=neon-vfpv4")
+        set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -mcpu=cortex-a7 -mfloat-abi=hard -mfpu=neon-vfpv4")
         add_definitions (-DHAVE_NEON)
     endif()
 endif()
 
 if (CMAKE_SYSTEM_PROCESSOR MATCHES "(i[456]|x)86.*")
     if (USE_SSE)
-        set (CMAKE_C_FLAGS "-msse2 -msse3 -mssse3")
+        set (CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -msse2 -msse3 -mssse3")
         add_definitions (-DHAVE_SSE2 -DHAVE_SSE3)
     endif()
 endif()
@@ -53,10 +92,119 @@ check_symbol_exists (CMPLXF complex.h HAVE_CMPLXF)
 check_symbol_exists (_Imaginary_I complex.h HAVE_IMAGINARY_I)
 check_symbol_exists (_Complex_I complex.h HAVE_COMPLEX_I)
 
-if (USE_FAAD2)
-    # libao only used if we have FAAD2
-    find_library (AO_LIBRARY ao)
+if (NOT USE_SYSTEM_FFTW)
+    set (FFTW_PREFIX "${CMAKE_BINARY_DIR}/fftw-prefix")
+    ExternalProject_Add (
+        fftw_external
+        URL "http://www.fftw.org/fftw-3.3.8.tar.gz"
+        URL_HASH SHA256=6113262f6e92c5bd474f2875fa1b01054c4ad5040f6b0da7c03c98821d9ae303
+        PREFIX ${FFTW_PREFIX}
 
+        CONFIGURE_COMMAND ${FFTW_PREFIX}/src/fftw_external/configure ${HOST_TRIPLE_ARG} --prefix=${FFTW_PREFIX} --enable-float --enable-static --disable-shared --enable-sse2 --enable-avx --enable-avx2 --with-our-malloc
+    )
+
+    add_library (fftw3f STATIC IMPORTED)
+    set_property (TARGET fftw3f PROPERTY IMPORTED_LOCATION "${FFTW_PREFIX}/lib/libfftw3f.a")
+    add_dependencies (fftw3f fftw_external)
+    include_directories ("${FFTW_PREFIX}/include")
+
+    set (FFTW3F_LIBRARY fftw3f)
+    set (FFTW3F_BUILTIN fftw3f)
+endif ()
+
+if (NOT USE_SYSTEM_LIBUSB)
+    set (LIBUSB_PREFIX "${CMAKE_BINARY_DIR}/libusb-prefix")
+    ExternalProject_Add (
+        libusb_external
+        GIT_REPOSITORY "https://github.com/libusb/libusb.git"
+        GIT_TAG v1.0.22
+        PREFIX ${LIBUSB_PREFIX}
+
+        UPDATE_COMMAND ""
+        CONFIGURE_COMMAND ${LIBUSB_PREFIX}/src/libusb_external/configure ${HOST_TRIPLE_ARG} --prefix=${LIBUSB_PREFIX}
+    )
+    ExternalProject_Add_Step (
+        libusb_external
+        bootstrap
+        COMMAND sh ./bootstrap.sh
+        DEPENDEES patch
+        DEPENDERS configure
+        WORKING_DIRECTORY <SOURCE_DIR>
+    )
+    add_library (libusb STATIC IMPORTED)
+    set_property (TARGET libusb PROPERTY IMPORTED_LOCATION "${LIBUSB_PREFIX}/lib/libusb-1.0.a")
+
+    set (LIBUSB_BUILTIN libusb_external)
+    set (LIBUSB_LIBRARY libusb)
+    set (RTLSDR_CMAKE_ARGS
+        -DLIBUSB_INCLUDE_DIR:STRING=${LIBUSB_PREFIX}/include/libusb-1.0
+        -DLIBUSB_LIBRARIES:STRING=${LIBUSB_PREFIX}/lib/libusb-1.0.a
+    )
+endif ()
+
+if (NOT USE_SYSTEM_RTLSDR)
+    set (RTLSDR_PREFIX "${CMAKE_BINARY_DIR}/rtlsdr-prefix")
+    ExternalProject_Add (
+        rtlsdr_external
+        GIT_REPOSITORY "https://github.com/osmocom/rtl-sdr.git"
+        GIT_TAG f68bb2fa772ad94f58c59babd78353667570630b
+        PREFIX ${RTLSDR_PREFIX}
+
+        UPDATE_COMMAND ""
+        CMAKE_ARGS
+            -DCMAKE_INSTALL_PREFIX:STRING=${RTLSDR_PREFIX}
+            -DCMAKE_C_COMPILER:STRING=${CMAKE_C_COMPILER}
+            -DCMAKE_SYSTEM_NAME:STRING=${CMAKE_SYSTEM_NAME}
+            ${RTLSDR_CMAKE_ARGS}
+    )
+
+    if (LIBUSB_BUILTIN)
+        add_dependencies (rtlsdr_external ${LIBUSB_BUILTIN})
+    endif ()
+
+    add_library (rtlsdr STATIC IMPORTED)
+    set_property (TARGET rtlsdr PROPERTY IMPORTED_LOCATION "${RTLSDR_PREFIX}/lib/librtlsdr_static.a")
+    add_dependencies (rtlsdr rtlsdr_external)
+    include_directories ("${RTLSDR_PREFIX}/include")
+
+    set (RTL_SDR_LIBRARY rtlsdr ${LIBUSB_LIBRARY})
+    set (RTL_SDR_BUILTIN rtlsdr)
+endif ()
+
+if (NOT USE_SYSTEM_LIBAO)
+    if (NOT WIN32)
+        message (FATAL_ERROR "Built-in libao only supported on Windows.")
+    endif ()
+
+    set (LIBAO_PREFIX "${CMAKE_BINARY_DIR}/libao-prefix")
+    ExternalProject_Add (
+        libao_external
+        GIT_REPOSITORY "https://git.xiph.org/libao.git"
+        GIT_TAG d5221655dfd1a2156aa6be83b5aadea7c1e0f5bd
+        PREFIX ${LIBAO_PREFIX}
+
+        UPDATE_COMMAND ""
+        CONFIGURE_COMMAND ${LIBAO_PREFIX}/src/libao_external/configure ${HOST_TRIPLE_ARG} --prefix=${LIBAO_PREFIX} --enable-static --disable-shared --disable-pulse
+    )
+    ExternalProject_Add_Step (
+        libao_external
+        bootstrap
+        COMMAND sh ./autogen.sh
+        DEPENDEES patch
+        DEPENDERS configure
+        WORKING_DIRECTORY <SOURCE_DIR>
+    )
+
+    add_library (libao STATIC IMPORTED)
+    set_property (TARGET libao PROPERTY IMPORTED_LOCATION "${LIBAO_PREFIX}/lib/libao.a")
+    add_dependencies (libao libao_external)
+    include_directories ("${LIBAO_PREFIX}/include")
+
+    set (AO_LIBRARY libao ksuser winmm)
+    set (AO_BUILTIN libao)
+endif ()
+
+if (USE_FAAD2)
     set (FAAD2_PREFIX "${CMAKE_BINARY_DIR}/faad2-prefix")
     ExternalProject_Add (
         faad2_external
@@ -68,7 +216,7 @@ if (USE_FAAD2)
         PATCH_COMMAND patch -p1 -Ni "${CMAKE_SOURCE_DIR}/support/faad2-hdc-support.patch" || exit 0
         COMMAND sh ./bootstrap
 
-        CONFIGURE_COMMAND ${FAAD2_PREFIX}/src/faad2_external/configure ${FAAD2_CONFIGURE_ARGS} --prefix=${FAAD2_PREFIX} --with-hdc "CFLAGS=-O3 -fPIC ${CMAKE_C_FLAGS}"
+        CONFIGURE_COMMAND ${FAAD2_PREFIX}/src/faad2_external/configure ${HOST_TRIPLE_ARG} ${FAAD2_CONFIGURE_ARGS} --prefix=${FAAD2_PREFIX} --with-hdc "CFLAGS=-O3 -fPIC ${CMAKE_C_FLAGS}"
     )
 
     add_library (faad2 STATIC IMPORTED)
@@ -78,7 +226,14 @@ if (USE_FAAD2)
 
     set (FAAD2_LIBRARY faad2)
     add_definitions (-DHAVE_FAAD2)
+    set (FAAD2_BUILTIN faad2)
+else ()
+    # we only use libao with faad2
+    unset (AO_LIBRARY)
+    unset (AO_BUILTIN)
 endif()
+
+set (BUILTIN_LIBRARIES ${FFTW3F_BUILTIN} ${RTL_SDR_BUILTIN} ${FAAD2_BUILTIN} ${AO_BUILTIN})
 
 if(EXISTS "${CMAKE_SOURCE_DIR}/.git")
   execute_process(

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -69,8 +69,6 @@ if (USE_FAAD2)
         COMMAND sh ./bootstrap
 
         CONFIGURE_COMMAND ${FAAD2_PREFIX}/src/faad2_external/configure ${FAAD2_CONFIGURE_ARGS} --prefix=${FAAD2_PREFIX} --with-hdc "CFLAGS=-O3 -fPIC ${CMAKE_C_FLAGS}"
-
-        BUILD_COMMAND make
     )
 
     add_library (faad2 STATIC IMPORTED)

--- a/README.md
+++ b/README.md
@@ -54,12 +54,7 @@ If the sample file does not work, make sure you followed all of the instructions
 
 Once everything is built, you can run nrsc5 independently of MSYS2. Copy the following files from your MSYS2/mingw32 directory (e.g. C:\\msys64\\mingw32\\bin):
 
-* libao-4.dll
-* libgcc\_s\_dw2-1.dll
 * libnrsc5.dll
-* librtlsdr.dll
-* libusb-1.0.dll
-* libwinpthread-1.dll
 * nrsc5.exe
 
 ### Cross-compiling for Windows from Ubuntu / Debian

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -11,6 +11,9 @@ elseif (CMAKE_SYSTEM_NAME MATCHES Darwin)
 elseif (CMAKE_SYSTEM_NAME MATCHES Windows)
     set (EXPORTS_LINKER_FLAGS "-Wl,--exclude-all-symbols")
 endif()
+if (USE_STATIC)
+    set (STATIC_LINKER_FLAGS -static)
+endif()
 
 configure_file (config.h.in config.h)
 include_directories ("${CMAKE_CURRENT_BINARY_DIR}" "${CMAKE_SOURCE_DIR}/include")
@@ -39,8 +42,8 @@ add_library (
     strndup.c
 )
 set_property(TARGET nrsc5_object PROPERTY POSITION_INDEPENDENT_CODE ON)
-if (USE_FAAD2)
-    add_dependencies(nrsc5_object faad2_external)
+if (BUILTIN_LIBRARIES)
+    add_dependencies(nrsc5_object ${BUILTIN_LIBRARIES})
 endif ()
 
 set (
@@ -61,7 +64,7 @@ target_link_libraries (
     ${LibraryDependencies}
 )
 set_target_properties(nrsc5 PROPERTIES PUBLIC_HEADER "../include/nrsc5.h")
-set_target_properties(nrsc5 PROPERTIES LINK_FLAGS "${EXPORTS_LINKER_FLAGS}")
+set_target_properties(nrsc5 PROPERTIES LINK_FLAGS "${STATIC_LINKER_FLAGS} ${EXPORTS_LINKER_FLAGS}")
 
 add_library (
     nrsc5_static
@@ -77,6 +80,7 @@ add_executable (
     main.c
 )
 set_property (TARGET app PROPERTY OUTPUT_NAME nrsc5)
+set_target_properties(app PROPERTIES LINK_FLAGS "${STATIC_LINKER_FLAGS}")
 target_link_libraries (
     app
     nrsc5_static

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -4,8 +4,13 @@ add_definitions (-D_GNU_SOURCE)
 set (THREAD_LIBRARY pthread)
 if (CMAKE_SYSTEM_NAME MATCHES Linux)
     check_library_exists (${THREAD_LIBRARY} pthread_setname_np "" HAVE_PTHREAD_SETNAME_NP)
+    set (EXPORTS_LINKER_FLAGS "-Wl,--version-script=${CMAKE_CURRENT_SOURCE_DIR}/libnrsc5.map")
+elseif (CMAKE_SYSTEM_NAME MATCHES Darwin)
+    set (CMAKE_MACOSX_RPATH ON)
+    set (EXPORTS_LINKER_FLAGS "-exported_symbols_list ${CMAKE_CURRENT_SOURCE_DIR}/libnrsc5.sym")
+elseif (CMAKE_SYSTEM_NAME MATCHES Windows)
+    set (EXPORTS_LINKER_FLAGS "-Wl,--exclude-all-symbols")
 endif()
-set (CMAKE_MACOSX_RPATH ON)
 
 configure_file (config.h.in config.h)
 include_directories ("${CMAKE_CURRENT_BINARY_DIR}" "${CMAKE_SOURCE_DIR}/include")
@@ -56,6 +61,7 @@ target_link_libraries (
     ${LibraryDependencies}
 )
 set_target_properties(nrsc5 PROPERTIES PUBLIC_HEADER "../include/nrsc5.h")
+set_target_properties(nrsc5 PROPERTIES LINK_FLAGS "${EXPORTS_LINKER_FLAGS}")
 
 add_library (
     nrsc5_static

--- a/src/libnrsc5.map
+++ b/src/libnrsc5.map
@@ -1,0 +1,19 @@
+LIBNRSC5_1.0 {
+    global:
+        nrsc5_open;
+        nrsc5_open_file;
+        nrsc5_open_pipe;
+        nrsc5_close;
+        nrsc5_start;
+        nrsc5_stop;
+        nrsc5_get_frequency;
+        nrsc5_set_frequency;
+        nrsc5_get_gain;
+        nrsc5_set_gain;
+        nrsc5_set_auto_gain;
+        nrsc5_set_callback;
+        nrsc5_pipe_samples;
+
+    local:
+        *;
+};

--- a/src/libnrsc5.sym
+++ b/src/libnrsc5.sym
@@ -1,0 +1,13 @@
+_nrsc5_open
+_nrsc5_open_file
+_nrsc5_open_pipe
+_nrsc5_close
+_nrsc5_start
+_nrsc5_stop
+_nrsc5_get_frequency
+_nrsc5_set_frequency
+_nrsc5_get_gain
+_nrsc5_set_gain
+_nrsc5_set_auto_gain
+_nrsc5_set_callback
+_nrsc5_pipe_samples

--- a/src/nrsc5.c
+++ b/src/nrsc5.c
@@ -3,6 +3,12 @@
 
 #include "private.h"
 
+#ifdef __MINGW32__
+#define NRSC5_API __declspec(dllexport)
+#else
+#define NRSC5_API
+#endif
+
 static int snr_callback(void *arg, float snr)
 {
     nrsc5_t *st = arg;
@@ -169,7 +175,7 @@ static void nrsc5_init(nrsc5_t *st)
     pthread_create(&st->worker, NULL, worker_thread, st);
 }
 
-int nrsc5_open(nrsc5_t **result, int device_index, int ppm_error)
+NRSC5_API int nrsc5_open(nrsc5_t **result, int device_index, int ppm_error)
 {
     int err;
     nrsc5_t *st = calloc(1, sizeof(*st));
@@ -200,7 +206,7 @@ error_init:
     return 1;
 }
 
-int nrsc5_open_file(nrsc5_t **result, FILE *fp)
+NRSC5_API int nrsc5_open_file(nrsc5_t **result, FILE *fp)
 {
     nrsc5_t *st;
 
@@ -213,7 +219,7 @@ int nrsc5_open_file(nrsc5_t **result, FILE *fp)
     return 0;
 }
 
-int nrsc5_open_pipe(nrsc5_t **result)
+NRSC5_API int nrsc5_open_pipe(nrsc5_t **result)
 {
     nrsc5_t *st;
 
@@ -225,7 +231,7 @@ int nrsc5_open_pipe(nrsc5_t **result)
     return 0;
 }
 
-void nrsc5_close(nrsc5_t *st)
+NRSC5_API void nrsc5_close(nrsc5_t *st)
 {
     if (!st)
         return;
@@ -249,7 +255,7 @@ void nrsc5_close(nrsc5_t *st)
     free(st);
 }
 
-void nrsc5_start(nrsc5_t *st)
+NRSC5_API void nrsc5_start(nrsc5_t *st)
 {
     // signal the worker to start
     pthread_mutex_lock(&st->worker_mutex);
@@ -258,7 +264,7 @@ void nrsc5_start(nrsc5_t *st)
     pthread_mutex_unlock(&st->worker_mutex);
 }
 
-void nrsc5_stop(nrsc5_t *st)
+NRSC5_API void nrsc5_stop(nrsc5_t *st)
 {
     // signal the worker to stop
     pthread_mutex_lock(&st->worker_mutex);
@@ -273,7 +279,7 @@ void nrsc5_stop(nrsc5_t *st)
     pthread_mutex_unlock(&st->worker_mutex);
 }
 
-void nrsc5_get_frequency(nrsc5_t *st, float *freq)
+NRSC5_API void nrsc5_get_frequency(nrsc5_t *st, float *freq)
 {
     if (st->dev)
         *freq = rtlsdr_get_center_freq(st->dev);
@@ -281,7 +287,7 @@ void nrsc5_get_frequency(nrsc5_t *st, float *freq)
         *freq = st->freq;
 }
 
-int nrsc5_set_frequency(nrsc5_t *st, float freq)
+NRSC5_API int nrsc5_set_frequency(nrsc5_t *st, float freq)
 {
     if (st->freq == freq)
         return 0;
@@ -303,7 +309,7 @@ int nrsc5_set_frequency(nrsc5_t *st, float freq)
     return 0;
 }
 
-void nrsc5_get_gain(nrsc5_t *st, float *gain)
+NRSC5_API void nrsc5_get_gain(nrsc5_t *st, float *gain)
 {
     if (st->dev)
         *gain = rtlsdr_get_tuner_gain(st->dev) / 10.0f;
@@ -311,7 +317,7 @@ void nrsc5_get_gain(nrsc5_t *st, float *gain)
         *gain = st->gain;
 }
 
-int nrsc5_set_gain(nrsc5_t *st, float gain)
+NRSC5_API int nrsc5_set_gain(nrsc5_t *st, float gain)
 {
     if (st->gain == gain)
         return 0;
@@ -328,13 +334,13 @@ int nrsc5_set_gain(nrsc5_t *st, float gain)
     return 0;
 }
 
-void nrsc5_set_auto_gain(nrsc5_t *st, int enabled)
+NRSC5_API void nrsc5_set_auto_gain(nrsc5_t *st, int enabled)
 {
     st->auto_gain = enabled;
     st->gain = -1;
 }
 
-void nrsc5_set_callback(nrsc5_t *st, nrsc5_callback_t callback, void *opaque)
+NRSC5_API void nrsc5_set_callback(nrsc5_t *st, nrsc5_callback_t callback, void *opaque)
 {
     pthread_mutex_lock(&st->worker_mutex);
     st->callback = callback;
@@ -342,7 +348,7 @@ void nrsc5_set_callback(nrsc5_t *st, nrsc5_callback_t callback, void *opaque)
     pthread_mutex_unlock(&st->worker_mutex);
 }
 
-int nrsc5_pipe_samples(nrsc5_t *st, uint8_t *samples, unsigned int length)
+NRSC5_API int nrsc5_pipe_samples(nrsc5_t *st, uint8_t *samples, unsigned int length)
 {
     input_push(&st->input, samples, length);
 

--- a/support/msys2-build
+++ b/support/msys2-build
@@ -2,62 +2,8 @@
 
 set -e
 
-fftw_version=3.3.8
-libao_version=1.2.2
-libusb_version=v1.0.22
-rtlsdr_version=0.6.0
-
 pacman -Su
 pacman -S --needed autoconf automake git gzip make ${MINGW_PACKAGE_PREFIX}-gcc ${MINGW_PACKAGE_PREFIX}-cmake ${MINGW_PACKAGE_PREFIX}-libtool patch tar xz
-
-cd ~
-if [ ! -d fftw-${fftw_version} ]; then
-    curl -L http://www.fftw.org/fftw-${fftw_version}.tar.gz | tar xvz
-fi
-if [ ! -e ${MINGW_PREFIX}/lib/libfftw3f.a ]; then
-    cd fftw-${fftw_version}
-    ./configure --enable-float --enable-sse2 --enable-avx --with-our-malloc
-    make
-    make install
-fi
-
-cd ~
-if [ ! -d libao ]; then
-    git clone https://git.xiph.org/libao.git
-fi
-if [ ! -e ${MINGW_PREFIX}/bin/libao-4.dll ]; then
-    cd libao
-    git checkout ${libao_version}
-    ./autogen.sh
-    LDFLAGS=-lksuser ./configure
-    make
-    make install
-fi
-
-cd ~
-if [ ! -d libusb ]; then
-    git clone https://github.com/libusb/libusb.git
-fi
-if [ ! -e ${MINGW_PREFIX}/bin/libusb-1.0.dll ]; then
-    cd libusb
-    git checkout ${libusb_version}
-    ./autogen.sh
-    make
-    make install
-fi
-
-cd ~
-if [ ! -d rtl-sdr ]; then
-    git clone git://git.osmocom.org/rtl-sdr.git
-fi
-if [ ! -e ${MINGW_PREFIX}/bin/librtlsdr.dll ]; then
-    mkdir -p rtl-sdr/build
-    cd rtl-sdr/build
-    git checkout ${rtlsdr_version}
-    cmake -G "MSYS Makefiles" -D LIBUSB_FOUND=1 -D LIBUSB_INCLUDE_DIR=${MINGW_PREFIX}/include/libusb-1.0 -D "LIBUSB_LIBRARIES=-L${MINGW_PREFIX}/lib -lusb-1.0" -D THREADS_PTHREADS_WIN32_LIBRARY=${MINGW_PREFIX}/${MINGW_CHOST}/lib/libpthread.a -D THREADS_PTHREADS_INCLUDE_DIR=${MINGW_PREFIX}/${MINGW_CHOST}/include -D CMAKE_INSTALL_PREFIX=${MINGW_PREFIX} ..
-    make
-    make install
-fi
 
 cd ~
 if [ ! -d nrsc5 ]; then
@@ -70,5 +16,5 @@ fi
 mkdir -p nrsc5/build
 cd nrsc5/build
 cmake -G "MSYS Makefiles" -D USE_COLOR=OFF -D USE_SSE=ON -D CMAKE_INSTALL_PREFIX=${MINGW_PREFIX} ..
-make
+make $*
 make install

--- a/support/win-cross-compile
+++ b/support/win-cross-compile
@@ -2,11 +2,6 @@
 
 set -e
 
-fftw_version=3.3.8
-libao_version=1.2.2
-libusb_version=v1.0.22
-rtlsdr_version=0.6.0
-
 root=`git rev-parse --show-toplevel`
 if [ "$1" == 32 ]; then
     prefix=${root}/build-win32
@@ -15,76 +10,24 @@ elif [ "$1" == 64 ]; then
     prefix=${root}/build-win64
     host=x86_64-w64-mingw32
 else
-    echo "Usage: $0 (32|64)"
+    echo "Usage: $0 (32|64) [make flags]"
     exit 1
 fi
+shift
 
 mkdir -p ${prefix}
 
 cd ${prefix}
-if [ ! -d fftw-${fftw_version} ]; then
-    curl -L http://www.fftw.org/fftw-${fftw_version}.tar.gz | tar xz
-fi
-if [ ! -e ${prefix}/lib/libfftw3f.a ]; then
-    cd fftw-${fftw_version}
-    ./configure --host=${host} --prefix=${prefix} --enable-float --enable-sse2 --enable-avx --with-our-malloc
-    make
-    make install
-fi
-
-cd ${prefix}
-if [ ! -d libao ]; then
-    git clone https://git.xiph.org/libao.git
-fi
-if [ ! -e ${prefix}/bin/libao-4.dll ]; then
-    cd libao
-    git checkout ${libao_version}
-    ./autogen.sh
-    LDFLAGS=-lksuser ./configure --host=${host} --prefix=${prefix} --enable-wmm --disable-pulse
-    make
-    make install
-fi
-
-cd ${prefix}
-if [ ! -d libusb ]; then
-    git clone https://github.com/libusb/libusb.git
-fi
-if [ ! -e ${prefix}/bin/libusb-1.0.dll ]; then
-    cd libusb
-    git checkout ${libusb_version}
-    ./autogen.sh --host=${host} --prefix=${prefix}
-    make
-    make install
-fi
-
-cd ${prefix}
-if [ ! -d rtl-sdr ]; then
-    git clone git://git.osmocom.org/rtl-sdr.git
-fi
-if [ ! -e ${prefix}/bin/librtlsdr.dll ]; then
-    mkdir -p rtl-sdr/build
-    cd rtl-sdr/build
-    git checkout ${rtlsdr_version}
-    cmake -D CMAKE_SYSTEM_NAME=Windows -D CMAKE_C_COMPILER=${host}-gcc -D LIBUSB_FOUND=1 -D LIBUSB_INCLUDE_DIR=${prefix}/include/libusb-1.0 -D "LIBUSB_LIBRARIES=-L${prefix}/lib -lusb-1.0" -D THREADS_PTHREADS_WIN32_LIBRARY=/usr/${host}/lib/libpthread.a -D THREADS_PTHREADS_INCLUDE_DIR=/usr/${host}/include -D CMAKE_INSTALL_PREFIX=${prefix} ..
-    make
-    make install
-fi
-
-cd ${prefix}
-cmake -D CMAKE_SYSTEM_NAME=Windows -D CMAKE_C_COMPILER=${host}-gcc -D CMAKE_LIBRARY_PATH=${prefix}/lib -D FAAD2_CONFIGURE_ARGS="--host=${host}" -D USE_COLOR=OFF -D USE_SSE=ON -D CMAKE_INSTALL_PREFIX=${prefix} ..
-C_INCLUDE_PATH=${prefix}/include make
+cmake \
+    -D CMAKE_SYSTEM_NAME=Windows \
+    -D CMAKE_C_COMPILER=${host}-gcc \
+    -D CMAKE_INSTALL_PREFIX=${prefix} \
+    -D USE_SSE=ON \
+    -D USE_STATIC=ON \
+    -D USE_SYSTEM_LIBUSB=OFF \
+    -D USE_SYSTEM_RTLSDR=OFF \
+    -D USE_SYSTEM_LIBAO=OFF \
+    -D USE_SYSTEM_FFTW=OFF \
+    ..
+make $*
 make install
-
-# On MacOS, libwinpthread-1.dll is in /bin so we need to use -print-prog-name.
-# On Linux, libwinpthread-1.dll is in /lib so we need to use -print-file-name.
-LIBWINPTHREAD_PATH="$(${host}-gcc -print-prog-name=libwinpthread-1.dll)"
-if [ ! -e "${LIBWINPTHREAD_PATH}" ]; then
-    LIBWINPTHREAD_PATH="$(${host}-gcc -print-file-name=libwinpthread-1.dll)"
-fi
-cp "${LIBWINPTHREAD_PATH}" "${prefix}/bin"
-
-if [ "$1" == 32 ]; then
-    cp "$(${host}-gcc -print-file-name=libgcc_s_sjlj-1.dll)" "${prefix}/bin"
-elif [ "$1" == 64 ]; then
-    cp "$(${host}-gcc -print-file-name=libgcc_s_seh-1.dll)" "${prefix}/bin"
-fi


### PR DESCRIPTION
This PR moves most of the logic to build external libraries to CMake instead of scripts. Its primarily targeted at cross compiling and building for Windows, since libao's dynamic plugins make it difficult to statically link on other platforms. I have not tested building with the built-in libraries on Linux yet.

There are also some changes to speed up the Travis CI build using ccache and parallel make jobs. It also tests the built Windows binary using wine on macOS.