### PR TITLE
Add signed 16-bit sample input.

### DIFF
--- a/include/nrsc5.h
+++ b/include/nrsc5.h
@@ -168,6 +168,7 @@ void nrsc5_get_gain(nrsc5_t *, float *gain);
 int nrsc5_set_gain(nrsc5_t *, float gain);
 void nrsc5_set_auto_gain(nrsc5_t *, int enabled);
 void nrsc5_set_callback(nrsc5_t *, nrsc5_callback_t callback, void *opaque);
-int nrsc5_pipe_samples(nrsc5_t *, uint8_t *samples, unsigned int length);
+int nrsc5_pipe_samples_cu8(nrsc5_t *, uint8_t *samples, unsigned int length);
+int nrsc5_pipe_samples_cs16(nrsc5_t *, int16_t *samples, unsigned int length);
 
 #endif /* NRSC5_H_ */

--- a/src/acquire.c
+++ b/src/acquire.c
@@ -83,7 +83,7 @@ void acquire_process(acquire_t *st)
         for (i = 0; i < FFTCP * (ACQUIRE_SYMBOLS + 1); i++)
         {
             fir_q15_execute(st->filter, &st->in_buffer[i], &y);
-            st->buffer[i] = cq15_to_cf(y);
+            st->buffer[i] = cq15_to_cf_conj(y);
         }
 
         memset(st->sums, 0, sizeof(float complex) * FFTCP);
@@ -118,7 +118,7 @@ void acquire_process(acquire_t *st)
     }
 
     for (i = 0; i < FFTCP * (ACQUIRE_SYMBOLS + 1); i++)
-        st->buffer[i] = cq15_to_cf(st->in_buffer[i]);
+        st->buffer[i] = cq15_to_cf_conj(st->in_buffer[i]);
 
     sync_adjust(&st->input->sync, FFTCP / 2 - samperr);
     angle -= 2 * M_PI * st->cfo;

--- a/src/defines.h
+++ b/src/defines.h
@@ -59,9 +59,9 @@ static inline cint16_t cf_to_cq15(float complex x)
     return cq15;
 }
 
-static inline float complex cq15_to_cf(cint16_t cq15)
+static inline float complex cq15_to_cf_conj(cint16_t cq15)
 {
-    return CMPLXF((float)cq15.r / 32767.0f, (float)cq15.i / 32767.0f);
+    return CMPLXF((float)cq15.r / 32767.0f, (float)cq15.i / -32767.0f);
 }
 
 static inline float normf(float complex v)

--- a/src/input.h
+++ b/src/input.h
@@ -53,7 +53,8 @@ typedef struct input_t
 void input_init(input_t *st, nrsc5_t *radio, output_t *output);
 void input_reset(input_t *st);
 void input_free(input_t *st);
-void input_push(input_t *st, uint8_t *buf, uint32_t len);
+void input_push_cu8(input_t *st, uint8_t *buf, uint32_t len);
+void input_push_cs16(input_t *st, int16_t *buf, uint32_t len);
 void input_set_snr_callback(input_t *st, input_snr_cb_t cb, void *);
 void input_set_skip(input_t *st, unsigned int skip);
 void input_pdu_push(input_t *st, uint8_t *pdu, unsigned int len, unsigned int program);

--- a/src/libnrsc5.map
+++ b/src/libnrsc5.map
@@ -13,7 +13,8 @@ LIBNRSC5_1.0 {
         nrsc5_set_gain;
         nrsc5_set_auto_gain;
         nrsc5_set_callback;
-        nrsc5_pipe_samples;
+        nrsc5_pipe_samples_cu8;
+        nrsc5_pipe_samples_cs16;
 
     local:
         *;

--- a/src/libnrsc5.sym
+++ b/src/libnrsc5.sym
@@ -11,4 +11,5 @@ _nrsc5_get_gain
 _nrsc5_set_gain
 _nrsc5_set_auto_gain
 _nrsc5_set_callback
-_nrsc5_pipe_samples
+_nrsc5_pipe_samples_cu8
+_nrsc5_pipe_samples_cs16

--- a/support/cli.py
+++ b/support/cli.py
@@ -29,6 +29,7 @@ class NRSC5CLI:
         parser.add_argument("-p", metavar="ppm-error", type=int, default=0)
         parser.add_argument("-g", metavar="gain", type=float)
         input_group.add_argument("-r", metavar="iq-input")
+        parser.add_argument("--iq-input-format", choices=["cu8", "cs16"], default="cu8")
         parser.add_argument("-w", metavar="iq-output")
         parser.add_argument("-o", metavar="wav-output")
         parser.add_argument("--dump-hdc", metavar="hdc-output")
@@ -79,7 +80,10 @@ class NRSC5CLI:
                     data = iq_input.read(32768)
                     if len(data) == 0:
                         break
-                    self.radio.pipe_samples(data[:(len(data) // 4) * 4])
+                    if self.args.iq_input_format == "cu8":
+                        self.radio.pipe_samples_cu8(data[:(len(data) // 4) * 4])
+                    elif self.args.iq_input_format == "cs16":
+                        self.radio.pipe_samples_cs16(data[:(len(data) // 4) * 4])
             else:
                 with self.device_condition:
                     self.device_condition.wait()

--- a/support/nrsc5.py
+++ b/support/nrsc5.py
@@ -352,9 +352,16 @@ class NRSC5:
         self.callback_func = CFUNCTYPE(None, POINTER(_Event), c_void_p)(callback_closure)
         NRSC5.libnrsc5.nrsc5_set_callback(self.radio, self.callback_func, None)
 
-    def pipe_samples(self, samples):
+    def pipe_samples_cu8(self, samples):
         if len(samples) % 4 != 0:
             raise NRSC5Error("len(samples) must be a multiple of 4.")
-        result = NRSC5.libnrsc5.nrsc5_pipe_samples(self.radio, samples, len(samples))
+        result = NRSC5.libnrsc5.nrsc5_pipe_samples_cu8(self.radio, samples, len(samples))
+        if result != 0:
+            raise NRSC5Error("Failed to pipe samples.")
+
+    def pipe_samples_cs16(self, samples):
+        if len(samples) % 4 != 0:
+            raise NRSC5Error("len(samples) must be a multiple of 4.")
+        result = NRSC5.libnrsc5.nrsc5_pipe_samples_cs16(self.radio, samples, len(samples) // 2)
         if result != 0:
             raise NRSC5Error("Failed to pipe samples.")


### PR DESCRIPTION
The `nrsc5_pipe_samples` function currently takes unsigned 8-bit samples at a sample rate of 1488375 Hz. This is convenient for the RTL-SDR but not for other SDRs, many of which have an ADC resolution higher than 8 bits.

To solve this problem, I've split `nrsc5_pipe_samples` into two functions:

* `nrsc5_pipe_samples_cu8` which uses the current RTL-SDR format
* `nrsc5_pipe_samples_cu16` which accepts 16-bit signed samples at a sample rate of 744187.5 Hz

The new `nrsc5_pipe_samples_cu16` function puts samples straight into the input module's buffer bypassing the halfband filter / decimator. 

To test the new functions, I've added an `--iq-input-format` argument to the Python CLI which defaults to the old RTL-SDR format. I received samples into a FIFO using a USRP B200:
```
mkfifo samples
uhd_rx_cfile -f 100.3e6 -r 744188 -g 50 -A TX/RX -s samples
```
And in a separate terminal I ran `cli.py`:
```
cli.py --iq-input-format cs16 -r samples 0
```