### PR TITLE
Remove level, filename and line number from log

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -7,7 +7,6 @@ project (nrsc5 C)
 
 execute_process (COMMAND ${CMAKE_C_COMPILER} -dumpmachine OUTPUT_VARIABLE HOST_TRIPLE_DEFAULT OUTPUT_STRIP_TRAILING_WHITESPACE)
 
-option (USE_COLOR "Colorize log output")
 option (USE_NEON "Use NEON instructions")
 option (USE_SSE "Use SSE3 instructions")
 option (USE_FAAD2 "AAC decoding with FAAD2" ON)

--- a/README.md
+++ b/README.md
@@ -16,7 +16,6 @@ This program receives NRSC-5 digital radio stations using an RTL-SDR dongle. It 
 
 Available build options:
 
-    -DUSE_COLOR=ON       Colorize log output. [default=OFF]
     -DUSE_NEON=ON        Use NEON instructions. [ARM, default=OFF]
     -DUSE_SSE=ON         Use SSSE3 instructions. [x86, default=OFF]
     -DUSE_FAAD2=ON       AAC decoding with FAAD2. [default=ON]

--- a/src/config.h.in
+++ b/src/config.h.in
@@ -1,7 +1,6 @@
 #pragma once
 
 #cmakedefine USE_FAAD2
-#cmakedefine USE_COLOR
 
 #cmakedefine HAVE_PTHREAD_SETNAME_NP
 #cmakedefine HAVE_STRNDUP

--- a/src/log.c
+++ b/src/log.c
@@ -39,17 +39,6 @@ static struct {
 } L;
 
 
-static const char *level_names[] = {
-  "TRACE", "DEBUG", "INFO", "WARN", "ERROR", "FATAL"
-};
-
-#ifdef USE_COLOR
-static const char *level_colors[] = {
-  "\x1b[94m", "\x1b[36m", "\x1b[32m", "\x1b[33m", "\x1b[31m", "\x1b[35m"
-};
-#endif
-
-
 static void lock(void)   {
   if (L.lock) {
     L.lock(L.udata, 1);
@@ -74,11 +63,6 @@ void log_set_lock(log_LockFn fn) {
 }
 
 
-void log_set_fp(FILE *fp) {
-  L.fp = fp;
-}
-
-
 void log_set_level(int level) {
   L.level = level;
 }
@@ -89,15 +73,9 @@ void log_set_quiet(int enable) {
 }
 
 
-void log_log(int level, const char *file, int line, const char *fmt, ...) {
+void log_log(int level, const char *fmt, ...) {
   if (level < L.level) {
     return;
-  }
-
-  /* awesie: cut off everything besides file name */
-  size_t slash;
-  while (slash = strcspn(file, "/\\"), file[slash] != 0) {
-    file += slash + 1;
   }
 
   /* Acquire lock */
@@ -112,31 +90,13 @@ void log_log(int level, const char *file, int line, const char *fmt, ...) {
     va_list args;
     char buf[16];
     buf[strftime(buf, sizeof(buf), "%H:%M:%S", lt)] = '\0';
-#ifdef USE_COLOR
-    fprintf(
-      stderr, "%s %s%-5s\x1b[0m \x1b[90m%s:%d:\x1b[0m ",
-      buf, level_colors[level], level_names[level], file, line);
-#else
-    fprintf(stderr, "%s %-5s %s:%d: ", buf, level_names[level], file, line);
-#endif
+    fprintf(stderr, "%s ", buf);
     va_start(args, fmt);
     vfprintf(stderr, fmt, args);
     va_end(args);
     fprintf(stderr, "\n");
     /* XXX required for correct output on Windows */
     fflush(stderr);
-  }
-
-  /* Log to file */
-  if (L.fp) {
-    va_list args;
-    char buf[32];
-    buf[strftime(buf, sizeof(buf), "%Y-%m-%d %H:%M:%S", lt)] = '\0';
-    fprintf(L.fp, "%s %-5s %s:%d: ", buf, level_names[level], file, line);
-    va_start(args, fmt);
-    vfprintf(L.fp, fmt, args);
-    va_end(args);
-    fprintf(L.fp, "\n");
   }
 
   /* Release lock */

--- a/src/log.h
+++ b/src/log.h
@@ -17,19 +17,18 @@ typedef void (*log_LockFn)(void *udata, int lock);
 
 enum { LOG_TRACE, LOG_DEBUG, LOG_INFO, LOG_WARN, LOG_ERROR, LOG_FATAL };
 
-#define log_trace(...) log_log(LOG_TRACE, __FILE__, __LINE__, __VA_ARGS__)
-#define log_debug(...) log_log(LOG_DEBUG, __FILE__, __LINE__, __VA_ARGS__)
-#define log_info(...)  log_log(LOG_INFO,  __FILE__, __LINE__, __VA_ARGS__)
-#define log_warn(...)  log_log(LOG_WARN,  __FILE__, __LINE__, __VA_ARGS__)
-#define log_error(...) log_log(LOG_ERROR, __FILE__, __LINE__, __VA_ARGS__)
-#define log_fatal(...) log_log(LOG_FATAL, __FILE__, __LINE__, __VA_ARGS__)
+#define log_trace(...) log_log(LOG_TRACE, __VA_ARGS__)
+#define log_debug(...) log_log(LOG_DEBUG, __VA_ARGS__)
+#define log_info(...) log_log(LOG_INFO, __VA_ARGS__)
+#define log_warn(...) log_log(LOG_WARN, __VA_ARGS__)
+#define log_error(...) log_log(LOG_ERROR, __VA_ARGS__)
+#define log_fatal(...) log_log(LOG_FATAL, __VA_ARGS__)
 
 void log_set_udata(void *udata);
 void log_set_lock(log_LockFn fn);
-void log_set_fp(FILE *fp);
 void log_set_level(int level);
 void log_set_quiet(int enable);
 
-void log_log(int level, const char *file, int line, const char *fmt, ...);
+void log_log(int level, const char *fmt, ...);
 
 #endif

--- a/support/cli.py
+++ b/support/cli.py
@@ -47,7 +47,7 @@ class NRSC5CLI:
 
     def run(self):
         logging.basicConfig(level=self.args.l * 10,
-                            format="%(asctime)s %(levelname)-5s %(filename)s:%(lineno)d: %(message)s",
+                            format="%(asctime)s %(message)s",
                             datefmt="%H:%M:%S")
         if self.args.q:
             logging.disable(logging.CRITICAL)

--- a/support/msys2-build
+++ b/support/msys2-build
@@ -21,7 +21,6 @@ cmake -G "MSYS Makefiles" \
     -D USE_SYSTEM_RTLSDR=OFF \
     -D USE_SYSTEM_LIBAO=OFF \
     -D USE_SYSTEM_FFTW=OFF \
-    -D USE_COLOR=OFF \
     -D USE_SSE=ON \
     -D CMAKE_INSTALL_PREFIX=${MINGW_PREFIX} \
     ..


### PR DESCRIPTION
Fixes #226.

As noted in #226, the log level, filename and line number are not particularly useful anymore and take up quite a bit of space. I agree with @awesie's suggestion to just get rid of them, which I've done here. I also removed `log_set_fp` as it is unused.