### PR TITLE
Always use hex when logging port numbers.

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -305,12 +305,12 @@ static void callback(const nrsc5_event_t *evt, void *opaque)
             {
                 if (sig_component->type == NRSC5_SIG_SERVICE_AUDIO)
                 {
-                    log_info("  Audio component: id=%d port=%d type=%d mime=%08X", sig_component->id,
+                    log_info("  Audio component: id=%d port=%04X type=%d mime=%08X", sig_component->id,
                              sig_component->audio.port, sig_component->audio.type, sig_component->audio.mime);
                 }
                 else if (sig_component->type == NRSC5_SIG_SERVICE_DATA)
                 {
-                    log_info("  Data component: id=%d port=%d service_data_type=%d type=%d mime=%08X",
+                    log_info("  Data component: id=%d port=%04X service_data_type=%d type=%d mime=%08X",
                              sig_component->id, sig_component->data.port, sig_component->data.service_data_type,
                              sig_component->data.type, sig_component->data.mime);
                 }
@@ -335,7 +335,7 @@ static void callback(const nrsc5_event_t *evt, void *opaque)
             log_info("Alert: %s", evt->sis.alert);
         if (!isnan(evt->sis.latitude))
             log_info("Station location: %f, %f, %dm", evt->sis.latitude, evt->sis.longitude, evt->sis.altitude);
-        for (audio_service = evt->sis.audio_services; audio_service != NULL; audio_service = audio_service->next) 
+        for (audio_service = evt->sis.audio_services; audio_service != NULL; audio_service = audio_service->next)
             log_info("Audio program %d: %s, type %d, sound experience %d",
                      audio_service->program, audio_service->access ? "restricted" : "public",
                      audio_service->type, audio_service->sound_exp);

--- a/src/output.c
+++ b/src/output.c
@@ -693,6 +693,6 @@ void output_aas_push(output_t *st, uint8_t *buf, unsigned int len)
     }
     else
     {
-        log_warn("unknown AAS port %x, seq %x, length %d", port, seq, len);
+        log_warn("unknown AAS port %04X, seq %04X, length %d", port, seq, len);
     }
 }

--- a/support/cli.py
+++ b/support/cli.py
@@ -196,11 +196,11 @@ class NRSC5CLI:
                              .format(service.type, service.number, service.name))
                 for component in service.components:
                     if component.type == nrsc5.ComponentType.AUDIO:
-                        logging.info("  Audio component: id={} port={} type={} mime={}"
+                        logging.info("  Audio component: id={} port={:04X} type={} mime={}"
                                      .format(component.id, component.audio.port,
                                              component.audio.type, component.audio.mime))
                     elif component.type == nrsc5.ComponentType.DATA:
-                        logging.info("  Data component: id={} port={} service_data_type={} type={} mime={}"
+                        logging.info("  Data component: id={} port={:04X} service_data_type={} type={} mime={}"
                                      .format(component.id, component.data.port,
                                              component.data.service_data_type,
                                              component.data.type, component.data.mime))


### PR DESCRIPTION
I noticed that AAS port numbers are not logged consistently; in most places they're printed as hexidecimal, but I used decimal when I added logging of SIG data. This changes the format to `%04X` everywhere.