### PR TITLE
Log SIG data in the C CLI.

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -290,14 +290,13 @@ static void callback(const nrsc5_event_t *evt, void *opaque)
         }
         break;
     case NRSC5_EVENT_SIG:
-        sig_service = evt->sig.services;
-        while (sig_service)
+        for (sig_service = evt->sig.services; sig_service != NULL; sig_service = sig_service->next)
         {
             log_info("SIG Service: type=%s number=%d name=%s",
                      sig_service->type == NRSC5_SIG_SERVICE_AUDIO ? "audio" : "data",
                      sig_service->number, sig_service->name);
-            sig_component = sig_service->components;
-            while (sig_component)
+
+            for (sig_component = sig_service->components; sig_component != NULL; sig_component = sig_component->next)
             {
                 if (sig_component->type == NRSC5_SIG_SERVICE_AUDIO)
                 {
@@ -310,9 +309,7 @@ static void callback(const nrsc5_event_t *evt, void *opaque)
                              sig_component->id, sig_component->data.port, sig_component->data.service_data_type,
                              sig_component->data.type, sig_component->data.mime);
                 }
-                sig_component = sig_component->next;
             }
-            sig_service = sig_service->next;
         }
         break;
     case NRSC5_EVENT_LOT:

--- a/src/main.c
+++ b/src/main.c
@@ -227,6 +227,8 @@ static void dump_ber(float cber)
 static void callback(const nrsc5_event_t *evt, void *opaque)
 {
     state_t *st = opaque;
+    nrsc5_sig_service_t *sig_service;
+    nrsc5_sig_component_t *sig_component;
 
     switch (evt->event)
     {
@@ -285,6 +287,32 @@ static void callback(const nrsc5_event_t *evt, void *opaque)
                 log_info("Unique file identifier: %s %s", evt->id3.ufid.owner, evt->id3.ufid.id);
             if (evt->id3.xhdr.param >= 0)
                 log_info("XHDR: %d %08X %d", evt->id3.xhdr.param, evt->id3.xhdr.mime, evt->id3.xhdr.lot);
+        }
+        break;
+    case NRSC5_EVENT_SIG:
+        sig_service = evt->sig.services;
+        while (sig_service)
+        {
+            log_info("SIG Service: type=%s number=%d name=%s",
+                     sig_service->type == NRSC5_SIG_SERVICE_AUDIO ? "audio" : "data",
+                     sig_service->number, sig_service->name);
+            sig_component = sig_service->components;
+            while (sig_component)
+            {
+                if (sig_component->type == NRSC5_SIG_SERVICE_AUDIO)
+                {
+                    log_info("  Audio component: id=%d port=%d type=%d mime=%08X", sig_component->id,
+                             sig_component->audio.port, sig_component->audio.type, sig_component->audio.mime);
+                }
+                else if (sig_component->type == NRSC5_SIG_SERVICE_DATA)
+                {
+                    log_info("  Data component: id=%d port=%d service_data_type=%d type=%d mime=%08X",
+                             sig_component->id, sig_component->data.port, sig_component->data.service_data_type,
+                             sig_component->data.type, sig_component->data.mime);
+                }
+                sig_component = sig_component->next;
+            }
+            sig_service = sig_service->next;
         }
         break;
     case NRSC5_EVENT_LOT:


### PR DESCRIPTION
This adds logging of SIG data in tho C CLI. This functionality is already present in the Python CLI.

Here's how it looks for a local station:

```
13:42:43 DEBUG main.c:298: SIG Service: type=audio number=1 name=MAJIC 100.3
13:42:43 DEBUG main.c:305:   Audio component: id=0 port=0 type=7 mime=4DC66C5A
13:42:43 DEBUG main.c:311:   Data component: id=1 port=2048 service_data_type=265 type=3 mime=BE4B7536
13:42:43 DEBUG main.c:311:   Data component: id=3 port=2049 service_data_type=265 type=3 mime=D9C72536
13:42:43 DEBUG main.c:298: SIG Service: type=audio number=2 name=580 CFRA on 100.3 HD2
13:42:43 DEBUG main.c:305:   Audio component: id=0 port=1 type=4 mime=4DC66C5A
13:42:43 DEBUG main.c:311:   Data component: id=1 port=2050 service_data_type=265 type=3 mime=BE4B7536
13:42:43 DEBUG main.c:311:   Data component: id=3 port=2051 service_data_type=265 type=3 mime=D9C72536
13:42:43 DEBUG main.c:298: SIG Service: type=audio number=3 name=TSN 1200 on HD3
13:42:43 DEBUG main.c:305:   Audio component: id=0 port=2 type=3 mime=4DC66C5A
13:42:43 DEBUG main.c:311:   Data component: id=1 port=2052 service_data_type=265 type=3 mime=BE4B7536
13:42:43 DEBUG main.c:311:   Data component: id=3 port=2053 service_data_type=265 type=3 mime=D9C72536
13:42:43 DEBUG main.c:298: SIG Service: type=data number=11 name=TTN TPEG
13:42:43 DEBUG main.c:311:   Data component: id=0 port=2176 service_data_type=259 type=0 mime=B39EBEB2
13:42:43 DEBUG main.c:311:   Data component: id=1 port=2177 service_data_type=259 type=0 mime=4EB03469
13:42:43 DEBUG main.c:311:   Data component: id=3 port=2178 service_data_type=259 type=0 mime=52103469
13:42:43 DEBUG main.c:298: SIG Service: type=data number=22 name=TTN STM
13:42:43 DEBUG main.c:311:   Data component: id=0 port=2064 service_data_type=66 type=3 mime=FF8422D7
13:42:43 DEBUG main.c:311:   Data component: id=2 port=2080 service_data_type=66 type=3 mime=EF042E96
```