### PR TITLE
Add simple keyboard commands to CLI.

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -414,7 +414,8 @@ static void *input_main(void *arg)
 #ifdef __MINGW32__
         ch = _getch();
 #else
-        ch = getchar();
+        if (read(STDIN_FILENO, &ch, 1) != 1)
+            break;
 #endif
 
         switch (ch)

--- a/src/main.c
+++ b/src/main.c
@@ -700,6 +700,7 @@ int main(int argc, char *argv[])
     pthread_cancel(input_thread);
     pthread_join(input_thread, NULL);
 
+    nrsc5_stop(radio);
     nrsc5_close(radio);
     cleanup(st);
     free(st);

--- a/src/main.c
+++ b/src/main.c
@@ -19,6 +19,7 @@
 #include <nrsc5.h>
 #include <pthread.h>
 #include <sys/time.h>
+#include <unistd.h>
 
 #include <assert.h>
 #include <stdio.h>
@@ -29,7 +30,6 @@
 #include <windows.h>
 #else
 #include <termios.h>
-#include <unistd.h>
 #endif
 
 #include "bitwriter.h"
@@ -395,6 +395,9 @@ static void restore_termios(void *arg)
 static void *input_main(void *arg)
 {
     state_t *st = arg;
+
+    if (!isatty(STDIN_FILENO))
+        return NULL;
 
 #ifndef __MINGW32__
     struct termios prev_termios, t;


### PR DESCRIPTION
Proof-of-concept for adding support for some basic commands like quit or change audio program. I only spent a few minutes on it, mainly to get something out there for feedback on resolving #73.

One issue is that the CLI doesn't keep track of valid program numbers to give user feedback if they select a missing program, though the recent SIS event support should make this possible.

Second issue is that there is still a delay because we don't buffer audio from programs that are not currently selected.