### PR TITLE
Require the caller to ensure input length is a multiple of 4.

### DIFF
--- a/support/cli.py
+++ b/support/cli.py
@@ -78,12 +78,14 @@ class NRSC5CLI:
                     data = iq_input.read(32768)
                     if len(data) == 0:
                         break
-                    radio.pipe_samples(data)
+                    radio.pipe_samples(data[:(len(data) // 4) * 4])
             else:
                 with self.device_condition:
                     self.device_condition.wait()
         except KeyboardInterrupt:
             logging.info("Stopping...")
+        except nrsc5.NRSC5Error as e:
+            logging.error(e)
 
         radio.stop()
         radio.close()

--- a/support/nrsc5.py
+++ b/support/nrsc5.py
@@ -348,6 +348,8 @@ class NRSC5:
         NRSC5.libnrsc5.nrsc5_set_callback(self.radio, self.callback_func, None)
 
     def pipe_samples(self, samples):
-        result = NRSC5.libnrsc5.nrsc5_pipe_samples(self.radio, samples, (len(samples) // 4) * 4)
+        if len(samples) % 4 != 0:
+            raise NRSC5Error("len(samples) must be a multiple of 4.")
+        result = NRSC5.libnrsc5.nrsc5_pipe_samples(self.radio, samples, len(samples))
         if result != 0:
             raise NRSC5Error("Failed to pipe samples.")


### PR DESCRIPTION
This should make it harder to use the API incorrectly.