### PR TITLE
Get nrsc5 version through the API.

### DIFF
--- a/include/nrsc5.h
+++ b/include/nrsc5.h
@@ -155,6 +155,7 @@ typedef struct nrsc5_t nrsc5_t;
 /*
  * Public functions. All functions return void or an error code (0 == success).
  */
+void nrsc5_get_version(char **version);
 int nrsc5_open(nrsc5_t **, int device_index, int ppm_error);
 int nrsc5_open_file(nrsc5_t **, FILE *fp);
 int nrsc5_open_pipe(nrsc5_t **);

--- a/include/nrsc5.h
+++ b/include/nrsc5.h
@@ -155,7 +155,7 @@ typedef struct nrsc5_t nrsc5_t;
 /*
  * Public functions. All functions return void or an error code (0 == success).
  */
-void nrsc5_get_version(char **version);
+void nrsc5_get_version(const char **version);
 int nrsc5_open(nrsc5_t **, int device_index, int ppm_error);
 int nrsc5_open_file(nrsc5_t **, FILE *fp);
 int nrsc5_open_pipe(nrsc5_t **);

--- a/src/libnrsc5.map
+++ b/src/libnrsc5.map
@@ -1,5 +1,6 @@
 LIBNRSC5_1.0 {
     global:
+        nrsc5_get_version;
         nrsc5_open;
         nrsc5_open_file;
         nrsc5_open_pipe;

--- a/src/libnrsc5.sym
+++ b/src/libnrsc5.sym
@@ -1,3 +1,4 @@
+_nrsc5_get_version
 _nrsc5_open
 _nrsc5_open_file
 _nrsc5_open_pipe

--- a/src/main.c
+++ b/src/main.c
@@ -307,7 +307,8 @@ static int parse_args(state_t *st, int argc, char *argv[])
         { "dump-hdc", required_argument, NULL, 2 },
         { 0 }
     };
-    char *version = NULL, *output_name = NULL, *audio_name = NULL, *hdc_name = NULL;
+    const char *version = NULL;
+    char *output_name = NULL, *audio_name = NULL, *hdc_name = NULL;
     char *endptr;
     int opt;
 

--- a/src/main.c
+++ b/src/main.c
@@ -307,7 +307,7 @@ static int parse_args(state_t *st, int argc, char *argv[])
         { "dump-hdc", required_argument, NULL, 2 },
         { 0 }
     };
-    char *output_name = NULL, *audio_name = NULL, *hdc_name = NULL;
+    char *version = NULL, *output_name = NULL, *audio_name = NULL, *hdc_name = NULL;
     char *endptr;
     int opt;
 
@@ -353,7 +353,8 @@ static int parse_args(state_t *st, int argc, char *argv[])
             log_set_level(atoi(optarg));
             break;
         case 'v':
-            printf("nrsc5 revision %s\n", GIT_COMMIT_HASH);
+            nrsc5_get_version(&version);
+            printf("nrsc5 revision %s\n", version);
             return 1;
         default:
             help(argv[0]);

--- a/src/nrsc5.c
+++ b/src/nrsc5.c
@@ -175,7 +175,7 @@ static void nrsc5_init(nrsc5_t *st)
     pthread_create(&st->worker, NULL, worker_thread, st);
 }
 
-NRSC5_API void nrsc5_get_version(char **version)
+NRSC5_API void nrsc5_get_version(const char **version)
 {
     *version = GIT_COMMIT_HASH;
 }

--- a/src/nrsc5.c
+++ b/src/nrsc5.c
@@ -175,6 +175,11 @@ static void nrsc5_init(nrsc5_t *st)
     pthread_create(&st->worker, NULL, worker_thread, st);
 }
 
+NRSC5_API void nrsc5_get_version(char **version)
+{
+    *version = GIT_COMMIT_HASH;
+}
+
 NRSC5_API int nrsc5_open(nrsc5_t **result, int device_index, int ppm_error)
 {
     int err;

--- a/support/nrsc5.py
+++ b/support/nrsc5.py
@@ -296,6 +296,11 @@ class NRSC5:
         self.radio = c_void_p()
         self.callback = callback
 
+    def get_version(self):
+        version = c_char_p()
+        NRSC5.libnrsc5.nrsc5_get_version(byref(version))
+        return version.value.decode()
+
     def open(self, device_index, ppm_error):
         result = NRSC5.libnrsc5.nrsc5_open(byref(self.radio), device_index, ppm_error)
         if result != 0:


### PR DESCRIPTION
It seems like querying the version of the nrsc5 library could be a useful thing, so I pushed the version number checking over to the other side of the API and made an `nrsc5_get_version` API call.

The Python CLI now has a `-v` flag, like the C version.