### PR TITLE
Reset frame state when sync is acquired.

### DIFF
--- a/src/sync.c
+++ b/src/sync.c
@@ -215,6 +215,7 @@ void sync_process(sync_t *st)
         {
             input_set_sync_state(st->input, SYNC_STATE_FINE);
             decode_reset(&st->input->decode);
+            frame_reset(&st->input->frame);
         }
         else if (st->cfo_wait == 0)
         {


### PR DESCRIPTION
if sync is lost and then regained, PSD CRC errors and audio decoding errors often occur. This happens because the beginning portions of partial PSD & audio packets remain in the frame state, and are then combined with the trailing portions of partial PSD & audio packets from a non-consecutive frame. The 16-bit PSD CRC check prevents most of the bogus PSD packets from being processed, but bogus audio packets are always sent to the AAC decoder since the 8-bit CRCs only apply to the pieces, not the whole packet.

To fix the problem, I've added a `frame_reset` call when sync is acquired. I tested this by making an IQ recording where I disconnected & reconnected my antenna five times. Prior to this change, 23 PSD CRC errors and 5 audio decode errors occurred, and after the change no errors occurred.