### PR TITLE
Add SIS messages to the API.

### DIFF
--- a/include/nrsc5.h
+++ b/include/nrsc5.h
@@ -90,8 +90,28 @@ enum
     NRSC5_EVENT_AUDIO,
     NRSC5_EVENT_ID3,
     NRSC5_EVENT_SIG,
-    NRSC5_EVENT_LOT
+    NRSC5_EVENT_LOT,
+    NRSC5_EVENT_SIS
 };
+
+struct nrsc5_sis_asd_t
+{
+    struct nrsc5_sis_asd_t *next;
+    unsigned int program;
+    unsigned int access;
+    unsigned int type;
+    unsigned int sound_exp;
+};
+typedef struct nrsc5_sis_asd_t nrsc5_sis_asd_t;
+
+struct nrsc5_sis_dsd_t
+{
+    struct nrsc5_sis_dsd_t *next;
+    unsigned int access;
+    unsigned int type;
+    uint32_t mime_type;
+};
+typedef struct nrsc5_sis_dsd_t nrsc5_sis_dsd_t;
 
 struct nrsc5_event_t
 {
@@ -146,6 +166,19 @@ struct nrsc5_event_t
         struct {
             nrsc5_sig_service_t *services;
         } sig;
+        struct {
+            const char *country_code;
+            int fcc_facility_id;
+            const char *name;
+            const char *slogan;
+            const char *message;
+            const char *alert;
+            float latitude;
+            float longitude;
+            int altitude;
+            nrsc5_sis_asd_t *audio_services;
+            nrsc5_sis_dsd_t *data_services;
+        } sis;
     };
 };
 typedef struct nrsc5_event_t nrsc5_event_t;

--- a/include/nrsc5.h
+++ b/include/nrsc5.h
@@ -25,6 +25,11 @@
 #define NRSC5_MIME_TEXT             0xBB492AAC
 #define NRSC5_MIME_JPEG             0x1E653E9C
 #define NRSC5_MIME_PNG              0x4F328CA0
