### PR TITLE
Prevent input_set_skip from occurring twice.

### DIFF
--- a/src/sync.c
+++ b/src/sync.c
@@ -209,12 +209,7 @@ void sync_process(sync_t *st)
         if (offset < 0)
             offset = find_first_block(st, UB_END, &psmi);
 
-        if (offset > 0)
-        {
-            log_debug("First block @ %d", offset);
-            input_set_skip(st->input, offset * FFTCP);
-        }
-        else if (offset == 0)
+        if (offset == 0)
         {
             log_info("Synchronized!");
             nrsc5_report_sync(st->input->radio);


### PR DESCRIPTION
At the moment, there are two places in `sync_process` that call `input_set_skip`:

https://github.com/theori-io/nrsc5/blob/965be89f9d7d2f21222c285e6b79dadb832e60b6/src/sync.c#L212-L249

If the first block that arrives happens to be block 0, line 215 executes. Then block 1 arrives before the input has been skipped and line 239 executes, requesting the same skip a second time. Synchronization is then delayed until `cfo_wait` counts down to zero and line 239 executes a second time. This behaviour can be reproduced like so:

```
$ xz -d < ../support/sample.xz | tail -c +2700001 | src/nrsc5 -r - 0
07:51:19 DEBUG sync.c:214: First block @ 9
07:51:19 DEBUG sync.c:242: Block @ 9
07:51:19 DEBUG sync.c:242: Block @ 23
07:51:19 INFO  sync.c:219: Synchronized!
```

A similar situation occurs if block 15 arrives first. In that case line 239 executes, then when block 0 in the next frame arrives line 215 executes:

```
$ xz -d < ../support/sample.xz | tail -c +2600001 | src/nrsc5 -r - 0
07:52:39 DEBUG sync.c:242: Block @ 21
07:52:39 DEBUG sync.c:214: First block @ 21
07:52:39 DEBUG sync.c:242: Block @ 11
07:52:39 INFO  sync.c:219: Synchronized!
```

Because the CFO detection code also detects the offset, there's no need to detect the offset in a second place, so I removed the first `if`. Synchronization now appears to work correctly regardless of which block arrives first.