### PR TITLE
Fix WAV file output on Windows

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -189,6 +189,7 @@ if (NOT USE_SYSTEM_LIBAO)
         PREFIX ${LIBAO_PREFIX}
 
         UPDATE_COMMAND ""
+        PATCH_COMMAND patch -p1 -Ni "${CMAKE_SOURCE_DIR}/support/libao-win-fix.patch" || exit 0
         CONFIGURE_COMMAND ${LIBAO_PREFIX}/src/libao_external/configure ${HOST_TRIPLE_ARG} --prefix=${LIBAO_PREFIX} --enable-static --disable-shared --disable-pulse
     )
     ExternalProject_Add_Step (

--- a/support/libao-win-fix.patch
+++ b/support/libao-win-fix.patch
@@ -1,0 +1,13 @@
+diff --git a/src/audio_out.c b/src/audio_out.c
+index f5942d6..166c72b 100644
+--- a/src/audio_out.c
++++ b/src/audio_out.c
+@@ -1387,7 +1387,7 @@ ao_device *ao_open_file (int driver_id, const char *filename, int overwrite,
+ 		}
+ 
+ 
+-		file = fopen(filename, "w");
++		file = fopen(filename, "wb");
+ 	}
+ 
+ 


### PR DESCRIPTION
Fixes #207.

When opening a WAV file for writing, libao doesn't request binary mode. On Windows, this causes carriage return characters to be inserted into the output file before line feed characters, corrupting the file.

For now I've modified nrsc5 to patch libao's `ao_open_file` function. I'll propose the patch to libao and remove it from here if the patch is accepted upstream.