### PR TITLE
Added function to set the log level to nrsc5 library.

### DIFF
--- a/include/nrsc5.h
+++ b/include/nrsc5.h
@@ -257,6 +257,7 @@ typedef struct nrsc5_t nrsc5_t;
 /*
  * Public functions. All functions return void or an error code (0 == success).
  */
+void nrsc5_log_set_level(int level);
 void nrsc5_get_version(const char **version);
 void nrsc5_service_data_type_name(unsigned int type, const char **name);
 void nrsc5_program_type_name(unsigned int type, const char **name);

--- a/src/libnrsc5.map
+++ b/src/libnrsc5.map
@@ -1,5 +1,6 @@
 LIBNRSC5_1.0 {
     global:
+        nrsc5_log_set_level;
         nrsc5_get_version;
         nrsc5_service_data_type_name;
         nrsc5_program_type_name;

--- a/src/libnrsc5.sym
+++ b/src/libnrsc5.sym
@@ -1,3 +1,4 @@
+_nrsc5_log_set_level
 _nrsc5_get_version
 _nrsc5_service_data_type_name
 _nrsc5_program_type_name

--- a/src/nrsc5.c
+++ b/src/nrsc5.c
@@ -214,6 +214,11 @@ static void nrsc5_init(nrsc5_t *st)
     pthread_create(&st->worker, NULL, worker_thread, st);
 }
 
+NRSC5_API void nrsc5_log_set_level(int level)
+{
+	log_set_level(level);
+}
+
 NRSC5_API void nrsc5_get_version(const char **version)
 {
     *version = GIT_COMMIT_HASH;

--- a/src/private.h
+++ b/src/private.h
@@ -11,6 +11,7 @@
 #include "input.h"
 #include "output.h"
 #include "rtltcp.h"
+#include "log.h"
 
 struct nrsc5_t
 {


### PR DESCRIPTION
Discovered I was unable to set the log level to suppress all the LOG_DEBUG calls generated by the library.  I thought this would be handy for anyone else using the library with their code.