### PR TITLE
Use a matched filter for coarse sync.

### DIFF
--- a/src/acquire.c
+++ b/src/acquire.c
@@ -63,7 +63,6 @@ void acquire_process(acquire_t *st)
     float angle, angle_diff, angle_factor, max_mag = -1.0f;
     int samperr = 0;
     unsigned int i, j, keep;
-    unsigned int mink = 0, maxk = FFTCP;
 
     if (st->idx != FFTCP * (ACQUIRE_SYMBOLS + 1))
         return;
@@ -88,19 +87,19 @@ void acquire_process(acquire_t *st)
         }
 
         memset(st->sums, 0, sizeof(float complex) * FFTCP);
-        for (i = mink; i < maxk + CP; ++i)
+        for (i = 0; i < FFTCP; ++i)
         {
             for (j = 0; j < ACQUIRE_SYMBOLS; ++j)
                 st->sums[i] += st->buffer[i + j * FFTCP] * conjf(st->buffer[i + j * FFTCP + FFT]);
         }
 
-        for (i = mink; i < maxk - 1; ++i)
+        for (i = 0; i < FFTCP; ++i)
         {
             float mag;
             float complex v = 0;
 
             for (j = 0; j < CP; ++j)
-                v += st->sums[(i + j) % FFTCP];
+                v += st->sums[(i + j) % FFTCP] * st->shape[j] * st->shape[j + FFT];
 
             mag = normf(v);
             if (mag > max_mag)

--- a/src/acquire.h
+++ b/src/acquire.h
@@ -10,7 +10,7 @@ typedef struct
     firdecim_q15 filter;
     cint16_t in_buffer[FFTCP * (ACQUIRE_SYMBOLS + 1)];
     float complex buffer[FFTCP * (ACQUIRE_SYMBOLS + 1)];
-    float complex sums[FFTCP + CP];
+    float complex sums[FFTCP];
     float complex fftin[FFT];
     float complex fftout[FFT];
     float shape[FFTCP];


### PR DESCRIPTION
During coarse synchronization, `acquire_process` uses a rectangular (in the time domain) filter to detect the OFDM cyclic suffix. This is sub-optimal because the transmitter's pulse-shaping filter gives the beginning & end of the OFDM symbol a non-rectangular shape. To correct this, I've switched to a matched filter by multiplying in the beginning & end of the pulse-shaping filter.

To test, I forced coarse synchronization to be used all the time and compared the performance before and after this change using my suite of IQ recordings. There was a slight improvement in both BER and number of frames decoded, and one weak station that was previously unreceivable now works (albeit with a high BER).