### PR TITLE
Speed up Viterbi decoding

### DIFF
--- a/src/conv_dec.c
+++ b/src/conv_dec.c
@@ -41,6 +41,7 @@
 #endif
 
 #define PARITY(X) __builtin_parity(X)
+#define TAIL_BITING_EXTRA 32
 
 /*
  * Trellis State
@@ -263,13 +264,13 @@ static void reset_decoder(struct vdecoder *dec, int term)
 }
 
 static int _traceback(struct vdecoder *dec,
-		       unsigned state, uint8_t *out, int len)
+		       unsigned state, uint8_t *out, int len, int offset)
 {
 	int i;
 	unsigned path;
 
 	for (i = len - 1; i >= 0; i--) {
-		path = dec->paths[i][state] + 1;
+		path = dec->paths[i + offset][state] + 1;
 		out[i] = dec->trellis->vals[state];
 		state = vstate_lshift(state, dec->k, path);
 	}
@@ -313,6 +314,10 @@ static int traceback(struct vdecoder *dec, uint8_t *out, int term, int len)
 		}
 		if (max < 0)
 			return -EPROTO;
+		for (i = dec->len - 1; i >= len + TAIL_BITING_EXTRA; i--) {
+			path = dec->paths[i][state] + 1;
+			state = vstate_lshift(state, dec->k, path);
+		}
 	} else {
 		for (i = dec->len - 1; i >= len; i--) {
 			path = dec->paths[i][state] + 1;
@@ -323,11 +328,9 @@ static int traceback(struct vdecoder *dec, uint8_t *out, int term, int len)
 	if (dec->recursive)
 		_traceback_rec(dec, state, out, len);
 	else
-		state =_traceback(dec, state, out, len);
+		state =_traceback(dec, state, out, len, term == CONV_TERM_TAIL_BITING ? TAIL_BITING_EXTRA : 0);
 
 	/* Don't handle the odd case of recursize tail-biting codes */
-	if (term == CONV_TERM_TAIL_BITING)
-		_traceback(dec, state, out, len);
 
 	return max - max_p;
 }
@@ -369,7 +372,7 @@ static struct vdecoder *alloc_vdec(const struct lte_conv_code *code)
 	if (code->term == CONV_TERM_FLUSH)
 		dec->len = code->len + code->k - 1;
 	else
-		dec->len = code->len;
+		dec->len = code->len + TAIL_BITING_EXTRA * 2;
 
 	dec->trellis = generate_trellis(code);
 	if (!dec->trellis)
@@ -393,13 +396,19 @@ fail:
  * accumulated path metric sums and path selections are stored. Normalize on
  * the interval specified by the decoder.
  */
