### PR TITLE
Start over from coarse sync if frame can't be decoded.

### DIFF
--- a/src/acquire.c
+++ b/src/acquire.c
@@ -68,7 +68,7 @@ void acquire_process(acquire_t *st)
     if (st->idx != FFTCP * (ACQUIRE_SYMBOLS + 1))
         return;
 
-    if (st->input->sync.ready)
+    if (st->input->sync_state == SYNC_STATE_FINE)
     {
         samperr = FFTCP / 2 + st->input->sync.samperr;
         st->input->sync.samperr = 0;
@@ -115,6 +115,7 @@ void acquire_process(acquire_t *st)
         angle_factor = (st->prev_angle) ? 0.25 : 1.0;
         angle = st->prev_angle + (angle_diff * angle_factor);
         st->prev_angle = angle;
+        st->input->sync_state = SYNC_STATE_COARSE;
     }
 
     for (i = 0; i < FFTCP * (ACQUIRE_SYMBOLS + 1); i++)

--- a/src/frame.c
+++ b/src/frame.c
@@ -472,7 +472,11 @@ void frame_process(frame_t *st, size_t length)
         hef_t hef = {0};
 
         if (!fix_header(st, st->buffer + offset))
+        {
+            if (offset == 0)
+                st->input->sync_state = SYNC_STATE_NONE;
             return;
+        }
 
         parse_header(st->buffer + offset, &hdr);
         offset += 14;

--- a/src/input.c
+++ b/src/input.c
@@ -184,6 +184,7 @@ void input_reset(input_t *st)
     st->avail = 0;
     st->used = 0;
     st->skip = 0;
+    st->sync_state = SYNC_STATE_NONE;
     for (int i = 0; i < 64; ++i)
         st->snr_power[i] = 0;
     st->snr_cnt = 0;

--- a/src/input.h
+++ b/src/input.h
@@ -17,6 +17,8 @@
 
 typedef int (*input_snr_cb_t) (void *, float);
 
+enum { SYNC_STATE_NONE, SYNC_STATE_COARSE, SYNC_STATE_FINE };
+
 typedef struct input_t
 {
     nrsc5_t *radio;
@@ -25,6 +27,7 @@ typedef struct input_t
     firdecim_q15 decim;
     cint16_t buffer[INPUT_BUF_LEN];
     unsigned int avail, used, skip;
+    unsigned int sync_state;
 
     fftwf_plan snr_fft;
     float complex snr_fft_in[64];

--- a/src/sync.h
+++ b/src/sync.h
@@ -10,7 +10,6 @@ typedef struct
     float complex buffer[FFT][BLKSZ];
     float phases[FFT][BLKSZ];
     unsigned int idx;
-    int ready;
     int cfo_wait;
     int samperr;
     float angle;


### PR DESCRIPTION
Fixes #172.

Since three components are now concerned with synchronization state, I've moved it out into the input struct. There are now three states:

* `SYNC_STATE_NONE` - not synchronized
* `SYNC_STATE_COARSE` - coarse synchronization has completed
* `SYNC_STATE_FINE` - fine synchronization has completed

If the reference subcarriers are not as expected or a frame fails to decode, then the state is set back to `SYNC_STATE_NONE`.

I'm still testing this out and would appreciate feedback. Testing instructions are available in #172. The amount of dropped samples can be changed by increasing or decreasing the number in the `tail` command. (Make sure the number remains odd, because each IQ sample is two bytes long.)