### PR TITLE
Improve synchronization

### DIFF
--- a/src/sync.h
+++ b/src/sync.h
@@ -10,6 +10,7 @@ typedef struct
     float complex buffer[FFT][BLKSZ];
     float phases[FFT][BLKSZ];
     unsigned int idx;
+    int psmi;
     int cfo_wait;
     int samperr;
     float angle;


### PR DESCRIPTION
I noticed that #223 made CFO detection worse when there is a frequency error of more than a few parts per million. The reason is that `adjust_ref` is now called multiple times for each subcarrier as different CFO values are tried, and so the symbol phases get adjusted multiple times. To fix this, I added a `reset_ref` function to undo the phase adjustments after each offset is tried.

I also fixed some other problems with the synchronization code:

* The CFO frequency calculation in `adjust_ref` was incorrect.
* The `sync_reset` function didn't reset the Costas loop parameter for some of the subcarriers that were accessed during CFO detection. I changed it to reset all subcarriers.
* Checking the validity of the reference subcarriers is unnecessary in the `SYNC_STATE_FINE` state, since `frame_process` already detects loss of sync. I removed this check.
* In the `SYNC_STATE_COARSE` state, one of two specific reference subcarriers must be present to trigger a transition into the `SYNC_STATE_FINE` state. If both are corrupted, then synchronization will not be achieved. I changed this to proceed if any four reference subcarriers are successfully decoded.

Overall these changes made an 0.3% improvement in the number of decoded audio packets in my suite of I/Q recordings. For high-SNR recordings there was no difference, but for low-SNR recordings the improvement was as high as 15%.