### PR TITLE
Remove magic numbers and fix SNR calculation.

### DIFF
--- a/src/acquire.c
+++ b/src/acquire.c
@@ -162,7 +162,7 @@ void acquire_cfo_adjust(acquire_t *st, int cfo)
         return;
 
     st->cfo += cfo;
-    hz = st->cfo * 744187.5 / FFT;
+    hz = (float) st->cfo * SAMPLE_RATE / 2 / FFT;
 
     log_info("CFO: %f Hz", hz);
 }

--- a/src/decode.c
+++ b/src/decode.c
@@ -48,7 +48,7 @@ static float calc_cber(int8_t *coded, uint8_t *decoded)
             errors++;
     }
 
-    return errors / (5.0 / 2.0 * P1_FRAME_LEN);;
+    return (float) errors / P1_FRAME_LEN_ENCODED;
 }
 
 static void descramble(uint8_t *buf, unsigned int length)
@@ -76,7 +76,7 @@ void decode_process_p1(decode_t *st)
         11, 3, 19, 7, 15, 9, 17, 1, 13, 5
     };
     unsigned int i, out = 0;
-    for (i = 0; i < 365440; i++)
+    for (i = 0; i < P1_FRAME_LEN_ENCODED; i++)
     {
         int partition = v[i % J];
         int block = ((i / J) + (partition * 7)) % B;
@@ -102,11 +102,11 @@ void decode_process_pids(decode_t *st)
         11, 3, 19, 7, 15, 9, 17, 1, 13, 5
     };
     unsigned int i, out = 0;
-    for (i = 0; i < 200; i++)
+    for (i = 0; i < PIDS_FRAME_LEN_ENCODED; i++)
     {
         int partition = v[i % J];
         int block = decode_get_block(st) - 1;
-        int k = ((i / J) % (200 / J)) + (365440 / (J * B));
+        int k = ((i / J) % (PIDS_FRAME_LEN_ENCODED / J)) + (P1_FRAME_LEN_ENCODED / (J * B));
         int row = (k * 11) % 32;
         int column = (k * 11 + k / (32*9)) % C;
         st->viterbi_pids[out++] = st->buffer_pm[(block * 32 + row) * 720 + partition * C + column];
@@ -125,7 +125,7 @@ void decode_process_p3(decode_t *st)
     const unsigned int bk_bits = 32 * C;
     const unsigned int bk_adj = 32 * C - 1;
     unsigned int i, out = 0;
-    for (i = 0; i < 9216; i++)
+    for (i = 0; i < P3_FRAME_LEN_ENCODED; i++)
     {
         int partition = ((st->i_p3 + 2 * (M / 4)) / M) % J;
         unsigned int pti = (st->pt_p3[partition])++;

--- a/src/defines.h
+++ b/src/defines.h
@@ -10,8 +10,6 @@
 
 #define FATAL_EXIT(...) do { log_fatal(__VA_ARGS__); exit(1); } while (0)
 
-#define SNR_FFT_COUNT 256
-
 // Sample rate before decimation
 #define SAMPLE_RATE 1488375
 // FFT length in samples
@@ -31,10 +29,16 @@
 #define UB_END (1024 + 546)
 // bits per P1 frame
 #define P1_FRAME_LEN 146176
+// bits per encoded P1 frame
+#define P1_FRAME_LEN_ENCODED (P1_FRAME_LEN * 5 / 2)
 // bits per PIDS frame
 #define PIDS_FRAME_LEN 80
-// bits per P1 frame
+// bits per encoded PIDS frame
+#define PIDS_FRAME_LEN_ENCODED (PIDS_FRAME_LEN * 5 / 2)
+// bits per P3 frame
 #define P3_FRAME_LEN 4608
+// bits per encoded P3 frame
+#define P3_FRAME_LEN_ENCODED (P3_FRAME_LEN * 2)
 // bits per L2 PCI
 #define PCI_LEN 24
 // bytes per L2 PDU (max)

--- a/src/input.h
+++ b/src/input.h
@@ -13,7 +13,14 @@
 #include "output.h"
 #include "sync.h"
 
-#define INPUT_BUF_LEN (2160 * 512)
+#define INPUT_BUF_LEN (FFTCP * 512)
+
+#define SNR_FFT_COUNT 256
+#define SNR_FFT_LEN 64
+#define SNR_NOISE_START 19
+#define SNR_NOISE_LEN 4
+#define SNR_SIGNAL_START 24
+#define SNR_SIGNAL_LEN 2
 
 typedef int (*input_snr_cb_t) (void *, float);
 
@@ -30,9 +37,9 @@ typedef struct input_t
     unsigned int sync_state;
 
     fftwf_plan snr_fft;
-    float complex snr_fft_in[64];
-    float complex snr_fft_out[64];
-    float snr_power[64];
+    float complex snr_fft_in[SNR_FFT_LEN];
+    float complex snr_fft_out[SNR_FFT_LEN];
+    float snr_power[SNR_FFT_LEN];
     int snr_cnt;
     input_snr_cb_t snr_cb;
     void *snr_cb_arg;

--- a/src/nrsc5.c
+++ b/src/nrsc5.c
@@ -54,7 +54,7 @@ static int do_auto_gain(nrsc5_t *st)
 
             input_push(&st->input, st->samples_buf, len);
         }
-        log_debug("Gain: %.1f dB, CNR: %.1f dB", gain / 10.0f, 20 * log10f(st->auto_gain_snr));
+        log_debug("Gain: %.1f dB, CNR: %.1f dB", gain / 10.0f, 10 * log10f(st->auto_gain_snr));
         if (st->auto_gain_snr > best_snr)
         {
             best_snr = st->auto_gain_snr;
@@ -63,7 +63,7 @@ static int do_auto_gain(nrsc5_t *st)
         input_reset(&st->input);
     }
 
-    log_debug("Best gain: %.1f dB, CNR: %.1f dB", best_gain / 10.0f, 20 * log10f(best_snr));
+    log_debug("Best gain: %.1f dB, CNR: %.1f dB", best_gain / 10.0f, 10 * log10f(best_snr));
     st->gain = best_gain;
     rtlsdr_set_tuner_gain(st->dev, best_gain);
     ret = 0;


### PR DESCRIPTION
This PR does two things:

1. Remove a bunch of magic numbers and replace them with constants.
2. Fix the SNR calculation used for AGC. The indices of the upper noise band were one too low, and so the first FFT bin included some of the signal. Also, the reported CNR values were off by a factor of 2; we're comparing powers and not amplitudes.