### PR TITLE
Optimize a few things.

### DIFF
--- a/src/decode.c
+++ b/src/decode.c
@@ -36,15 +36,15 @@ static float calc_cber(int8_t *coded, uint8_t *decoded)
         // shift in new bit
         r = (r >> 1) | (decoded[i] << 6);
 
-        if ((coded[j++] > 0 ? 1 : 0) != (__builtin_popcount(r & 0133) & 1))
+        if ((coded[j++] > 0) != __builtin_parity(r & 0133))
             errors++;
 
-        if ((coded[j++] > 0 ? 1 : 0) != (__builtin_popcount(r & 0171) & 1))
+        if ((coded[j++] > 0) != __builtin_parity(r & 0171))
             errors++;
 
         if ((j % 6) == 5)
             j++;
-        else if ((coded[j++] > 0 ? 1 : 0) != (__builtin_popcount(r & 0165) & 1))
+        else if ((coded[j++] > 0) != __builtin_parity(r & 0165))
             errors++;
     }
 

--- a/src/input.c
+++ b/src/input.c
@@ -164,14 +164,14 @@ void input_push_cu8(input_t *st, uint8_t *buf, uint32_t len)
     if (input_shift(st, len / 4) != 0)
         return;
 
-    for (i = 0; i < len / 4; i++)
+    for (i = 0; i < len; i += 4)
     {
         cint16_t x[2];
 
-        x[0].r = U8_Q15(buf[i * 4 + 0]);
-        x[0].i = U8_Q15(buf[i * 4 + 1]);
-        x[1].r = U8_Q15(buf[i * 4 + 2]);
-        x[1].i = U8_Q15(buf[i * 4 + 3]);
+        x[0].r = U8_Q15(buf[i]);
+        x[0].i = U8_Q15(buf[i + 1]);
+        x[1].r = U8_Q15(buf[i + 2]);
+        x[1].i = U8_Q15(buf[i + 3]);
 
         halfband_q15_execute(st->decim, x, &st->buffer[st->avail++]);
     }


### PR DESCRIPTION
I profiled nrsc5 and made some optimizations to the parts that use the most CPU cycles. The result is a speedup of about 5%.

The most significant changes are in sync.c where I updated some loops to process only the FFT bins which might later be used (i.e. the ones that may contain digital subcarriers).