### PR TITLE
Add support for AM

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,8 @@ Replace `32` with `64` if you want a 64-bit build. Once the build is complete, c
        -l log-level                    set log level
                                          (1 = DEBUG, 2 = INFO, 3 = WARN)
        -v                              print the version number and exit
+       --am                            receive AM signals
+                                         (default is FM)
        --dump-aas-files dir-name       dump AAS files
                                          (WARNING: insecure)
        --dump-hdc file-name            dump HDC packets

--- a/include/nrsc5.h
+++ b/include/nrsc5.h
@@ -31,6 +31,12 @@
 #define NRSC5_MIME_TTN_STM_TRAFFIC  0xFF8422D7
 #define NRSC5_MIME_TTN_STM_WEATHER  0xEF042E96
 
+enum
+{
+    NRSC5_MODE_FM,
+    NRSC5_MODE_AM
+};
+
 /*
  * Data types.
  */
@@ -267,6 +273,7 @@ int nrsc5_open_rtltcp(nrsc5_t **, int socket);
 void nrsc5_close(nrsc5_t *);
 void nrsc5_start(nrsc5_t *);
 void nrsc5_stop(nrsc5_t *);
+int nrsc5_set_mode(nrsc5_t *, int mode);
 int nrsc5_set_freq_correction(nrsc5_t *, int ppm_error);
 void nrsc5_get_frequency(nrsc5_t *, float *freq);
 int nrsc5_set_frequency(nrsc5_t *, float freq);

--- a/src/acquire.c
+++ b/src/acquire.c
@@ -21,8 +21,10 @@
 #include "input.h"
 
 #define FILTER_DELAY 15
+#define DECIMATION_FACTOR_FM 2
+#define DECIMATION_FACTOR_AM 32
 