+#define TTN_TPEG_1                  0xB39EBEB2
+#define TTN_TPEG_2                  0x4EB03469
+#define TTN_TPEG_3                  0x52103469
+#define TTN_STM_TRAFFIC             0xFF8422D7
+#define TTN_STM_WEATHER             0xEF042E96
 
 /*
  * Data types.

--- a/include/nrsc5.h
+++ b/include/nrsc5.h
@@ -25,11 +25,11 @@
 #define NRSC5_MIME_TEXT             0xBB492AAC
 #define NRSC5_MIME_JPEG             0x1E653E9C
 #define NRSC5_MIME_PNG              0x4F328CA0
-#define TTN_TPEG_1                  0xB39EBEB2
-#define TTN_TPEG_2                  0x4EB03469
-#define TTN_TPEG_3                  0x52103469
-#define TTN_STM_TRAFFIC             0xFF8422D7
-#define TTN_STM_WEATHER             0xEF042E96
+#define NRSC5_MIME_TTN_TPEG_1       0xB39EBEB2
+#define NRSC5_MIME_TTN_TPEG_2       0x4EB03469
+#define NRSC5_MIME_TTN_TPEG_3       0x52103469
+#define NRSC5_MIME_TTN_STM_TRAFFIC  0xFF8422D7
+#define NRSC5_MIME_TTN_STM_WEATHER  0xEF042E96
 
 /*
  * Data types.

--- a/src/decode.c
+++ b/src/decode.c
@@ -159,7 +159,7 @@ void decode_reset(decode_t *st)
     st->i_p3 = 0;
     st->ready_p3 = 0;
     memset(st->pt_p3, 0, sizeof(unsigned int) * 4);
-    pids_init(&st->pids);
+    pids_init(&st->pids, st->input);
 }
 
 void decode_init(decode_t *st, struct input_t *input)

--- a/src/main.c
+++ b/src/main.c
@@ -333,25 +333,14 @@ static void callback(const nrsc5_event_t *evt, void *opaque)
             log_info("Alert: %s", evt->sis.alert);
         if (!isnan(evt->sis.latitude))
             log_info("Station location: %f, %f, %dm", evt->sis.latitude, evt->sis.longitude, evt->sis.altitude);
-
-        audio_service = evt->sis.audio_services;
-        while (audio_service)
-        {
+        for (audio_service = evt->sis.audio_services; audio_service != NULL; audio_service = audio_service->next) 
             log_info("Audio program %d: %s, type %d, sound experience %d",
                      audio_service->program, audio_service->access ? "restricted" : "public",
                      audio_service->type, audio_service->sound_exp);
-            audio_service = audio_service->next;
-        }
-
-        data_service = evt->sis.data_services;
-        while (data_service)
-        {
+        for (data_service = evt->sis.data_services; data_service != NULL; data_service = data_service->next)
             log_info("Data service: %s, type %d, MIME type %03x",
                      data_service->access ? "restricted" : "public",
                      data_service->type, data_service->mime_type);
-            data_service = data_service->next;
-        }
-
         break;
     }
 }

--- a/src/main.c
+++ b/src/main.c
@@ -15,6 +15,7 @@
 
 #include <ao/ao.h>
 #include <getopt.h>
+#include <math.h>
 #include <nrsc5.h>
 #include <pthread.h>
 #include <sys/time.h>
@@ -229,6 +230,8 @@ static void callback(const nrsc5_event_t *evt, void *opaque)
     state_t *st = opaque;
     nrsc5_sig_service_t *sig_service;
     nrsc5_sig_component_t *sig_component;
+    nrsc5_sis_asd_t *audio_service;
+    nrsc5_sis_dsd_t *data_service;
 
     switch (evt->event)
     {
@@ -316,6 +319,39 @@ static void callback(const nrsc5_event_t *evt, void *opaque)
         if (st->aas_files_path)
             dump_aas_file(st, evt);
         log_info("LOT file: port=%04X lot=%d name=%s size=%d mime=%08X", evt->lot.port, evt->lot.lot, evt->lot.name, evt->lot.size, evt->lot.mime);
+        break;
+    case NRSC5_EVENT_SIS:
+        if (evt->sis.country_code)
+            log_info("Country: %s, FCC facility ID: %d", evt->sis.country_code, evt->sis.fcc_facility_id);
+        if (evt->sis.name)
+            log_info("Station name: %s", evt->sis.name);
+        if (evt->sis.slogan)
+            log_info("Slogan: %s", evt->sis.slogan);
+        if (evt->sis.message)
+            log_info("Message: %s", evt->sis.message);
+        if (evt->sis.alert)
+            log_info("Alert: %s", evt->sis.alert);
+        if (!isnan(evt->sis.latitude))
+            log_info("Station location: %f, %f, %dm", evt->sis.latitude, evt->sis.longitude, evt->sis.altitude);
+
+        audio_service = evt->sis.audio_services;
+        while (audio_service)
+        {
+            log_info("Audio program %d: %s, type %d, sound experience %d",
+                     audio_service->program, audio_service->access ? "restricted" : "public",
+                     audio_service->type, audio_service->sound_exp);
+            audio_service = audio_service->next;
+        }
+
+        data_service = evt->sis.data_services;
+        while (data_service)
+        {
+            log_info("Data service: %s, type %d, MIME type %03x",
+                     data_service->access ? "restricted" : "public",
+                     data_service->type, data_service->mime_type);
+            data_service = data_service->next;
+        }
+
         break;
     }
 }

--- a/src/nrsc5.c
+++ b/src/nrsc5.c
@@ -555,3 +555,26 @@ void nrsc5_report_sig(nrsc5_t *st, sig_service_t *services, unsigned int count)
         free(p);
     }
 }
+
+void nrsc5_report_sis(nrsc5_t *st, const char *country_code, int fcc_facility_id, const char *name,
+                      const char *slogan, const char *message, const char *alert,
+                      float latitude, float longitude, int altitude, nrsc5_sis_asd_t *audio_services,
+                      nrsc5_sis_dsd_t *data_services)
+{
+    nrsc5_event_t evt;
+
+    evt.event = NRSC5_EVENT_SIS;
+    evt.sis.country_code = country_code;
+    evt.sis.fcc_facility_id = fcc_facility_id;
+    evt.sis.name = name;
+    evt.sis.slogan = slogan;
+    evt.sis.message = message;
+    evt.sis.alert = alert;
+    evt.sis.latitude = latitude;
+    evt.sis.longitude = longitude;
+    evt.sis.altitude = altitude;
+    evt.sis.audio_services = audio_services;
+    evt.sis.data_services = data_services;
+
+    nrsc5_report(st, &evt);
+}

--- a/src/pids.c
+++ b/src/pids.c
@@ -22,7 +22,7 @@
 
 static char *chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZ ?-*$ ";
 
-uint16_t crc12(uint8_t *bits)
+static uint16_t crc12(uint8_t *bits)
 {
     uint16_t poly = 0xD010;
     uint16_t reg = 0x0000;
@@ -45,7 +45,7 @@ uint16_t crc12(uint8_t *bits)
     return reg & 0xfff;
 }
 
-int check_crc12(uint8_t *bits)
+static int check_crc12(uint8_t *bits)
 {
     uint16_t expected_crc = 0;
     int i;
@@ -58,7 +58,7 @@ int check_crc12(uint8_t *bits)
     return expected_crc == crc12(bits);
 }
 
-unsigned int decode_int(uint8_t *bits, int *off, unsigned int length)
+static unsigned int decode_int(uint8_t *bits, int *off, unsigned int length)
 {
     unsigned int i, result = 0;
     for (i = 0; i < length; i++)
@@ -69,23 +69,23 @@ unsigned int decode_int(uint8_t *bits, int *off, unsigned int length)
     return result;
 }
 
-int decode_signed_int(uint8_t *bits, int *off, unsigned int length)
+static int decode_signed_int(uint8_t *bits, int *off, unsigned int length)
 {
     int result = (int) decode_int(bits, off, length);
     return (result & (1 << (length - 1))) ? result - (1 << length) : result;
 }
 
-char decode_char5(uint8_t *bits, int *off)
+static char decode_char5(uint8_t *bits, int *off)
 {
     return chars[decode_int(bits, off, 5)];
 }
 
-char decode_char7(uint8_t *bits, int *off)
+static char decode_char7(uint8_t *bits, int *off)
 {
     return (char) decode_int(bits, off, 7);
 }
 
-char *utf8_encode(int encoding, char *buf, int len)
+static char *utf8_encode(int encoding, char *buf, int len)
 {
     if (encoding == 0)
         return iso_8859_1_to_utf_8((uint8_t *) buf, len);
@@ -97,7 +97,7 @@ char *utf8_encode(int encoding, char *buf, int len)
     return NULL;
 }
 
-void report(pids_t *st)
+static void report(pids_t *st)
 {
     int i;
     char *country_code = NULL;
@@ -190,7 +190,7 @@ void report(pids_t *st)
     }
 }
 
-void decode_sis(pids_t *st, uint8_t *bits)
+static void decode_sis(pids_t *st, uint8_t *bits)
 {
     int payloads, off, i;
 

--- a/src/pids.c
+++ b/src/pids.c
@@ -100,8 +100,8 @@ static char *utf8_encode(int encoding, char *buf, int len)
 static void report(pids_t *st)
 {
     int i;
-    char *country_code = NULL;
-    char *name = NULL;
+    const char *country_code = NULL;
+    const char *name = NULL;
     char *slogan = NULL;
     char *message = NULL;
     char *alert = NULL;
@@ -120,7 +120,7 @@ static void report(pids_t *st)
     if (st->slogan_displayed)
         slogan = utf8_encode(st->slogan_encoding, st->slogan, st->slogan_len);
     else if (st->long_name_displayed)
-        slogan = st->long_name;
+        slogan = strdup(st->long_name);
 
     if (st->message_displayed)
         message = utf8_encode(st->message_encoding, st->message, st->message_len);
@@ -168,12 +168,9 @@ static void report(pids_t *st)
     nrsc5_report_sis(st->input->radio, country_code, st->fcc_facility_id, name, slogan, message, alert,
                      latitude, longitude, altitude, audio_services, data_services);
 
-    if (st->slogan_displayed)
-        free(slogan);
-    if (st->message_displayed)
-        free(message);
-    if (st->alert_displayed)
-        free(alert);
+    free(slogan);
+    free(message);
+    free(alert);
 
     while (audio_services)
     {

--- a/src/pids.c
+++ b/src/pids.c
@@ -190,6 +190,7 @@ static void report(pids_t *st)
 static void decode_sis(pids_t *st, uint8_t *bits)
 {
     int payloads, off, i;
+    int updated = 0;
 
     if (bits[0] != 0) return;
     payloads = bits[1] + 1;
@@ -228,7 +229,7 @@ static void decode_sis(pids_t *st, uint8_t *bits)
             {
                 strcpy(st->country_code, country_code);
                 st->fcc_facility_id = fcc_facility_id;
-                report(st);
+                updated = 1;
             }
             break;
         case 1:
@@ -244,7 +245,7 @@ static void decode_sis(pids_t *st, uint8_t *bits)
             if (strcmp(short_name, st->short_name) != 0)
             {
                 strcpy(st->short_name, short_name);
-                report(st);
+                updated = 1;
             }
             break;
         case 2:
@@ -277,7 +278,7 @@ static void decode_sis(pids_t *st, uint8_t *bits)
                 if (complete)
                 {
                     st->long_name_displayed = 1;
-                    report(st);
+                    updated = 1;
                 }
             }
 
@@ -295,7 +296,8 @@ static void decode_sis(pids_t *st, uint8_t *bits)
                 if (latitude != st->latitude)
                 {
                     st->latitude = latitude;
-                    report(st);
+                    if (!isnan(st->longitude))
+                        updated = 1;
                 }
             }
             else
@@ -305,7 +307,8 @@ static void decode_sis(pids_t *st, uint8_t *bits)
                 if (longitude != st->longitude)
                 {
                     st->longitude = longitude;
-                    report(st);
+                    if (!isnan(st->latitude))
+                        updated = 1;
                 }
             }
             break;
@@ -347,7 +350,7 @@ static void decode_sis(pids_t *st, uint8_t *bits)
                 if (complete)
                 {
                     st->message_displayed = 1;
-                    report(st);
+                    updated = 1;
                 }
             }
             break;
@@ -374,7 +377,7 @@ static void decode_sis(pids_t *st, uint8_t *bits)
                     || st->audio_services[prog_num].sound_exp != audio_service.sound_exp)
                 {
                     st->audio_services[prog_num] = audio_service;
-                    report(st);
+                    updated = 1;
                 }
                 break;
             case 1:
@@ -394,7 +397,7 @@ static void decode_sis(pids_t *st, uint8_t *bits)
                     else if (st->data_services[j].type == -1)
                     {
                         st->data_services[j] = data_service;
-                        report(st);
+                        updated = 1;
                         break;
                     }
                 }
@@ -500,7 +503,7 @@ static void decode_sis(pids_t *st, uint8_t *bits)
                     if (complete)
                     {
                         st->slogan_displayed = 1;
-                        report(st);
+                        updated = 1;
                     }
                 }
             }
@@ -543,7 +546,7 @@ static void decode_sis(pids_t *st, uint8_t *bits)
                 if (complete)
                 {
                     st->alert_displayed = 1;
-                    report(st);
+                    updated = 1;
                 }
             }
             break;
@@ -551,6 +554,9 @@ static void decode_sis(pids_t *st, uint8_t *bits)
             log_error("unexpected msg_id: %d", msg_id);
         }
     }
+
+    if (updated == 1)
+        report(st);
 }
 
 void pids_frame_push(pids_t *st, uint8_t *bits)

--- a/src/pids.h
+++ b/src/pids.h
@@ -30,6 +30,8 @@ typedef struct
 
 typedef struct
 {
+    struct input_t *input;
+
     char country_code[3];
     int fcc_facility_id;
 
@@ -73,4 +75,4 @@ typedef struct
 } pids_t;
 
 void pids_frame_push(pids_t *st, uint8_t *bits);
-void pids_init(pids_t *st);
+void pids_init(pids_t *st, struct input_t *input);

--- a/src/private.h
+++ b/src/private.h
@@ -46,3 +46,7 @@ void nrsc5_report_hdc(nrsc5_t *, unsigned int program, const uint8_t *data, size
 void nrsc5_report_audio(nrsc5_t *, unsigned int program, const int16_t *data, size_t count);
 void nrsc5_report_lot(nrsc5_t *, uint16_t port, unsigned int lot, unsigned int size, uint32_t mime, const char *name, const uint8_t *data);
 void nrsc5_report_sig(nrsc5_t *, sig_service_t *services, unsigned int count);
+void nrsc5_report_sis(nrsc5_t *, const char *country_code, int fcc_facility_id, const char *name,
+                      const char *slogan, const char *message, const char *alert,
+                      float latitude, float longitude, int altitude, nrsc5_sis_asd_t *audio_services,
+                      nrsc5_sis_dsd_t *data_services);

--- a/support/cli.py
+++ b/support/cli.py
@@ -207,6 +207,25 @@ class NRSC5CLI:
                 path = os.path.join(self.args.dump_aas_files, evt.name)
                 with open(path, "wb") as f:
                     f.write(evt.data)
+        elif type == nrsc5.EventType.SIS:
+            if evt.country_code:
+                logging.info("Country: {}, FCC facility ID: {}".format(evt.country_code, evt.fcc_facility_id))
+            if evt.name:
+                logging.info("Station name: {}".format(evt.name))
+            if evt.slogan:
+                logging.info("Slogan: {}".format(evt.slogan))
+            if evt.message:
+                logging.info("Message: {}".format(evt.message))
+            if evt.alert:
+                logging.info("Alert: {}".format(evt.alert))
+            if evt.latitude:
+                logging.info("Station location: {}, {}, {}m".format(evt.latitude, evt.longitude, evt.altitude))
+            for audio_service in evt.audio_services:
+                logging.info("Audio program {}: {}, {}, sound experience {}".format(
+                    audio_service.program, audio_service.access, audio_service.type, audio_service.sound_exp))
+            for data_service in evt.data_services:
+                logging.info("Data service: {}, {}, MIME type {:03x}".format(
+                    data_service.access, data_service.type, data_service.mime_type))
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes #176.

This pull request adds Station Information Service (SIS) messages to the nrsc5 API (both C and Python).

Each time a new SIS message is received, the entire struct containing all SIS messages received so far is reported. This is a bit noisy for the current C & Python CLI applications, but seems appropriate for GUI applications.

"Station Name - long format" and "Station Slogan" messages are both returned in the `slogan` field (with Station Slogan taking precedence) since the NRSC-5 spec says that the long station name is deprecated in favor of slogan. (Some stations send the same data in both messages.)

A few things are not included in the API because I didn't think they were useful enough:

* ALFN
* Priority field for Station Message
* Control Data for Emergency Alert Message
* SIS Parameter Messages (time zone & leap second data, exciter & importer version numbers)