### PR TITLE
Fix reporting of synchronization state.

### DIFF
--- a/src/acquire.c
+++ b/src/acquire.c
@@ -114,7 +114,7 @@ void acquire_process(acquire_t *st)
         angle_factor = (st->prev_angle) ? 0.25 : 1.0;
         angle = st->prev_angle + (angle_diff * angle_factor);
         st->prev_angle = angle;
-        st->input->sync_state = SYNC_STATE_COARSE;
+        input_set_sync_state(st->input, SYNC_STATE_COARSE);
     }
 
     for (i = 0; i < FFTCP * (ACQUIRE_SYMBOLS + 1); i++)

--- a/src/frame.c
+++ b/src/frame.c
@@ -484,7 +484,7 @@ void frame_process(frame_t *st, size_t length)
         {
             // go back to coarse sync if we fail to decode any audio packets in a P1 frame
             if (length == MAX_PDU_LEN && offset == 0)
-                st->input->sync_state = SYNC_STATE_NONE;
+                input_set_sync_state(st->input, SYNC_STATE_NONE);
             return;
         }
 
@@ -589,8 +589,6 @@ void frame_push(frame_t *st, uint8_t *bits, size_t length)
             }
         }
     }
-
-    // log_debug("PCI %x", header);
 
     st->pci = header;
     frame_process(st, ptr - st->buffer);

--- a/src/input.h
+++ b/src/input.h
@@ -53,6 +53,7 @@ typedef struct input_t
 void input_init(input_t *st, nrsc5_t *radio, output_t *output);
 void input_reset(input_t *st);
 void input_free(input_t *st);
+void input_set_sync_state(input_t *st, unsigned int new_state);
 void input_push_cu8(input_t *st, uint8_t *buf, uint32_t len);
 void input_push_cs16(input_t *st, int16_t *buf, uint32_t len);
 void input_set_snr_callback(input_t *st, input_snr_cb_t cb, void *);

--- a/src/main.c
+++ b/src/main.c
@@ -260,7 +260,7 @@ static void callback(const nrsc5_event_t *evt, void *opaque)
             st->audio_packets++;
             st->audio_bytes += evt->hdc.count * sizeof(evt->hdc.data[0]);
             if (st->audio_packets >= 32) {
-                log_debug("Audio bit rate: %.1f kbps", (float)st->audio_bytes * 8 * 44100 / 2048 / st->audio_packets / 1000);
+                log_info("Audio bit rate: %.1f kbps", (float)st->audio_bytes * 8 * 44100 / 2048 / st->audio_packets / 1000);
                 st->audio_packets = 0;
                 st->audio_bytes = 0;
             }
@@ -271,9 +271,11 @@ static void callback(const nrsc5_event_t *evt, void *opaque)
             push_audio_buffer(st, evt->audio.data, evt->audio.count);
         break;
     case NRSC5_EVENT_SYNC:
+        log_info("Synchronized");
         st->audio_ready = 0;
         break;
     case NRSC5_EVENT_LOST_SYNC:
+        log_info("Lost synchronization");
         break;
     case NRSC5_EVENT_ID3:
         if (evt->id3.program == st->program)

--- a/src/sync.c
+++ b/src/sync.c
@@ -199,9 +199,7 @@ void sync_process(sync_t *st)
         {
             if (find_first_block(st, UB_END, &psmi) != 0)
             {
-                log_debug("lost sync (%d, %d)!", find_first_block(st, LB_START, &psmi), find_first_block(st, UB_END, &psmi));
-                nrsc5_report_lost_sync(st->input->radio);
-                st->input->sync_state = SYNC_STATE_NONE;
+                input_set_sync_state(st->input, SYNC_STATE_NONE);
             }
         }
     }
@@ -215,10 +213,8 @@ void sync_process(sync_t *st)
 
         if (offset == 0)
         {
-            log_info("Synchronized!");
-            nrsc5_report_sync(st->input->radio);
+            input_set_sync_state(st->input, SYNC_STATE_FINE);
             decode_reset(&st->input->decode);
-            st->input->sync_state = SYNC_STATE_FINE;
         }
         else if (st->cfo_wait == 0)
         {

--- a/support/cli.py
+++ b/support/cli.py
@@ -157,9 +157,9 @@ class NRSC5CLI:
             if self.args.w:
                 self.iq_output.write(evt.data)
         elif type == nrsc5.EventType.SYNC:
-            logging.info("Got Sync")
+            logging.info("Synchronized")
         elif type == nrsc5.EventType.LOST_SYNC:
-            logging.info("Lost sync")
+            logging.info("Lost synchronization")
         elif type == nrsc5.EventType.MER:
             logging.info("MER: {:.1f} dB (lower), {:.1f} dB (upper)".format(evt.lower, evt.upper))
         elif type == nrsc5.EventType.BER:


### PR DESCRIPTION
I noticed a couple problems with the reporting of synchronization state. First, loss of synchronization is not reported if it occurs in `frame_process`. Second, the synchronization state is logged in sync.c instead of main.c.

To fix these problems, I've created a new `input_set_sync_state` function which is called whenever the sync state needs to be updated. It reports sync events through the API where appropriate.