-static float filter_taps[] = {
+static float filter_taps_fm[] = {
     -0.000685643230099231,
     0.005636964458972216,
     0.009015781804919243,
@@ -57,6 +59,41 @@ static float filter_taps[] = {
     0
 };
 
+static float filter_taps_am[] = {
+    -0.00038464731187559664,
+    -0.00021618751634377986,
+    0.0026779419276863337,
+    -0.00029802651260979474,
+    -0.0012626448879018426,
+    -0.0013182522961869836,
+    -0.012252614833414555,
+    0.015980124473571777,
+    0.037112727761268616,
+    -0.05451361835002899,
+    -0.05804193392395973,
+    0.11320608854293823,
+    0.055298302322626114,
+    -0.16878043115139008,
+    -0.022917453199625015,
+    0.19178225100040436,
+    -0.022917453199625015,
+    -0.16878043115139008,
+    0.055298302322626114,
+    0.11320608854293823,
+    -0.05804193392395973,
+    -0.05451361835002899,
+    0.037112727761268616,
+    0.015980124473571777,
+    -0.012252614833414555,
+    -0.0013182522961869836,
+    -0.0012626448879018426,
+    -0.00029802651260979474,
+    0.0026779419276863337,
+    -0.00021618751634377986,
+    -0.00038464731187559664,
+    0
+};
+
 void acquire_process(acquire_t *st)
 {
     float complex max_v = 0, phase_increment;
@@ -64,12 +101,12 @@ void acquire_process(acquire_t *st)
     int samperr = 0;
     unsigned int i, j, keep;
 
-    if (st->idx != FFTCP * (ACQUIRE_SYMBOLS + 1))
+    if (st->idx != st->fftcp * (ACQUIRE_SYMBOLS + 1))
         return;
 
     if (st->input->sync_state == SYNC_STATE_FINE)
     {
-        samperr = FFTCP / 2 + st->input->sync.samperr;
+        samperr = st->fftcp / 2 + st->input->sync.samperr;
         st->input->sync.samperr = 0;
 
         angle_diff = -st->input->sync.angle;
@@ -80,33 +117,33 @@ void acquire_process(acquire_t *st)
     else
     {
         cint16_t y;
-        for (i = 0; i < FFTCP * (ACQUIRE_SYMBOLS + 1); i++)
+        for (i = 0; i < st->fftcp * (ACQUIRE_SYMBOLS + 1); i++)
         {
-            fir_q15_execute(st->filter, &st->in_buffer[i], &y);
-            st->buffer[i] = cq15_to_cf_conj(y);
+            fir_q15_execute((st->mode == NRSC5_MODE_FM) ? st->filter_fm : st->filter_am, &st->in_buffer[i], &y);
+            st->buffer[i] = (st->mode == NRSC5_MODE_FM) ? cq15_to_cf_conj(y) : cq15_to_cf(y);
         }
 
-        memset(st->sums, 0, sizeof(float complex) * FFTCP);
-        for (i = 0; i < FFTCP; ++i)
+        memset(st->sums, 0, sizeof(float complex) * st->fftcp);
+        for (i = 0; i < st->fftcp; ++i)
         {
             for (j = 0; j < ACQUIRE_SYMBOLS; ++j)
-                st->sums[i] += st->buffer[i + j * FFTCP] * conjf(st->buffer[i + j * FFTCP + FFT]);
+                st->sums[i] += st->buffer[i + j * st->fftcp] * conjf(st->buffer[i + j * st->fftcp + st->fft]);
         }
 
-        for (i = 0; i < FFTCP; ++i)
+        for (i = 0; i < st->fftcp; ++i)
         {
             float mag;
             float complex v = 0;
 
-            for (j = 0; j < CP; ++j)
-                v += st->sums[(i + j) % FFTCP] * st->shape[j] * st->shape[j + FFT];
+            for (j = 0; j < st->cp; ++j)
+                v += st->sums[(i + j) % st->fftcp] * st->shape[j] * st->shape[j + st->fft];
 
             mag = normf(v);
             if (mag > max_mag)
             {
                 max_mag = mag;
                 max_v = v;
-                samperr = (i + FFTCP - FILTER_DELAY) % FFTCP;
+                samperr = (i + st->fftcp - FILTER_DELAY) % st->fftcp;
             }
         }
 
@@ -117,38 +154,106 @@ void acquire_process(acquire_t *st)
         input_set_sync_state(st->input, SYNC_STATE_COARSE);
     }
 
-    for (i = 0; i < FFTCP * (ACQUIRE_SYMBOLS + 1); i++)
-        st->buffer[i] = cq15_to_cf_conj(st->in_buffer[i]);
+    for (i = 0; i < st->fftcp * (ACQUIRE_SYMBOLS + 1); i++)
+        st->buffer[i] = (st->mode == NRSC5_MODE_FM) ? cq15_to_cf_conj(st->in_buffer[i]) : cq15_to_cf(st->in_buffer[i]);
 
-    sync_adjust(&st->input->sync, FFTCP / 2 - samperr);
+    sync_adjust(&st->input->sync, st->fftcp / 2 - samperr);
     angle -= 2 * M_PI * st->cfo;
 
-    st->phase *= cexpf(-(FFTCP / 2 - samperr) * angle / FFT * I);
+    st->phase *= cexpf(-(st->fftcp / 2 - samperr) * angle / st->fft * I);
 
-    phase_increment = cexpf(angle / FFT * I);
+    phase_increment = cexpf(angle / st->fft * I);
+
+    if (st->mode == NRSC5_MODE_AM)
+    {
+        float y, sum_y = 0, sum_xy = 0, sum_x2 = 0;
+        float complex last_carrier;
+        float complex temp_phase = st->phase;
+        float mag_sums[FFT_AM] = {0};
+
+        for (i = 0; i < ACQUIRE_SYMBOLS; ++i)
+        {
+            int offset = (st->mode == NRSC5_MODE_FM) ? 0 : (FFT_AM - CP_AM) / 2;
+            for (int j = 0; j < st->fftcp; ++j)
+            {
+                float complex sample = temp_phase * st->buffer[i * st->fftcp + j + samperr];
+                if (j < st->cp)
+                    st->fftin[(j + offset) % st->fft] = st->shape[j] * sample;
+                else if (j < st->fft)
+                    st->fftin[(j + offset) % st->fft] = sample;
+                else
+                    st->fftin[(j + offset) % st->fft] += st->shape[j] * sample;
+
+                temp_phase *= phase_increment;
+            }
+            temp_phase /= cabsf(temp_phase);
+
+            fftwf_execute((st->mode == NRSC5_MODE_FM) ? st->fft_plan_fm : st->fft_plan_am);
+            fftshift(st->fftout, st->fft);
+
+            float x = st->fftcp * (i - (float) (ACQUIRE_SYMBOLS - 1) / 2);
+            if (i == 0)
+                y = cargf(st->fftout[CENTER_AM]);
+            else
+                y += cargf(st->fftout[CENTER_AM] / last_carrier);
+            last_carrier = st->fftout[CENTER_AM];
+
+            sum_y += y;
+            sum_xy += x * y;
+            sum_x2 += x * x;
+
+            if (st->input->sync_state != SYNC_STATE_FINE)
+            {
+                for (int j = CENTER_AM - PIDS_2_INDEX_AM; j <= CENTER_AM + PIDS_2_INDEX_AM; j++)
+                {
+                    mag_sums[j] += cabsf(st->fftout[j]);
+                }
+            }
+        }
+
+        if (st->input->sync_state != SYNC_STATE_FINE)
+        {
+            float max_mag = -1.0f;
+            int max_index = -1;
+            for (int j = CENTER_AM - PIDS_2_INDEX_AM; j <= CENTER_AM + PIDS_2_INDEX_AM; j++)
+            {
+                if (mag_sums[j] > max_mag)
+                {
+                    max_mag = mag_sums[j];
+                    max_index = j;
+                }
+            }
+            acquire_cfo_adjust(st, max_index - CENTER_AM);
+        }
+
+        phase_increment *= cexpf(-sum_xy / sum_x2 * I);
+        // TODO: Investigate why 0.06 is needed below
+        st->phase *= cexpf((-sum_y / ACQUIRE_SYMBOLS + (sum_xy / sum_x2)*(ACQUIRE_SYMBOLS)*st->fftcp/2 - 0.06) * I);
+    }
+
     for (i = 0; i < ACQUIRE_SYMBOLS; ++i)
     {
-        int j;
-        for (j = 0; j < FFTCP; ++j)
+        int offset = (st->mode == NRSC5_MODE_FM) ? 0 : (FFT_AM - CP_AM) / 2;
+        for (int j = 0; j < st->fftcp; ++j)
         {
-            float complex sample = st->phase * st->buffer[i * FFTCP + j + samperr];
-            if (j < CP)
-                st->fftin[j] = st->shape[j] * sample;
-            else if (j < FFT)
-                st->fftin[j] = sample;
+            float complex sample = st->phase * st->buffer[i * st->fftcp + j + samperr];
+            if (j < st->cp)
+                st->fftin[(j + offset) % st->fft] = st->shape[j] * sample;
+            else if (j < st->fft)
+                st->fftin[(j + offset) % st->fft] = sample;
             else
-                st->fftin[j - FFT] += st->shape[j] * sample;
+                st->fftin[(j + offset) % st->fft] += st->shape[j] * sample;
 
             st->phase *= phase_increment;
         }
         st->phase /= cabsf(st->phase);
 
-        fftwf_execute(st->fft);
-        fftshift(st->fftout, FFT);
+        fftwf_execute((st->mode == NRSC5_MODE_FM) ? st->fft_plan_fm : st->fft_plan_am);
+        fftshift(st->fftout, st->fft);
         sync_push(&st->input->sync, st->fftout);
     }
 
-    keep = FFTCP + (FFTCP / 2 - samperr);
+    keep = st->fftcp + (st->fftcp / 2 - samperr);
     memmove(&st->in_buffer[0], &st->in_buffer[st->idx - keep], sizeof(cint16_t) * keep);
     st->idx = keep;
 }
@@ -161,14 +266,15 @@ void acquire_cfo_adjust(acquire_t *st, int cfo)
         return;
 
     st->cfo += cfo;
-    hz = (float) st->cfo * SAMPLE_RATE / 2 / FFT;
+    hz = (float) st->cfo * SAMPLE_RATE / st->fft;
+    hz /= (st->mode == NRSC5_MODE_FM ? DECIMATION_FACTOR_FM : DECIMATION_FACTOR_AM);
 
     log_info("CFO: %f Hz", hz);
 }
 
 unsigned int acquire_push(acquire_t *st, cint16_t *buf, unsigned int length)
 {
-    unsigned int needed = FFTCP - st->idx % FFTCP;
+    unsigned int needed = st->fftcp - st->idx % st->fftcp;
 
     if (length < needed)
         return 0;
@@ -181,7 +287,8 @@ unsigned int acquire_push(acquire_t *st, cint16_t *buf, unsigned int length)
 
 void acquire_reset(acquire_t *st)
 {
-    firdecim_q15_reset(st->filter);
+    firdecim_q15_reset(st->filter_fm);
+    firdecim_q15_reset(st->filter_am);
     st->idx = 0;
     st->prev_angle = 0;
     st->phase = 1;
@@ -192,26 +299,70 @@ void acquire_init(acquire_t *st, input_t *input)
 {
     int i;
 
-    st->input = input;
-    st->filter = firdecim_q15_create(filter_taps, sizeof(filter_taps) / sizeof(filter_taps[0]));
-    st->fft = fftwf_plan_dft_1d(FFT, st->fftin, st->fftout, FFTW_FORWARD, 0);
+    st->mode = NRSC5_MODE_FM;
+    st->fft = FFT_FM;
+    st->fftcp = FFTCP_FM;
+    st->cp = CP_FM;
 
-    for (i = 0; i < FFTCP; ++i)
+    st->input = input;
+
+    st->filter_fm = firdecim_q15_create(filter_taps_fm, sizeof(filter_taps_fm) / sizeof(filter_taps_fm[0]));
+    st->filter_am = firdecim_q15_create(filter_taps_am, sizeof(filter_taps_am) / sizeof(filter_taps_am[0]));
+
+    st->fft_plan_fm = fftwf_plan_dft_1d(FFT_FM, st->fftin, st->fftout, FFTW_FORWARD, 0);
+    st->fft_plan_am = fftwf_plan_dft_1d(FFT_AM, st->fftin, st->fftout, FFTW_FORWARD, 0);
+
+    for (i = 0; i < FFTCP_FM; ++i)
     {
-        // Pulse shaping window function
-        if (i < CP)
-            st->shape[i] = sinf(M_PI / 2 * i / CP);
-        else if (i < FFT)
-            st->shape[i] = 1;
+        // Pulse shaping window function for FM
+        if (i < CP_FM)
+            st->shape_fm[i] = sinf(M_PI / 2 * i / CP_FM);
+        else if (i < FFT_FM)
+            st->shape_fm[i] = 1;
         else
-            st->shape[i] = cosf(M_PI / 2 * (i - FFT) / CP);
+            st->shape_fm[i] = cosf(M_PI / 2 * (i - FFT_FM) / CP_FM);
     }
+
+    for (i = 0; i < FFTCP_AM; ++i)
+    {
+        // Pulse shaping window function for AM
+        if (i < CP_AM)
+            st->shape_am[i] = sinf(M_PI / 2 * i / CP_AM);
+        else if (i < FFT_AM)
+            st->shape_am[i] = 1;
+        else
+            st->shape_am[i] = cosf(M_PI / 2 * (i - FFT_AM) / CP_AM);
+    }
+
+    st->shape = st->shape_fm;
 
     acquire_reset(st);
 }
 
+void acquire_set_mode(acquire_t *st, int mode)
+{
+    st->mode = mode;
+
+    if (st->mode == NRSC5_MODE_FM)
+    {
+        st->fft = FFT_FM;
+        st->fftcp = FFTCP_FM;
+        st->cp = CP_FM;
+        st->shape = st->shape_fm;
+    }
+    else
+    {
+        st->fft = FFT_AM;
+        st->fftcp = FFTCP_AM;
+        st->cp = CP_AM;
+        st->shape = st->shape_am;
+    }
+}
+
 void acquire_free(acquire_t *st)
 {
-    firdecim_q15_free(st->filter);
-    fftwf_destroy_plan(st->fft);
+    firdecim_q15_free(st->filter_fm);
+    firdecim_q15_free(st->filter_am);
+    fftwf_destroy_plan(st->fft_plan_fm);
+    fftwf_destroy_plan(st->fft_plan_am);
 }

--- a/src/acquire.h
+++ b/src/acquire.h
@@ -7,19 +7,28 @@
 typedef struct
 {
     struct input_t *input;
-    firdecim_q15 filter;
-    cint16_t in_buffer[FFTCP * (ACQUIRE_SYMBOLS + 1)];
-    float complex buffer[FFTCP * (ACQUIRE_SYMBOLS + 1)];
-    float complex sums[FFTCP];
-    float complex fftin[FFT];
-    float complex fftout[FFT];
-    float shape[FFTCP];
-    fftwf_plan fft;
+    firdecim_q15 filter_fm;
+    firdecim_q15 filter_am;
+    cint16_t in_buffer[FFTCP_FM * (ACQUIRE_SYMBOLS + 1)];
+    float complex buffer[FFTCP_FM * (ACQUIRE_SYMBOLS + 1)];
+    float complex sums[FFTCP_FM];
+    float complex fftin[FFT_FM];
+    float complex fftout[FFT_FM];
+    float *shape;
+    float shape_fm[FFTCP_FM];
+    float shape_am[FFTCP_AM];
+    fftwf_plan fft_plan_fm;
+    fftwf_plan fft_plan_am;
 
     unsigned int idx;
     float prev_angle;
     float complex phase;
     int cfo;
+
+    int mode;
+    int fft;
+    int fftcp;
+    int cp;
 } acquire_t;
 
 void acquire_process(acquire_t *st);
@@ -27,4 +36,5 @@ void acquire_cfo_adjust(acquire_t *st, int cfo);
 unsigned int acquire_push(acquire_t *st, cint16_t *buf, unsigned int length);
 void acquire_reset(acquire_t *st);
 void acquire_init(acquire_t *st, struct input_t *input);
+void acquire_set_mode(acquire_t *st, int mode);
 void acquire_free(acquire_t *st);

--- a/src/conv.h
+++ b/src/conv.h
@@ -31,5 +31,8 @@ struct lte_conv_code {
 int nrsc5_conv_decode_p1(const int8_t *in, uint8_t *out);
 int nrsc5_conv_decode_pids(const int8_t *in, uint8_t *out);
 int nrsc5_conv_decode_p3(const int8_t *in, uint8_t *out);
+int nrsc5_conv_decode_e1(const int8_t *in, uint8_t *out, int len);
+int nrsc5_conv_decode_e2(const int8_t *in, uint8_t *out, int len);
+int nrsc5_conv_decode_e3(const int8_t *in, uint8_t *out, int len);
 
 #endif /* _CONV_H_ */

--- a/src/conv_gen.h
+++ b/src/conv_gen.h
@@ -100,6 +100,7 @@ static void _gen_path_metrics(int num_states, int16_t *sums,
 	memcpy(sums, new_sums, num_states * sizeof(int16_t));
 }
 
+#if !defined(HAVE_SSE3) && !defined(HAVE_NEON)
 static void gen_metrics_k7_n3(const int8_t *seq, const int16_t *out,
 		       int16_t *sums, int16_t *paths, int norm)
 {
@@ -107,5 +108,16 @@ static void gen_metrics_k7_n3(const int8_t *seq, const int16_t *out,
 
 	_gen_branch_metrics_n3(64, seq, out, metrics);
 	_gen_path_metrics(64, sums, metrics, paths, norm);
+
+}
+#endif
+
+static void gen_metrics_k9_n3(const int8_t *seq, const int16_t *out,
+		       int16_t *sums, int16_t *paths, int norm)
+{
+	int16_t metrics[128];
+
+	_gen_branch_metrics_n3(256, seq, out, metrics);
+	_gen_path_metrics(256, sums, metrics, paths, norm);
 
 }

--- a/src/decode.c
+++ b/src/decode.c
@@ -21,34 +21,162 @@
 #include "pids.h"
 #include "private.h"
 
-// calculate channel bit error rate by re-encoding and comparing to the input
-static float calc_cber(int8_t *coded, uint8_t *decoded)
+/* 1012s.pdf figure 10-4 */
+static int bl_delay[] = { 2, 1, 5 };
+static int ml_delay[] = { 11, 6, 7 };
+static int bu_delay[] = { 10, 8, 9 };
+static int mu_delay[] = { 4, 3, 0 };
+static int el_delay[] = { 0, 1 };
+static int eu_delay[] = { 2, 3, 5, 4 };
+
+/* 1012s.pdf figure 10-5 */
+static int pids_il_delay[] = { 0, 1, 12, 13, 6, 5, 18, 17, 11, 7, 23, 19 };
+static int pids_iu_delay[] = { 2, 4, 14, 16, 3, 8, 15, 20, 9, 10, 21, 22 };
+
+static int bit_map(unsigned char matrix[PARTITION_WIDTH_AM * BLKSZ * 8], int b, int k, int p)
 {
-    uint8_t r = 0;
+    int col = (9*k) % 25;
+    int row = (11*col + 16*(k/25) + 11*(k/50)) % 32;
+    return (matrix[PARTITION_WIDTH_AM * (b*BLKSZ + row) + col] >> p) & 1;
+}
+
+static void interleaver_ma1(decode_t *st)
+{
+    int b, k, p;
+    for (int n = 0; n < 18000; n++)
+    {
+        b = n/2250;
+        k = (n + n/750 + 1) % 750;
+        p = n % 3;
+        st->bl[n] = bit_map(st->buffer_pl, b, k, p);
+
+        b = (3*n + 3) % 8;
+        k = (n + n/3000 + 3) % 750;
+        p = 3 + (n % 3);
+        st->ml[DIVERSITY_DELAY_AM + n] = bit_map(st->buffer_pl, b, k, p);
+
+        b = n/2250;
+        k = (n + n/750) % 750;
+        p = n % 3;
+        st->bu[n] = bit_map(st->buffer_pu, b, k, p);
+
+        b = (3*n) % 8;
+        k = (n + n/3000 + 2) % 750;
+        p = 3 + (n % 3);
+        st->mu[DIVERSITY_DELAY_AM + n] = bit_map(st->buffer_pu, b, k, p);
+    }
+    for (int n = 0; n < 12000; n++)
+    {
+        b = (3*n + n/3000) % 8;
+        k = (n + (n/6000)) % 750;
+        p = n % 2;
+        st->el[n] = bit_map(st->buffer_t, b, k, p);
+    }
+    for (int n = 0; n < 24000; n++)
+    {
+        b = (3*n + n/3000 + 2*(n/12000)) % 8;
+        k = (n + (n/6000)) % 750;
+        p = n % 4;
+        st->eu[n] = bit_map(st->buffer_s, b, k, p);
+    }
+
+    for (int i = 0; i < 6000; i++)
+    {
+        for (int j = 0; j < 3; j++)
+        {
+            st->p1_am[i*12 + bl_delay[j]] = st->bl[i*3 + j];
+            st->p1_am[i*12 + ml_delay[j]] = st->ml[i*3 + j];
+            st->p1_am[i*12 + bu_delay[j]] = st->bu[i*3 + j];
+            st->p1_am[i*12 + mu_delay[j]] = st->mu[i*3 + j];
+        }
+        for (int j = 0; j < 2; j++)
+        {
+            st->p3_am[i*6 + el_delay[j]] = st->el[i*2 + j];
+        }
+        for (int j = 0; j < 4; j++)
+        {
+            st->p3_am[i*6 + eu_delay[j]] = st->eu[i*4 + j];
+        }
+    }
+
+    memmove(st->ml, st->ml + 18000, DIVERSITY_DELAY_AM);
+    memmove(st->mu, st->mu + 18000, DIVERSITY_DELAY_AM);
+
+    int offset = 0;
+    for (int i = 0; i < 8 * P1_FRAME_LEN_AM * 3; i++)
+    {
+        switch (i % 15)
+        {
+        case 1:
+        case 4:
+        case 7:
+            st->viterbi_p1_am[i] = 0;
+            break;
+        default:
+            st->viterbi_p1_am[i] = st->p1_am[offset++] ? 1 : -1;
+        }
+    }
+
+    offset = 0;
+    for (int i = 0; i < P3_FRAME_LEN_AM * 3; i++)
+    {
+        switch (i % 6)
+        {
+        case 1:
+        case 4:
+        case 5:
+            st->viterbi_p3_am[i] = 0;
+            break;
+        default:
+            st->viterbi_p3_am[i] = st->p3_am[offset++] ? 1 : -1;
+        }
+    }
+}
+
+// calculate number of bit errors by re-encoding and comparing to the input
+static int bit_errors(int8_t *coded, uint8_t *decoded, int k, int frame_len,
+                      unsigned int g1, unsigned int g2, unsigned int g3,
+                      uint8_t *puncture, int puncture_len)
+{
+    uint16_t r = 0;
     unsigned int i, j, errors = 0;
 
     // tail biting
-    for (i = 0; i < 6; i++)
-        r = (r >> 1) | (decoded[P1_FRAME_LEN - 6 + i] << 6);
+    for (i = 0; i < (k-1); i++)
+        r = (r >> 1) | (decoded[frame_len - (k-1) + i] << (k-1));
 
-    for (i = 0, j = 0; i < P1_FRAME_LEN; i++)
+    for (i = 0, j = 0; i < frame_len; i++, j += 3)
     {
         // shift in new bit
-        r = (r >> 1) | (decoded[i] << 6);
+        r = (r >> 1) | (decoded[i] << (k-1));
 
-        if ((coded[j++] > 0) != __builtin_parity(r & 0133))
+        if (puncture[j % puncture_len] && ((coded[j] > 0) != __builtin_parity(r & g1)))
             errors++;
-
-        if ((coded[j++] > 0) != __builtin_parity(r & 0171))
+        if (puncture[(j+1) % puncture_len] && ((coded[j+1] > 0) != __builtin_parity(r & g2)))
             errors++;
-
-        if ((j % 6) == 5)
-            j++;
-        else if ((coded[j++] > 0) != __builtin_parity(r & 0165))
+        if (puncture[(j+2) % puncture_len] && ((coded[j+2] > 0) != __builtin_parity(r & g3)))
             errors++;
     }
 
-    return (float) errors / P1_FRAME_LEN_ENCODED;
+    return errors;
+}
+
+static int bit_errors_p1_fm(int8_t *coded, uint8_t *decoded)
+{
+    uint8_t puncture[] = {1, 1, 1, 1, 1, 0};
+    return bit_errors(coded, decoded, 7, P1_FRAME_LEN_FM, 0133, 0171, 0165, puncture, 6);
+}
+
+static int bit_errors_p1_am(int8_t *coded, uint8_t *decoded)
+{
+    uint8_t puncture[] = {1, 0, 1, 1, 0, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1};
+    return bit_errors(coded, decoded, 9, P1_FRAME_LEN_AM, 0561, 0657, 0711, puncture, 15);
+}
+
+static int bit_errors_p3_am(int8_t *coded, uint8_t *decoded)
+{
+    uint8_t puncture[] = {1, 0, 1, 1, 0, 0};
+    return bit_errors(coded, decoded, 9, P3_FRAME_LEN_AM, 0561, 0753, 0711, puncture, 6);
 }
 
 static void descramble(uint8_t *buf, unsigned int length)
@@ -76,7 +204,7 @@ void decode_process_p1(decode_t *st)
         11, 3, 19, 7, 15, 9, 17, 1, 13, 5
     };
     unsigned int i, out = 0;
-    for (i = 0; i < P1_FRAME_LEN_ENCODED; i++)
+    for (i = 0; i < P1_FRAME_LEN_ENCODED_FM; i++)
     {
         int partition = v[i % J];
         int block = ((i / J) + (partition * 7)) % B;
@@ -89,9 +217,9 @@ void decode_process_p1(decode_t *st)
     }
 
     nrsc5_conv_decode_p1(st->viterbi_p1, st->scrambler_p1);
-    nrsc5_report_ber(st->input->radio, calc_cber(st->viterbi_p1, st->scrambler_p1));
-    descramble(st->scrambler_p1, P1_FRAME_LEN);
-    frame_push(&st->input->frame, st->scrambler_p1, P1_FRAME_LEN);
+    nrsc5_report_ber(st->input->radio, (float) bit_errors_p1_fm(st->viterbi_p1, st->scrambler_p1) / P1_FRAME_LEN_ENCODED_FM);
+    descramble(st->scrambler_p1, P1_FRAME_LEN_FM);
+    frame_push(&st->input->frame, st->scrambler_p1, P1_FRAME_LEN_FM);
 }
 
 void decode_process_pids(decode_t *st)
@@ -102,11 +230,11 @@ void decode_process_pids(decode_t *st)
         11, 3, 19, 7, 15, 9, 17, 1, 13, 5
     };
     unsigned int i, out = 0;
-    for (i = 0; i < PIDS_FRAME_LEN_ENCODED; i++)
+    for (i = 0; i < PIDS_FRAME_LEN_ENCODED_FM; i++)
     {
         int partition = v[i % J];
         int block = decode_get_block(st) - 1;
-        int k = ((i / J) % (PIDS_FRAME_LEN_ENCODED / J)) + (P1_FRAME_LEN_ENCODED / (J * B));
+        int k = ((i / J) % (PIDS_FRAME_LEN_ENCODED_FM / J)) + (P1_FRAME_LEN_ENCODED_FM / (J * B));
         int row = (k * 11) % 32;
         int column = (k * 11 + k / (32*9)) % C;
         st->viterbi_pids[out++] = st->buffer_pm[(block * 32 + row) * 720 + partition * C + column];
@@ -125,7 +253,7 @@ void decode_process_p3(decode_t *st)
     const unsigned int bk_bits = 32 * C;
     const unsigned int bk_adj = 32 * C - 1;
     unsigned int i, out = 0;
-    for (i = 0; i < P3_FRAME_LEN_ENCODED; i++)
+    for (i = 0; i < P3_FRAME_LEN_ENCODED_FM; i++)
     {
         int partition = ((st->i_p3 + 2 * (M / 4)) / M) % J;
         unsigned int pti = (st->pt_p3[partition])++;
@@ -142,8 +270,8 @@ void decode_process_p3(decode_t *st)
     if (st->ready_p3)
     {
         nrsc5_conv_decode_p3(st->viterbi_p3, st->scrambler_p3);
-        descramble(st->scrambler_p3, P3_FRAME_LEN);
-        frame_push(&st->input->frame, st->scrambler_p3, P3_FRAME_LEN);
+        descramble(st->scrambler_p3, P3_FRAME_LEN_FM);
+        frame_push(&st->input->frame, st->scrambler_p3, P3_FRAME_LEN_FM);
     }
     if (st->i_p3 == N)
     {
@@ -152,10 +280,71 @@ void decode_process_p3(decode_t *st)
     }
 }
 
+void decode_process_pids_am(decode_t *st)
+{
+    uint8_t il[120], iu[120];
+
+    /* 1012s.pdf section 10.4 */
+    for (int n = 0; n < 120; n++) {
+        int k, p, row;
+
+        p = n % 4;
+
+        k = (n + (n/60) + 11) % 30;
+        row = (11 * (k + (k/15)) + 3) % 32;
+        il[n] = (st->buffer_pids_am[row*2] >> p) & 1;
+
+        k = (n + (n/60)) % 30;
+        row = (11 * (k + (k/15)) + 3) % 32;
+        iu[n] = (st->buffer_pids_am[row*2 + 1] >> p) & 1;
+    }
+
+    /* 1012s.pdf figure 10-5 */
+    for (int i = 0; i < 10; i++) {
+      for (int j = 0; j < 12; j++) {
+        st->viterbi_pids[i*24 + pids_il_delay[j]] = il[i*12 + j] ? 1 : -1;
+        st->viterbi_pids[i*24 + pids_iu_delay[j]] = iu[i*12 + j] ? 1 : -1;
+      }
+    }
+
+    nrsc5_conv_decode_e3(st->viterbi_pids, st->scrambler_pids, PIDS_FRAME_LEN);
+    descramble(st->scrambler_pids, PIDS_FRAME_LEN);
+    pids_frame_push(&st->pids, st->scrambler_pids);
+}
+
+void decode_process_p1_p3_am(decode_t *st)
+{
+    int total_errors = 0;
+
+    interleaver_ma1(st);
+
+    if (st->am_diversity_wait > 0)
+    {
+        st->am_diversity_wait--;
+        return;
+    }
+
+    for (int block = 0; block < 8; block++)
+    {
+        nrsc5_conv_decode_e1(st->viterbi_p1_am + (block * P1_FRAME_LEN_AM * 3), st->scrambler_p1_am, P1_FRAME_LEN_AM);
+        total_errors += bit_errors_p1_am(st->viterbi_p1_am + (block * P1_FRAME_LEN_AM * 3), st->scrambler_p1_am);
+        descramble(st->scrambler_p1_am, P1_FRAME_LEN_AM);
+        frame_push(&st->input->frame, st->scrambler_p1_am, P1_FRAME_LEN_AM);
+    }
+    nrsc5_conv_decode_e2(st->viterbi_p3_am, st->scrambler_p3_am, P3_FRAME_LEN_AM);
+    total_errors += bit_errors_p3_am(st->viterbi_p3_am, st->scrambler_p3_am);
+    descramble(st->scrambler_p3_am, P3_FRAME_LEN_AM);
+    frame_push(&st->input->frame, st->scrambler_p3_am, P3_FRAME_LEN_AM);
+
+    nrsc5_report_ber(st->input->radio, (float) total_errors / (8 * P1_FRAME_LEN_ENCODED_AM + P3_FRAME_LEN_ENCODED_AM));
+}
+
 void decode_reset(decode_t *st)
 {
     st->idx_pm = 0;
     st->idx_px1 = 0;
+    st->idx_pu_pl_s_t = 0;
+    st->am_diversity_wait = 3;
     st->i_p3 = 0;
     st->ready_p3 = 0;
     memset(st->pt_p3, 0, sizeof(unsigned int) * 4);

--- a/src/decode.h
+++ b/src/decode.h
@@ -4,6 +4,8 @@
 #include "defines.h"
 #include "pids.h"
 
+#define DIVERSITY_DELAY_AM (18000 * 3)
+
 typedef struct
 {
     struct input_t *input;
@@ -11,17 +13,39 @@ typedef struct
     unsigned int idx_pm;
     int8_t buffer_px1[144 * BLKSZ * 2];
     unsigned int idx_px1;
+    uint8_t buffer_pids_am[2 * BLKSZ];
+    unsigned int idx_pids_am;
+    uint8_t buffer_pu[PARTITION_WIDTH_AM * BLKSZ * 8];
+    uint8_t buffer_pl[PARTITION_WIDTH_AM * BLKSZ * 8];
+    uint8_t buffer_s[PARTITION_WIDTH_AM * BLKSZ * 8];
+    uint8_t buffer_t[PARTITION_WIDTH_AM * BLKSZ * 8];
+    unsigned int idx_pu_pl_s_t;
+    unsigned int am_diversity_wait;
 
-    int8_t viterbi_p1[P1_FRAME_LEN * 3];
-    uint8_t scrambler_p1[P1_FRAME_LEN];
+    uint8_t bl[18000];
+    uint8_t bu[18000];
+    uint8_t ml[18000 + DIVERSITY_DELAY_AM];
+    uint8_t mu[18000 + DIVERSITY_DELAY_AM];
+    uint8_t el[12000];
+    uint8_t eu[24000];
+
+    int8_t viterbi_p1[P1_FRAME_LEN_FM * 3];
+    uint8_t scrambler_p1[P1_FRAME_LEN_FM];
     int8_t viterbi_pids[PIDS_FRAME_LEN * 3];
     uint8_t scrambler_pids[PIDS_FRAME_LEN];
-    int8_t internal_p3[P3_FRAME_LEN * 32];
+    int8_t internal_p3[P3_FRAME_LEN_FM * 32];
     unsigned int i_p3;
     int ready_p3;
     unsigned int pt_p3[4];
-    int8_t viterbi_p3[P3_FRAME_LEN * 3];
-    uint8_t scrambler_p3[P3_FRAME_LEN];
+    int8_t viterbi_p3[P3_FRAME_LEN_FM * 3];
+    uint8_t scrambler_p3[P3_FRAME_LEN_FM];
+
+    uint8_t p1_am[8 * P1_FRAME_LEN_ENCODED_AM];
+    int8_t viterbi_p1_am[8 * P1_FRAME_LEN_AM * 3];
+    uint8_t scrambler_p1_am[P1_FRAME_LEN_AM];
+    uint8_t p3_am[P3_FRAME_LEN_ENCODED_AM];
+    int8_t viterbi_p3_am[P3_FRAME_LEN_AM * 3];
+    uint8_t scrambler_p3_am[P3_FRAME_LEN_AM];
 
     pids_t pids;
 } decode_t;
@@ -29,6 +53,8 @@ typedef struct
 void decode_process_p1(decode_t *st);
 void decode_process_pids(decode_t *st);
 void decode_process_p3(decode_t *st);
+void decode_process_pids_am(decode_t *st);
+void decode_process_p1_p3_am(decode_t *st);
 static inline unsigned int decode_get_block(decode_t *st)
 {
     return st->idx_pm / (720 * BLKSZ);
@@ -53,6 +79,28 @@ static inline void decode_push_px1(decode_t *st, int8_t sbit)
     {
         decode_process_p3(st);
         st->idx_px1 = 0;
+    }
+}
+static inline void decode_push_pids(decode_t *st, uint8_t sym)
+{
+    st->buffer_pids_am[st->idx_pids_am++] = sym;
+    if (st->idx_pids_am == 2 * BLKSZ)
+    {
+        decode_process_pids_am(st);
+        st->idx_pids_am = 0;
+    }
+}
+static inline void decode_push_pl_pu_s_t(decode_t *st, uint8_t sym_pl, uint8_t sym_pu, uint8_t sym_s, uint8_t sym_t)
+{
+    st->buffer_pl[st->idx_pu_pl_s_t] = sym_pl;
+    st->buffer_pu[st->idx_pu_pl_s_t] = sym_pu;
+    st->buffer_s[st->idx_pu_pl_s_t] = sym_s;
+    st->buffer_t[st->idx_pu_pl_s_t] = sym_t;
+    st->idx_pu_pl_s_t++;
+    if (st->idx_pu_pl_s_t == PARTITION_WIDTH_AM * BLKSZ * 8)
+    {
+        decode_process_p1_p3_am(st);
+        st->idx_pu_pl_s_t = 0;
     }
 }
 void decode_reset(decode_t *st);

--- a/src/defines.h
+++ b/src/defines.h
@@ -13,36 +13,60 @@
 // Sample rate before decimation
 #define SAMPLE_RATE 1488375
 // FFT length in samples
-#define FFT 2048
+#define FFT_FM 2048
+#define FFT_AM 256
 // cyclic preflex length in samples
-#define CP 112
-#define FFTCP (FFT + CP)
+#define CP_FM 112
+#define CP_AM 14
+#define FFTCP_FM (FFT_FM + CP_FM)
+#define FFTCP_AM (FFT_AM + CP_AM)
 // OFDM symbols per L1 block
 #define BLKSZ 32
 // symbols processed by each invocation of acquire_process
 #define ACQUIRE_SYMBOLS (BLKSZ * 2)
 // index of first lower sideband subcarrier
-#define LB_START ((FFT / 2) - 546)
+#define LB_START ((FFT_FM / 2) - 546)
 // index of last upper sideband subcarrier
-#define UB_END ((FFT / 2) + 546)
+#define UB_END ((FFT_FM / 2) + 546)
+// index of AM carrier
+#define CENTER_AM (FFT_AM / 2)
+// indexes of AM subcarriers
+#define REF_INDEX_AM 1
+#define PIDS_1_INDEX_AM 27
+#define PIDS_2_INDEX_AM 53
+#define TERTIARY_INDEX_AM 2
+#define SECONDARY_INDEX_AM 28
+#define PRIMARY_INDEX_AM 57
+#define MAX_INDEX_AM 81
 // bits per P1 frame
-#define P1_FRAME_LEN 146176
+#define P1_FRAME_LEN_FM 146176
+#define P1_FRAME_LEN_AM 3750
 // bits per encoded P1 frame
-#define P1_FRAME_LEN_ENCODED (P1_FRAME_LEN * 5 / 2)
+#define P1_FRAME_LEN_ENCODED_FM (P1_FRAME_LEN_FM * 5 / 2)
+#define P1_FRAME_LEN_ENCODED_AM (P1_FRAME_LEN_AM * 12 / 5)
 // bits per PIDS frame
 #define PIDS_FRAME_LEN 80
 // bits per encoded PIDS frame
-#define PIDS_FRAME_LEN_ENCODED (PIDS_FRAME_LEN * 5 / 2)
+#define PIDS_FRAME_LEN_ENCODED_FM (PIDS_FRAME_LEN * 5 / 2)
+#define PIDS_FRAME_LEN_ENCODED_AM (PIDS_FRAME_LEN * 3)
 // bits per P3 frame
-#define P3_FRAME_LEN 4608
+#define P3_FRAME_LEN_FM 4608
+#define P3_FRAME_LEN_AM 24000
 // bits per encoded P3 frame
-#define P3_FRAME_LEN_ENCODED (P3_FRAME_LEN * 2)
+#define P3_FRAME_LEN_ENCODED_FM (P3_FRAME_LEN_FM * 2)
+#define P3_FRAME_LEN_ENCODED_AM (P3_FRAME_LEN_AM * 3 / 2)
 // bits per L2 PCI
 #define PCI_LEN 24
 // bytes per L2 PDU (max)
-#define MAX_PDU_LEN ((P1_FRAME_LEN - PCI_LEN) / 8)
+#define MAX_PDU_LEN ((P1_FRAME_LEN_FM - PCI_LEN) / 8)
+// bytes per L2 PDU in P1 frame (AM)
+#define P1_PDU_LEN_AM 466
 // number of programs (max)
 #define MAX_PROGRAMS 8
+// number of streams per program (max)
+#define MAX_STREAMS 4
+// number of subcarriers per AM partition
+#define PARTITION_WIDTH_AM 25
 
 #define U8_F(x) ( (((float)(x)) - 127) / 128 )
 #define U8_Q15(x) ( ((int16_t)(x) - 127) * 64 )
@@ -57,6 +81,11 @@ static inline cint16_t cf_to_cq15(float complex x)
     cq15.r = crealf(x) * 32767.0f;
     cq15.i = cimagf(x) * 32767.0f;
     return cq15;
+}
+
+static inline float complex cq15_to_cf(cint16_t cq15)
+{
+    return CMPLXF((float)cq15.r / 32767.0f, (float)cq15.i / 32767.0f);
 }
 
 static inline float complex cq15_to_cf_conj(cint16_t cq15)

--- a/src/frame.h
+++ b/src/frame.h
@@ -20,8 +20,8 @@ typedef struct
 {
     struct input_t *input;
     uint8_t buffer[MAX_PDU_LEN];
-    uint8_t pdu[MAX_PROGRAMS][0x10000];
-    unsigned int pdu_idx[MAX_PROGRAMS];
+    uint8_t pdu[MAX_PROGRAMS][MAX_STREAMS][0x10000];
+    unsigned int pdu_idx[MAX_PROGRAMS][MAX_STREAMS];
     unsigned int pci;
     unsigned int program;
     uint8_t psd_buf[MAX_PROGRAMS][MAX_AAS_LEN];

--- a/src/input.h
+++ b/src/input.h
@@ -13,7 +13,8 @@
 #include "output.h"
 #include "sync.h"
 
-#define INPUT_BUF_LEN (FFTCP * 512)
+#define INPUT_BUF_LEN (FFTCP_FM * 512)
+#define AM_DECIM_STAGES 5
 
 #define SNR_FFT_COUNT 256
 #define SNR_FFT_LEN 64
@@ -31,9 +32,10 @@ typedef struct input_t
     nrsc5_t *radio;
     output_t *output;
 
-    firdecim_q15 decim;
+    firdecim_q15 decim[AM_DECIM_STAGES];
+    cint16_t stages[AM_DECIM_STAGES][2];
     cint16_t buffer[INPUT_BUF_LEN];
-    unsigned int avail, used, skip;
+    unsigned int avail, used, skip, offset;
     unsigned int sync_state;
 
     fftwf_plan snr_fft;
@@ -51,6 +53,7 @@ typedef struct input_t
 } input_t;
 
 void input_init(input_t *st, nrsc5_t *radio, output_t *output);
+void input_set_mode(input_t *st);
 void input_reset(input_t *st);
 void input_free(input_t *st);
 void input_set_sync_state(input_t *st, unsigned int new_state);
@@ -58,5 +61,5 @@ void input_push_cu8(input_t *st, uint8_t *buf, uint32_t len);
 void input_push_cs16(input_t *st, int16_t *buf, uint32_t len);
 void input_set_snr_callback(input_t *st, input_snr_cb_t cb, void *);
 void input_set_skip(input_t *st, unsigned int skip);
-void input_pdu_push(input_t *st, uint8_t *pdu, unsigned int len, unsigned int program);
+void input_pdu_push(input_t *st, uint8_t *pdu, unsigned int len, unsigned int program, unsigned int stream_id);
 void input_aas_push(input_t *st, uint8_t *psd, unsigned int len);

--- a/src/libnrsc5.map
+++ b/src/libnrsc5.map
@@ -10,6 +10,7 @@ LIBNRSC5_1.0 {
         nrsc5_close;
         nrsc5_start;
         nrsc5_stop;
+        nrsc5_set_mode;
         nrsc5_set_freq_correction;
         nrsc5_get_frequency;
         nrsc5_set_frequency;

--- a/src/libnrsc5.sym
+++ b/src/libnrsc5.sym
@@ -8,6 +8,7 @@ _nrsc5_open_rtltcp
 _nrsc5_close
 _nrsc5_start
 _nrsc5_stop
+_nrsc5_set_mode
 _nrsc5_set_freq_correction
 _nrsc5_get_frequency
 _nrsc5_set_frequency

--- a/src/main.c
+++ b/src/main.c
@@ -52,6 +52,7 @@ typedef struct buffer_t {
 
 typedef struct {
     float freq;
+    int mode;
     float gain;
     unsigned int device_index;
     int ppm_error;
@@ -505,7 +506,7 @@ static void *input_main(void *arg)
 
 static void help(const char *progname)
 {
-    fprintf(stderr, "Usage: %s [-v] [-q] [-l log-level] [-d device-index] [-H rtltcp-host] [-p ppm-error] [-g gain] [-r iq-input] [-w iq-output] [-o wav-output] [--dump-hdc hdc-output] [--dump-aas-files directory] frequency program\n", progname);
+    fprintf(stderr, "Usage: %s [-v] [-q] [--am] [-l log-level] [-d device-index] [-H rtltcp-host] [-p ppm-error] [-g gain] [-r iq-input] [-w iq-output] [-o wav-output] [--dump-hdc hdc-output] [--dump-aas-files directory] frequency program\n", progname);
 }
 
 static int parse_args(state_t *st, int argc, char *argv[])
@@ -513,6 +514,7 @@ static int parse_args(state_t *st, int argc, char *argv[])
     static const struct option long_opts[] = {
         { "dump-aas-files", required_argument, NULL, 1 },
         { "dump-hdc", required_argument, NULL, 2 },
+        { "am", no_argument, NULL, 3 },
         { 0 }
     };
     const char *version = NULL;
@@ -520,6 +522,7 @@ static int parse_args(state_t *st, int argc, char *argv[])
     char *endptr;
     int opt;
 
+    st->mode = NRSC5_MODE_FM;
     st->gain = -1;
     st->ppm_error = INT_MIN;
 
@@ -532,6 +535,9 @@ static int parse_args(state_t *st, int argc, char *argv[])
             break;
         case 2:
             hdc_name = optarg;
+            break;
+        case 3:
+            st->mode = NRSC5_MODE_AM;
             break;
         case 'r':
             st->input_name = strdup(optarg);
@@ -739,6 +745,7 @@ int main(int argc, char *argv[])
         log_fatal("Set frequency failed.");
         return 1;
     }
+    nrsc5_set_mode(radio, st->mode);
     if (st->gain >= 0.0f)
         nrsc5_set_gain(radio, st->gain);
     nrsc5_set_callback(radio, callback, st);

--- a/src/nrsc5.c
+++ b/src/nrsc5.c
@@ -203,6 +203,7 @@ static void nrsc5_init(nrsc5_t *st)
     st->auto_gain = 1;
     st->gain = -1;
     st->freq = NRSC5_SCAN_BEGIN;
+    st->mode = NRSC5_MODE_FM;
     st->callback = NULL;
 
     output_init(&st->output, st);
@@ -413,6 +414,17 @@ NRSC5_API void nrsc5_stop(nrsc5_t *st)
     while (st->stopped != st->worker_stopped)
         pthread_cond_wait(&st->worker_cond, &st->worker_mutex);
     pthread_mutex_unlock(&st->worker_mutex);
+}
+
+NRSC5_API int nrsc5_set_mode(nrsc5_t *st, int mode)
+{
+    if (mode == NRSC5_MODE_FM || mode == NRSC5_MODE_AM)
+    {
+        st->mode = mode;
+        input_set_mode(&st->input);
+        return 0;
+    }
+    return 1;
 }
 
 NRSC5_API int nrsc5_set_freq_correction(nrsc5_t *st, int ppm_error)

--- a/src/output.c
+++ b/src/output.c
@@ -26,9 +26,12 @@
 #include "private.h"
 #include "unicode.h"
 
-void output_push(output_t *st, uint8_t *pkt, unsigned int len, unsigned int program)
+void output_push(output_t *st, uint8_t *pkt, unsigned int len, unsigned int program, unsigned int stream_id)
 {
     nrsc5_report_hdc(st->radio, program, pkt, len);
+
+    if (stream_id != 0)
+        return; // TODO: Process enhanced stream
 
 #ifdef USE_FAAD2
     void *buffer;

--- a/src/output.h
+++ b/src/output.h
@@ -110,7 +110,7 @@ typedef struct
     sig_service_t services[MAX_SIG_SERVICES];
 } output_t;
 
-void output_push(output_t *st, uint8_t *pkt, unsigned int len, unsigned int program);
+void output_push(output_t *st, uint8_t *pkt, unsigned int len, unsigned int program, unsigned int stream_id);
 void output_begin(output_t *st);
 void output_reset(output_t *st);
 void output_init(output_t *st, nrsc5_t *);

--- a/src/private.h
+++ b/src/private.h
@@ -19,6 +19,7 @@ struct nrsc5_t
     rtltcp_t *rtltcp;
     uint8_t samples_buf[128 * 256];
     float freq;
+    int mode;
     int gain;
     int auto_gain;
     int auto_gain_snr_ready;

--- a/src/sync.h
+++ b/src/sync.h
@@ -7,18 +7,19 @@
 typedef struct
 {
     struct input_t *input;
-    float complex buffer[FFT][BLKSZ];
-    float phases[FFT][BLKSZ];
+    float complex buffer[FFT_FM][BLKSZ];
+    float phases[FFT_FM][BLKSZ];
     unsigned int idx;
     int psmi;
     int cfo_wait;
+    unsigned int offset_history;
     int samperr;
     float angle;
 
     float alpha;
     float beta;
-    float costas_freq[FFT];
-    float costas_phase[FFT];
+    float costas_freq[FFT_FM];
+    float costas_phase[FFT_FM];
 
     int mer_cnt;
     float error_lb;

--- a/support/cli.py
+++ b/support/cli.py
@@ -12,6 +12,7 @@ import pyaudio
 
 import nrsc5
 
+
 class NRSC5CLI:
     def __init__(self):
         self.radio = nrsc5.NRSC5(lambda evt_type, evt: self.callback(evt_type, evt))
@@ -28,6 +29,7 @@ class NRSC5CLI:
         input_group = parser.add_mutually_exclusive_group()
         parser.add_argument("-v", action="version", version="nrsc5 revision " + self.nrsc5_version)
         parser.add_argument("-q", action="store_true")
+        parser.add_argument("--am", action="store_true")
         parser.add_argument("-l", metavar="log-level", type=int, default=1)
         parser.add_argument("-d", metavar="device-index", type=int, default=0)
         parser.add_argument("-p", metavar="ppm-error", type=int)
@@ -70,6 +72,9 @@ class NRSC5CLI:
             self.radio.set_frequency(self.args.frequency)
             if self.args.g:
                 self.radio.set_gain(self.args.g)
+
+        if self.args.am:
+            self.radio.set_mode(nrsc5.Mode.AM)
 
         if self.args.p is not None:
             self.radio.set_freq_correction(self.args.p)

--- a/support/faad2-hdc-support.patch
+++ b/support/faad2-hdc-support.patch
@@ -1,24 +1,25 @@
-From 176e496b2a5461af122e20054079887b0b3d46a8 Mon Sep 17 00:00:00 2001
-From: Andrew Wesie <awesie@gmail.com>
-Date: Wed, 14 Jun 2017 03:14:18 -0500
+From 63fd6f941c6673501c719cd672892ead21d0413c Mon Sep 17 00:00:00 2001
+From: Clayton Smith <argilo@gmail.com>
+Date: Thu, 6 Aug 2020 00:13:01 -0400
 Subject: [PATCH] Support for HDC variant
 
 ---
- configure.in         |   7 ++
+ configure.in         |   9 ++
  frontend/main.c      |   3 +-
  include/neaacdec.h   |   4 +
  libfaad/bits.c       |   2 +-
  libfaad/bits.h       |   2 +-
- libfaad/common.c     |   5 ++
- libfaad/decoder.c    |  42 +++++++++++
+ libfaad/common.c     |   5 +
+ libfaad/decoder.c    |  42 +++++++++
+ libfaad/sbr_dec.c    |   2 +-
  libfaad/sbr_dec.h    |   4 +
- libfaad/sbr_syntax.c |  12 +++
- libfaad/syntax.c     | 208 +++++++++++++++++++++++++++++++++++++++++++++++++--
+ libfaad/sbr_syntax.c |  16 +++-
+ libfaad/syntax.c     | 218 +++++++++++++++++++++++++++++++++++++++++--
  libfaad/syntax.h     |   1 +
- 11 files changed, 279 insertions(+), 11 deletions(-)
+ 12 files changed, 294 insertions(+), 14 deletions(-)
 
 diff --git a/configure.in b/configure.in
-index 740b056..d0b9035 100644
+index 740b056..6a53d11 100644
 --- a/configure.in
 +++ b/configure.in
 @@ -33,6 +33,9 @@ AC_ARG_WITH(xmms,[  --with-xmms             compile XMMS-1 plugin],
@@ -110,18 +111,18 @@ diff --git a/libfaad/common.c b/libfaad/common.c
 index be08d35..49b084c 100644
 --- a/libfaad/common.c
 +++ b/libfaad/common.c
-@@ -167,6 +167,11 @@ int8_t can_decode_ot(const uint8_t object_type)
+@@ -166,6 +166,11 @@ int8_t can_decode_ot(const uint8_t object_type)
+ #else
          return -1;
  #endif
- #endif
++#endif
 +
 +#ifdef HDC
 +    case HDC_LC:
 +        return 0;
-+#endif
+ #endif
      }
  
-     return -1;
 diff --git a/libfaad/decoder.c b/libfaad/decoder.c
 index 85dd423..afbe760 100644
 --- a/libfaad/decoder.c
@@ -211,29 +212,29 @@ index 40c1d53..5693c6b 100644
      uint8_t numTimeSlots;
      uint8_t tHFGen;
 diff --git a/libfaad/sbr_syntax.c b/libfaad/sbr_syntax.c
-index 6c9b97c..643596f 100644
+index 6c9b97c..0ec7afe 100644
 --- a/libfaad/sbr_syntax.c
 +++ b/libfaad/sbr_syntax.c
-@@ -155,6 +155,9 @@ uint8_t sbr_extension_data(bitfile *ld, sbr_info *sbr, uint16_t cnt,
+@@ -154,6 +154,9 @@ uint8_t sbr_extension_data(bitfile *ld, sbr_info *sbr, uint16_t cnt,
+ 
  #ifdef DRM
      if (!sbr->Is_DRM_SBR)
- #endif
++#endif
 +#ifdef HDC
 +    if (!sbr->Is_HDC_SBR)
-+#endif
+ #endif
      {
          uint8_t bs_extension_type = (uint8_t)faad_getbits(ld, 4
-             DEBUGVAR(1,198,"sbr_bitstream(): bs_extension_type"));
-@@ -248,6 +251,9 @@ uint8_t sbr_extension_data(bitfile *ld, sbr_info *sbr, uint16_t cnt,
+@@ -247,6 +250,9 @@ uint8_t sbr_extension_data(bitfile *ld, sbr_info *sbr, uint16_t cnt,
+ 
  #ifdef DRM
      if (!sbr->Is_DRM_SBR)
- #endif
++#endif
 +#ifdef HDC
 +    if (!sbr->Is_HDC_SBR)
-+#endif
+ #endif
      {       
          /* -4 does not apply, bs_extension_type is re-read in this function */
-         num_align_bits = 8*cnt /*- 4*/ - num_sbr_bits2;
 @@ -391,6 +397,12 @@ static uint8_t sbr_single_channel_element(bitfile *ld, sbr_info *sbr)
          faad_get1bit(ld);
      }
@@ -258,9 +259,9 @@ index 6c9b97c..643596f 100644
 +        return num_bits_left;
      }
  }
-
+ 
 diff --git a/libfaad/syntax.c b/libfaad/syntax.c
-index f8e808c..cafe01e 100644
+index f8e808c..f893e25 100644
 --- a/libfaad/syntax.c
 +++ b/libfaad/syntax.c
 @@ -88,7 +88,7 @@ static uint8_t spectral_data(NeAACDecStruct *hDecoder, ic_stream *ics, bitfile *
@@ -272,7 +273,7 @@ index f8e808c..cafe01e 100644
  #ifdef LTP_DEC
  static uint8_t ltp_data(NeAACDecStruct *hDecoder, ic_stream *ics, ltp_info *ltp, bitfile *ld);
  #endif
-@@ -415,6 +415,95 @@ static void decode_cpe(NeAACDecStruct *hDecoder, NeAACDecFrameInfo *hInfo, bitfi
+@@ -415,6 +415,97 @@ static void decode_cpe(NeAACDecStruct *hDecoder, NeAACDecFrameInfo *hInfo, bitfi
      hDecoder->fr_ch_ele++;
  }
  
@@ -294,6 +295,8 @@ index f8e808c..cafe01e 100644
 +        // FIXME ignore data afterwards, why?
 +        return;
 +    case 1:
++    case 5:
++    case 6:
 +        decode_sce_lfe(hDecoder, hInfo, ld, ID_SCE);
 +        break;
 +    case 2:
@@ -368,7 +371,7 @@ index f8e808c..cafe01e 100644
  void raw_data_block(NeAACDecStruct *hDecoder, NeAACDecFrameInfo *hInfo,
                      bitfile *ld, program_config *pce, drc_info *drc)
  {
-@@ -426,6 +515,14 @@ void raw_data_block(NeAACDecStruct *hDecoder, NeAACDecFrameInfo *hInfo,
+@@ -426,6 +517,14 @@ void raw_data_block(NeAACDecStruct *hDecoder, NeAACDecFrameInfo *hInfo,
      hDecoder->first_syn_ele = 25;
      hDecoder->has_lfe = 0;
  
@@ -383,7 +386,7 @@ index f8e808c..cafe01e 100644
  #ifdef ERROR_RESILIENCE
      if (hDecoder->object_type < ER_OBJECT_START)
      {
-@@ -597,13 +694,33 @@ static uint8_t single_lfe_channel_element(NeAACDecStruct *hDecoder, bitfile *ld,
+@@ -597,13 +696,33 @@ static uint8_t single_lfe_channel_element(NeAACDecStruct *hDecoder, bitfile *ld,
      ic_stream *ics = &(sce.ics1);
      ALIGN int16_t spec_data[1024] = {0};
  
@@ -417,7 +420,7 @@ index f8e808c..cafe01e 100644
      retval = individual_channel_stream(hDecoder, &sce, ld, ics, 0, spec_data);
      if (retval > 0)
          return retval;
-@@ -619,6 +736,16 @@ static uint8_t single_lfe_channel_element(NeAACDecStruct *hDecoder, bitfile *ld,
+@@ -619,6 +738,16 @@ static uint8_t single_lfe_channel_element(NeAACDecStruct *hDecoder, bitfile *ld,
      {
          faad_flushbits(ld, LEN_SE_ID);
  
@@ -434,7 +437,7 @@ index f8e808c..cafe01e 100644
          /* one sbr_info describes a channel_element not a channel! */
          if ((retval = fill_element(hDecoder, ld, hDecoder->drc, hDecoder->fr_ch_ele)) > 0)
          {
-@@ -649,12 +776,27 @@ static uint8_t channel_pair_element(NeAACDecStruct *hDecoder, bitfile *ld,
+@@ -649,12 +778,27 @@ static uint8_t channel_pair_element(NeAACDecStruct *hDecoder, bitfile *ld,
      cpe.channel        = channels;
      cpe.paired_channel = channels+1;
  
@@ -464,7 +467,7 @@ index f8e808c..cafe01e 100644
      {
          /* both channels have common ics information */
          if ((result = ics_info(hDecoder, ics1, ld, cpe.common_window)) > 0)
-@@ -706,6 +848,18 @@ static uint8_t channel_pair_element(NeAACDecStruct *hDecoder, bitfile *ld,
+@@ -706,6 +850,18 @@ static uint8_t channel_pair_element(NeAACDecStruct *hDecoder, bitfile *ld,
          ics1->ms_mask_present = 0;
      }
  
@@ -483,7 +486,7 @@ index f8e808c..cafe01e 100644
      if ((result = individual_channel_stream(hDecoder, &cpe, ld, ics1,
          0, spec_data1)) > 0)
      {
-@@ -747,6 +901,16 @@ static uint8_t channel_pair_element(NeAACDecStruct *hDecoder, bitfile *ld,
+@@ -747,6 +903,16 @@ static uint8_t channel_pair_element(NeAACDecStruct *hDecoder, bitfile *ld,
      {
          faad_flushbits(ld, LEN_SE_ID);
  
@@ -500,7 +503,7 @@ index f8e808c..cafe01e 100644
          /* one sbr_info describes a channel_element not a channel! */
          if ((result = fill_element(hDecoder, ld, hDecoder->drc, hDecoder->fr_ch_ele)) > 0)
          {
-@@ -776,10 +940,21 @@ static uint8_t ics_info(NeAACDecStruct *hDecoder, ic_stream *ics, bitfile *ld,
+@@ -776,10 +942,21 @@ static uint8_t ics_info(NeAACDecStruct *hDecoder, ic_stream *ics, bitfile *ld,
          DEBUGVAR(1,43,"ics_info(): ics_reserved_bit"));
      if (ics_reserved_bit != 0)
          return 32;
@@ -522,7 +525,7 @@ index f8e808c..cafe01e 100644
  
  #ifdef LD_DEC
      /* No block switching in LD */
-@@ -808,6 +983,9 @@ static uint8_t ics_info(NeAACDecStruct *hDecoder, ic_stream *ics, bitfile *ld,
+@@ -808,6 +985,9 @@ static uint8_t ics_info(NeAACDecStruct *hDecoder, ic_stream *ics, bitfile *ld,
      if (ics->max_sfb > ics->num_swb)
          return 16;
  
@@ -532,7 +535,7 @@ index f8e808c..cafe01e 100644
      if (ics->window_sequence != EIGHT_SHORT_SEQUENCE)
      {
          if ((ics->predictor_data_present = faad_get1bit(ld
-@@ -1102,6 +1280,14 @@ static uint8_t fill_element(NeAACDecStruct *hDecoder, bitfile *ld, drc_info *drc
+@@ -1102,6 +1282,14 @@ static uint8_t fill_element(NeAACDecStruct *hDecoder, bitfile *ld, drc_info *drc
                  hDecoder->ps_used_global = 1;
              }
  #endif
@@ -547,7 +550,7 @@ index f8e808c..cafe01e 100644
          } else {
  #endif
  #ifndef DRM
-@@ -1286,12 +1464,12 @@ void DRM_aac_scalable_main_element(NeAACDecStruct *hDecoder, NeAACDecFrameInfo *
+@@ -1286,12 +1474,12 @@ void DRM_aac_scalable_main_element(NeAACDecStruct *hDecoder, NeAACDecFrameInfo *
      }
      /* Stereo4 / Mono2 */
      if (ics1->tns_data_present)
@@ -562,7 +565,7 @@ index f8e808c..cafe01e 100644
      }
  
  #ifdef DRM
-@@ -1504,6 +1682,9 @@ static uint8_t side_info(NeAACDecStruct *hDecoder, element *ele,
+@@ -1504,6 +1692,9 @@ static uint8_t side_info(NeAACDecStruct *hDecoder, element *ele,
      ics->global_gain = (uint8_t)faad_getbits(ld, 8
          DEBUGVAR(1,67,"individual_channel_stream(): global_gain"));
  
@@ -572,7 +575,7 @@ index f8e808c..cafe01e 100644
      if (!ele->common_window && !scal_flag)
      {
          if ((result = ics_info(hDecoder, ics, ld, ele->common_window)) > 0)
-@@ -1516,6 +1697,9 @@ static uint8_t side_info(NeAACDecStruct *hDecoder, element *ele,
+@@ -1516,6 +1707,9 @@ static uint8_t side_info(NeAACDecStruct *hDecoder, element *ele,
      if ((result = scale_factor_data(hDecoder, ics, ld)) > 0)
          return result;
  
@@ -582,7 +585,7 @@ index f8e808c..cafe01e 100644
      if (!scal_flag)
      {
          /**
-@@ -1538,7 +1722,7 @@ static uint8_t side_info(NeAACDecStruct *hDecoder, element *ele,
+@@ -1538,7 +1732,7 @@ static uint8_t side_info(NeAACDecStruct *hDecoder, element *ele,
  #ifdef ERROR_RESILIENCE
              if (hDecoder->object_type < ER_OBJECT_START)
  #endif
@@ -591,7 +594,7 @@ index f8e808c..cafe01e 100644
          }
  
          /* get gain control data */
-@@ -1599,10 +1783,13 @@ static uint8_t individual_channel_stream(NeAACDecStruct *hDecoder, element *ele,
+@@ -1599,10 +1793,13 @@ static uint8_t individual_channel_stream(NeAACDecStruct *hDecoder, element *ele,
      if (result > 0)
          return result;
  
@@ -606,7 +609,7 @@ index f8e808c..cafe01e 100644
      }
  
  #ifdef DRM
-@@ -1927,7 +2114,7 @@ static uint8_t scale_factor_data(NeAACDecStruct *hDecoder, ic_stream *ics, bitfi
+@@ -1927,7 +2124,7 @@ static uint8_t scale_factor_data(NeAACDecStruct *hDecoder, ic_stream *ics, bitfi
  }
  
  /* Table 4.4.27 */
@@ -615,7 +618,7 @@ index f8e808c..cafe01e 100644
  {
      uint8_t w, filt, i, start_coef_bits, coef_bits;
      uint8_t n_filt_bits = 2;
-@@ -1943,6 +2130,11 @@ static void tns_data(ic_stream *ics, tns_info *tns, bitfile *ld)
+@@ -1943,6 +2140,11 @@ static void tns_data(ic_stream *ics, tns_info *tns, bitfile *ld)
  
      for (w = 0; w < ics->num_windows; w++)
      {
@@ -640,5 +643,5 @@ index 2a1fc6d..5361b2b 100644
  /* header types */
  #define RAW        0
 -- 
-2.13.1
+2.25.1
 

--- a/support/nrsc5.py
+++ b/support/nrsc5.py
@@ -6,6 +6,11 @@ import platform
 import socket
 
 
+class Mode(enum.Enum):
+    FM = 0
+    AM = 1
+
+
 class EventType(enum.Enum):
     LOST_DEVICE = 0
     IQ = 1
@@ -451,15 +456,15 @@ class NRSC5:
         return version.value.decode()
 
     @staticmethod
-    def service_data_type_name(type):
+    def service_data_type_name(service_data_type):
         name = ctypes.c_char_p()
-        NRSC5.libnrsc5.nrsc5_service_data_type_name(type.value, ctypes.byref(name))
+        NRSC5.libnrsc5.nrsc5_service_data_type_name(service_data_type.value, ctypes.byref(name))
         return name.value.decode()
 
     @staticmethod
-    def program_type_name(type):
+    def program_type_name(program_type):
         name = ctypes.c_char_p()
-        NRSC5.libnrsc5.nrsc5_program_type_name(type.value, ctypes.byref(name))
+        NRSC5.libnrsc5.nrsc5_program_type_name(program_type.value, ctypes.byref(name))
         return name.value.decode()
 
     def open(self, device_index):
@@ -489,6 +494,9 @@ class NRSC5:
 
     def stop(self):
         NRSC5.libnrsc5.nrsc5_stop(self.radio)
+
+    def set_mode(self, mode):
+        NRSC5.libnrsc5.nrsc5_set_mode(self.radio, mode.value)
 
     def set_freq_correction(self, ppm_error):
         result = NRSC5.libnrsc5.nrsc5_set_freq_correction(self.radio, ppm_error)


### PR DESCRIPTION
Resolves #33.

This adds basic support for receiving AM signals, as described in [NRSC-5 Layer 1 AM](https://www.nrscstandards.org/standards-and-guidelines/documents/standards/nrsc-5-d/reference-docs/1012s.pdf).

To use the new functionality, simply add the `--am` command line option.

Some limitations:

* Only the hybrid mode (MA1) is supported. Fortunately, almost all stations (except WWFD) are using this mode.
* Audio quality is sub-optimal, because only the "core" audio stream (20 kbps) is decoded. I don't yet know how to decode the packets in the "enhanced" audio stream, which contains an additional 16 kbps.
* Receive performance is sub-optimal. In particular, decimation and OFDM synchronization could be improved, and the Viterbi decoder could be switched from hard to soft decisions.
* Automatic gain selection is not implemented. The `-g` option should be used to manually specify a gain value.

Since the code is in a working state and the number of changes is already large, I thought it would make sense to merge in the feature now and continue working on it in subsequent pull requests.

I used my test suite of I/Q recordings to verify that the FM receiver functions identically before & after these changes.