### PR TITLE
Fix off-by-one when passing AAS data to output.

### DIFF
--- a/src/frame.c
+++ b/src/frame.c
@@ -326,7 +326,7 @@ static void aas_push(frame_t *st, uint8_t* psd, unsigned int length)
     else
     {
         // remove protocol and fcs fields
-        input_aas_push(st->input, psd + 1, length - 2);
+        input_aas_push(st->input, psd + 1, length - 3);
     }
 }
 

--- a/src/output.c
+++ b/src/output.c
@@ -685,13 +685,11 @@ void output_aas_push(output_t *st, uint8_t *buf, unsigned int len)
     else if (port == 0x20)
     {
         // Station Information Guide
-        // FIXME: what is the last byte for?
-        parse_sig(st, buf + 4, len - 5);
+        parse_sig(st, buf + 4, len - 4);
     }
     else if (port >= 0x401 && port <= 0x50FF)
     {
-        // FIXME: what is the last byte for?
-        process_port(st, port, buf + 4, len - 5);
+        process_port(st, port, buf + 4, len - 4);
     }
     else
     {


### PR DESCRIPTION
We need to subtract 3 from the length because we skip the first byte and
ignore the last two bytes. This resolves the FIXMEs in output.c because we no
longer have the extraneous byte at the end.