-static void _conv_decode(struct vdecoder *dec, const int8_t *seq)
+static void _conv_decode(struct vdecoder *dec, const int8_t *seq, int term, int len)
 {
-	int i;
+	int i, j = 0;
 	struct vtrellis *trellis = dec->trellis;
 
-	for (i = 0; i < dec->len; i++) {
-		gen_metrics_k7_n3(&seq[dec->n * i],
+	if (term == CONV_TERM_TAIL_BITING)
+		j = len - TAIL_BITING_EXTRA;
+
+	for (i = 0; i < dec->len; i++, j++) {
+		if (term == CONV_TERM_TAIL_BITING && j == len)
+			j = 0;
+
+		gen_metrics_k7_n3(&seq[dec->n * j],
 				 trellis->outputs,
 				 trellis->sums,
 				 dec->paths[i],
@@ -425,10 +434,7 @@ static int nrsc5_conv_decode(const int8_t *in, uint8_t *out, int len)
 	reset_decoder(vdec, code.term);
 
 	/* Propagate through the trellis with interval normalization */
-	_conv_decode(vdec, in);
-
-	if (code.term == CONV_TERM_TAIL_BITING)
-		_conv_decode(vdec, in);
+	_conv_decode(vdec, in, code.term, code.len);
 
 	rc = traceback(vdec, out, code.term, code.len);
 

--- a/src/conv_dec.c
+++ b/src/conv_dec.c
@@ -407,12 +407,12 @@ static void _conv_decode(struct vdecoder *dec, const int8_t *seq)
 	}
 }
 
-int nrsc5_conv_decode_p1(const int8_t *in, uint8_t *out)
+static int nrsc5_conv_decode(const int8_t *in, uint8_t *out, int len)
 {
 	const struct lte_conv_code code = {
 		.n = 3,
 		.k = 7,
-		.len = P1_FRAME_LEN,
+		.len = len,
 		.gen = { 0133, 0171, 0165 },
 		.term = CONV_TERM_TAIL_BITING,
 	};
@@ -434,62 +434,19 @@ int nrsc5_conv_decode_p1(const int8_t *in, uint8_t *out)
 
 	free_vdec(vdec);
 	return rc;
+}
+
+int nrsc5_conv_decode_p1(const int8_t *in, uint8_t *out)
+{
+	return nrsc5_conv_decode(in, out, P1_FRAME_LEN);
 }
 
 int nrsc5_conv_decode_pids(const int8_t *in, uint8_t *out)
 {
-	const struct lte_conv_code code = {
-		.n = 3,
-		.k = 7,
-		.len = PIDS_FRAME_LEN,
-		.gen = { 0133, 0171, 0165 },
-		.term = CONV_TERM_TAIL_BITING,
-	};
-	int rc;
-
-	struct vdecoder *vdec = alloc_vdec(&code);
-	if (!vdec)
-		return -EFAULT;
-
-	reset_decoder(vdec, code.term);
-
-	/* Propagate through the trellis with interval normalization */
-	_conv_decode(vdec, in);
-
-	if (code.term == CONV_TERM_TAIL_BITING)
-		_conv_decode(vdec, in);
-
-	rc = traceback(vdec, out, code.term, code.len);
-
-	free_vdec(vdec);
-	return rc;
+	return nrsc5_conv_decode(in, out, PIDS_FRAME_LEN);
 }
 
 int nrsc5_conv_decode_p3(const int8_t *in, uint8_t *out)
 {
-	const struct lte_conv_code code = {
-		.n = 3,
-		.k = 7,
-		.len = P3_FRAME_LEN,
-		.gen = { 0133, 0171, 0165 },
-		.term = CONV_TERM_TAIL_BITING,
-	};
-	int rc;
-
-	struct vdecoder *vdec = alloc_vdec(&code);
-	if (!vdec)
-		return -EFAULT;
-
-	reset_decoder(vdec, code.term);
-
-	/* Propagate through the trellis with interval normalization */
-	_conv_decode(vdec, in);
-
-	if (code.term == CONV_TERM_TAIL_BITING)
-		_conv_decode(vdec, in);
-
-	rc = traceback(vdec, out, code.term, code.len);
-
-	free_vdec(vdec);
-	return rc;
+	return nrsc5_conv_decode(in, out, P3_FRAME_LEN);
 }

--- a/src/conv_neon.h
+++ b/src/conv_neon.h
@@ -171,11 +171,3 @@ static inline void gen_metrics_k7_n3(const int8_t *val, const int16_t *out,
 
 	_neon_metrics_k7_n4(_val, out, sums, paths, norm);
 }
-
-static inline void gen_metrics_k7_n4(const int8_t *val, const int16_t *out,
-		       int16_t *sums, int16_t *paths, int norm)
-{
-	const int16_t _val[4] = { val[0], val[1], val[2], val[3] };
-
-	_neon_metrics_k7_n4(_val, out, sums, paths, norm);
-}

--- a/src/conv_sse.h
+++ b/src/conv_sse.h
@@ -1,5 +1,5 @@
 /*
- * Viterbi decoder for convolutional codes - Intel SSE/AVX 
+ * Viterbi decoder for convolutional codes - Intel SSE/AVX
  *
  * Copyright (C) 2015 Ettus Research LLC
  *
@@ -68,32 +68,7 @@
 	M1 = _mm_cmpgt_epi16(M0, M1); \
 }
 
-/*
- * Two lane deinterleaving K = 5
- *
- * Take 16 interleaved 16-bit integers and deinterleave to 2 packed 128-bit
- * registers. The operation summarized below. Four registers are used with
- * the lower 2 as input and upper 2 as output.
- *
- * In   - 10101010 10101010 10101010 10101010
- * Out  - 00000000 11111111 00000000 11111111
- *
- * Input:
- * M0:1 - Packed 16-bit integers
- *
- * Output:
- * M2:3 - Deinterleaved packed 16-bit integers
- */
 #define _I8_SHUFFLE_MASK 15, 14, 11, 10, 7, 6, 3, 2, 13, 12, 9, 8, 5, 4, 1, 0
-
-#define SSE_DEINTERLEAVE_K5(M0,M1,M2,M3) \
-{ \
-	M2 = _mm_set_epi8(_I8_SHUFFLE_MASK); \
-	M0 = _mm_shuffle_epi8(M0, M2); \
-	M1 = _mm_shuffle_epi8(M1, M2); \
-	M2 = _mm_unpacklo_epi64(M0, M1); \
-	M3 = _mm_unpackhi_epi64(M0, M1); \
-}
 
 /*
  * Two lane deinterleaving K = 7
@@ -131,28 +106,6 @@
 	M13 = _mm_unpackhi_epi64(M4, M5); \
 	M14 = _mm_unpacklo_epi64(M6, M7); \
 	M15 = _mm_unpackhi_epi64(M6, M7); \
-}
-
-/*
- * Generate branch metrics N = 2
- *
- * Compute 16 branch metrics from trellis outputs and input values.
- *
- * Input:
- * M0:3 - 16 x 2 packed 16-bit trellis outputs
- * M4   - Expanded and packed 16-bit input value
- *
- * Output:
- * M6:7 - 16 computed 16-bit branch metrics
- */
-#define SSE_BRANCH_METRIC_N2(M0,M1,M2,M3,M4,M6,M7) \
-{ \
-	M0 = _mm_sign_epi16(M4, M0); \
-	M1 = _mm_sign_epi16(M4, M1); \
-	M2 = _mm_sign_epi16(M4, M2); \
-	M3 = _mm_sign_epi16(M4, M3); \
-	M6 = _mm_hadds_epi16(M0, M1); \
-	M7 = _mm_hadds_epi16(M2, M3); \
 }
 
 /*
@@ -241,29 +194,6 @@
 #endif
 
 /*
- * Normalize state metrics K = 5:
- *
- * Compute 16-wide normalization by subtracting the smallest value from
- * all values. Inputs are 16 packed 16-bit integers across 2 XMM registers.
- * Two intermediate registers are used and normalized results are placed
- * in the originating locations.
- *
- * Input:
- * M0:1 - Path metrics 0:1 (packed 16-bit integers)
- *
- * Output:
- * M0:1 - Normalized path metrics 0:1
- */
-#define SSE_NORMALIZE_K5(M0,M1,M2,M3) \
-{ \
-	M2 = _mm_min_epi16(M0, M1); \
-	SSE_MINPOS(M2, M3) \
-	SSE_BROADCAST(M2) \
-	M0 = _mm_subs_epi16(M0, M2); \
-	M1 = _mm_subs_epi16(M1, M2); \
-}
-
-/*
  * Normalize state metrics K = 7:
  *
  * Compute 64-wide normalization by subtracting the smallest value from
@@ -295,179 +225,6 @@
 	M5  = _mm_subs_epi16(M5, M8); \
 	M6  = _mm_subs_epi16(M6, M8); \
 	M7  = _mm_subs_epi16(M7, M8); \
-}
-
-/*
- * Combined BMU/PMU (K=5, N=2)
- *
- * Compute branch metrics followed by path metrics for half rate 16-state
- * trellis. 8 butterflies are computed. Accumulated path sums are not
- * preserved and read and written into the same memory location. Normalize
- * sums if requires.
- */
-__always_inline void _sse_metrics_k5_n2(const int16_t *val,
-					const int16_t *out,
-					int16_t *sums,
-					int16_t *paths,
-					int norm)
-{
-	__m128i m0, m1, m2, m3, m4, m5, m6;
-
-	/* (BMU) Load input sequence */
-	m2 = _mm_castpd_si128(_mm_loaddup_pd((double const *) val));
-
-	/* (BMU) Load trellis outputs */
-	m0 = _mm_load_si128((__m128i *) &out[0]);
-	m1 = _mm_load_si128((__m128i *) &out[8]);
-
-	/* (BMU) Compute branch metrics */
-	m0 = _mm_sign_epi16(m2, m0);
-	m1 = _mm_sign_epi16(m2, m1);
-	m2 = _mm_hadds_epi16(m0, m1);
-
-	/* (PMU) Load accumulated path matrics */
-	m0 = _mm_load_si128((__m128i *) &sums[0]);
-	m1 = _mm_load_si128((__m128i *) &sums[8]);
-
-	SSE_DEINTERLEAVE_K5(m0, m1, m3, m4)
-
-	/* (PMU) Butterflies: 0-7 */
-	SSE_BUTTERFLY(m3, m4, m2, m5, m6)
-
-	if (norm)
-		SSE_NORMALIZE_K5(m2, m6, m0, m1)
-
-	_mm_store_si128((__m128i *) &sums[0], m2);
-	_mm_store_si128((__m128i *) &sums[8], m6);
-	_mm_store_si128((__m128i *) &paths[0], m5);
-	_mm_store_si128((__m128i *) &paths[8], m4);
-}
-
-/*
- * Combined BMU/PMU (K=5, N=3 and N=4)
- * 
- * Compute branch metrics followed by path metrics for 16-state and rates
- * to 1/4. 8 butterflies are computed. The input sequence is read four 16-bit
- * values at a time, and extra values should be set to zero for rates other
- * than 1/4. Normally only rates 1/3 and 1/4 are used as there is a
- * dedicated implementation of rate 1/2.
- */
-__always_inline void _sse_metrics_k5_n4(const int16_t *val,
-					const int16_t *out,
-					int16_t *sums,
-					int16_t *paths,
-					int norm)
-{
-	__m128i m0, m1, m2, m3, m4, m5, m6;
-
-	/* (BMU) Load input sequence */
-	m4 = _mm_castpd_si128(_mm_loaddup_pd((double const *) val));
-
-	/* (BMU) Load trellis outputs */
-	m0 = _mm_load_si128((__m128i *) &out[0]);
-	m1 = _mm_load_si128((__m128i *) &out[8]);
-	m2 = _mm_load_si128((__m128i *) &out[16]);
-	m3 = _mm_load_si128((__m128i *) &out[24]);
-
-	SSE_BRANCH_METRIC_N4(m0, m1, m2, m3, m4, m2)
-
-	/* (PMU) Load accumulated path matrics */
-	m0 = _mm_load_si128((__m128i *) &sums[0]);
-	m1 = _mm_load_si128((__m128i *) &sums[8]);
-
-	SSE_DEINTERLEAVE_K5(m0, m1, m3, m4)
-
-	/* (PMU) Butterflies: 0-7 */
-	SSE_BUTTERFLY(m3, m4, m2, m5, m6)
-
-	if (norm)
-		SSE_NORMALIZE_K5(m2, m6, m0, m1)
-
-	_mm_store_si128((__m128i *) &sums[0], m2);
-	_mm_store_si128((__m128i *) &sums[8], m6);
-	_mm_store_si128((__m128i *) &paths[0], m5);
-	_mm_store_si128((__m128i *) &paths[8], m4);
-}
-
-/*
- * Combined BMU/PMU (K=7, N=2)
- *
- * Compute branch metrics followed by path metrics for half rate 64-state
- * trellis. 32 butterfly operations are computed. Deinterleaving path
- * metrics requires usage of the full SSE register file, so separate sums
- * before computing branch metrics to avoid register spilling.
- */
-__always_inline void _sse_metrics_k7_n2(const int16_t *val,
-					const int16_t *out,
-					int16_t *sums,
-					int16_t *paths,
-					int norm)
-{
-	__m128i m0, m1, m2, m3, m4, m5, m6, m7, m8,
-		m9, m10, m11, m12, m13, m14, m15;
-
-	/* (PMU) Load accumulated path matrics */
-	m0 = _mm_load_si128((__m128i *) &sums[0]);
-	m1 = _mm_load_si128((__m128i *) &sums[8]);
-	m2 = _mm_load_si128((__m128i *) &sums[16]);
-	m3 = _mm_load_si128((__m128i *) &sums[24]);
-	m4 = _mm_load_si128((__m128i *) &sums[32]);
-	m5 = _mm_load_si128((__m128i *) &sums[40]);
-	m6 = _mm_load_si128((__m128i *) &sums[48]);
-	m7 = _mm_load_si128((__m128i *) &sums[56]);
-
-	/* (PMU) Deinterleave to even-odd registers */
-	SSE_DEINTERLEAVE_K7(m0, m1, m2, m3 ,m4 ,m5, m6, m7,
-			    m8, m9, m10, m11, m12, m13, m14, m15)
-
-	/* (BMU) Load input symbols */
-	m7 = _mm_castpd_si128(_mm_loaddup_pd((double const *) val));
-
-	/* (BMU) Load trellis outputs */
-	m0 = _mm_load_si128((__m128i *) &out[0]);
-	m1 = _mm_load_si128((__m128i *) &out[8]);
-	m2 = _mm_load_si128((__m128i *) &out[16]);
-	m3 = _mm_load_si128((__m128i *) &out[24]);
-
-	SSE_BRANCH_METRIC_N2(m0, m1, m2, m3, m7, m4, m5)
-
-	m0 = _mm_load_si128((__m128i *) &out[32]);
-	m1 = _mm_load_si128((__m128i *) &out[40]);
-	m2 = _mm_load_si128((__m128i *) &out[48]);
-	m3 = _mm_load_si128((__m128i *) &out[56]);
-
-	SSE_BRANCH_METRIC_N2(m0, m1, m2, m3, m7, m6, m7)
-
-	/* (PMU) Butterflies: 0-15 */
-	SSE_BUTTERFLY(m8, m9, m4, m0, m1)
-	SSE_BUTTERFLY(m10, m11, m5, m2, m3)
-
-	_mm_store_si128((__m128i *) &paths[0], m0);
-	_mm_store_si128((__m128i *) &paths[8], m2);
-	_mm_store_si128((__m128i *) &paths[32], m9);
-	_mm_store_si128((__m128i *) &paths[40], m11);
-
-	/* (PMU) Butterflies: 17-31 */
-	SSE_BUTTERFLY(m12, m13, m6, m0, m2)
-	SSE_BUTTERFLY(m14, m15, m7, m9, m11)
-
-	_mm_store_si128((__m128i *) &paths[16], m0);
-	_mm_store_si128((__m128i *) &paths[24], m9);
-	_mm_store_si128((__m128i *) &paths[48], m13);
-	_mm_store_si128((__m128i *) &paths[56], m15);
-
-	if (norm)
-		SSE_NORMALIZE_K7(m4, m1, m5, m3, m6, m2,
-				 m7, m11, m0, m8, m9, m10)
-
-	_mm_store_si128((__m128i *) &sums[0], m4);
-	_mm_store_si128((__m128i *) &sums[8], m5);
-	_mm_store_si128((__m128i *) &sums[16], m6);
-	_mm_store_si128((__m128i *) &sums[24], m7);
-	_mm_store_si128((__m128i *) &sums[32], m1);
-	_mm_store_si128((__m128i *) &sums[40], m3);
-	_mm_store_si128((__m128i *) &sums[48], m2);
-	_mm_store_si128((__m128i *) &sums[56], m11);
 }
 
 /*
@@ -561,50 +318,10 @@ __always_inline void _sse_metrics_k7_n4(const int16_t *val, const int16_t *out,
 	_mm_store_si128((__m128i *) &sums[56], m11);
 }
 
-static void gen_metrics_k5_n2(const int8_t *val, const int16_t *out,
-			      int16_t *sums, int16_t *paths, int norm)
-{
-	const int16_t _val[4] = { val[0], val[1], val[0], val[1] };
-
-	_sse_metrics_k5_n2(_val, out, sums, paths, norm);
-}
-
-static void gen_metrics_k5_n3(const int8_t *val, const int16_t *out,
-		       int16_t *sums, int16_t *paths, int norm)
-{
-	const int16_t _val[4] = { val[0], val[1], val[2], 0 };
-
-	_sse_metrics_k5_n4(_val, out, sums, paths, norm);
-}
-
-static void gen_metrics_k5_n4(const int8_t *val, const int16_t *out,
-		       int16_t *sums, int16_t *paths, int norm)
-{
-	const int16_t _val[4] = { val[0], val[1], val[2], val[3] };
-
-	_sse_metrics_k5_n4(_val, out, sums, paths, norm);
-}
-
-static void gen_metrics_k7_n2(const int8_t *val, const int16_t *out,
-		       int16_t *sums, int16_t *paths, int norm)
-{
-	const int16_t _val[4] = { val[0], val[1], val[0], val[1] };
-
-	_sse_metrics_k7_n2(_val, out, sums, paths, norm);
-}
-
 static void gen_metrics_k7_n3(const int8_t *val, const int16_t *out,
 		       int16_t *sums, int16_t *paths, int norm)
 {
 	const int16_t _val[4] = { val[0], val[1], val[2], 0 };
-
-	_sse_metrics_k7_n4(_val, out, sums, paths, norm);
-}
-
-static void gen_metrics_k7_n4(const int8_t *val, const int16_t *out,
-		       int16_t *sums, int16_t *paths, int norm)
-{
-	const int16_t _val[4] = { val[0], val[1], val[2], val[3] };
 
 	_sse_metrics_k7_n4(_val, out, sums, paths, norm);
 }


### PR DESCRIPTION
NRSC-5 uses convolutional codes in tail-biting mode. Currently the convolutional decoder in nrsc5 performs two full passes of Viterbi decoding. This improves decoding, but doubles the computational cost. Extending the beginning & end of the trellis by 32 achieves the same decoding performance at much lower computational cost. Making this change improves the overall performance of nrsc5 by about 7%.

In this PR I've also removed the unused functions in conv_neon.h and conv_sse.h to silence compiler warnings.