### PR TITLE
Add support for bias-T & direct sampling

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,7 +4,7 @@ os:
   - linux
   - osx
 
-dist: xenial
+dist: bionic
 
 compiler:
   - gcc
@@ -18,7 +18,6 @@ before_install:
 
 install:
   - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo apt-get install -y libao-dev libfftw3-dev librtlsdr-dev mingw-w64 python3-pyaudio; fi
-  - if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then sudo ln -s /usr/bin/ccache /usr/lib/ccache/i686-w64-mingw32-gcc; sudo ln -s /usr/bin/ccache /usr/lib/ccache/x86_64-w64-mingw32-gcc; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew cask install wine-stable; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then brew install libao fftw librtlsdr mingw-w64 portaudio ccache; fi
   - if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then export PATH="/usr/local/opt/ccache/libexec:$PATH"; ln -s /usr/local/bin/ccache /usr/local/opt/ccache/libexec/i686-w64-mingw32-gcc; ln -s /usr/local/bin/ccache /usr/local/opt/ccache/libexec/x86_64-w64-mingw32-gcc; fi

--- a/README.md
+++ b/README.md
@@ -103,6 +103,9 @@ Replace `32` with `64` if you want a 64-bit build. Once the build is complete, c
        -v                              print the version number and exit
        --am                            receive AM signals
                                          (default is FM)
+       -T                              enable bias-T
+       -D direct-sampling-mode         enable direct sampling
+                                         (1 = I-ADC input, 2 = Q-ADC input)
        --dump-aas-files dir-name       dump AAS files
                                          (WARNING: insecure)
        --dump-hdc file-name            dump HDC packets

--- a/include/nrsc5.h
+++ b/include/nrsc5.h
@@ -274,6 +274,8 @@ void nrsc5_close(nrsc5_t *);
 void nrsc5_start(nrsc5_t *);
 void nrsc5_stop(nrsc5_t *);
 int nrsc5_set_mode(nrsc5_t *, int mode);
+int nrsc5_set_bias_tee(nrsc5_t *, int on);
+int nrsc5_set_direct_sampling(nrsc5_t *, int on);
 int nrsc5_set_freq_correction(nrsc5_t *, int ppm_error);
 void nrsc5_get_frequency(nrsc5_t *, float *freq);
 int nrsc5_set_frequency(nrsc5_t *, float freq);

--- a/src/libnrsc5.map
+++ b/src/libnrsc5.map
@@ -11,6 +11,8 @@ LIBNRSC5_1.0 {
         nrsc5_start;
         nrsc5_stop;
         nrsc5_set_mode;
+        nrsc5_set_bias_tee;
+        nrsc5_set_direct_sampling;
         nrsc5_set_freq_correction;
         nrsc5_get_frequency;
         nrsc5_set_frequency;

--- a/src/libnrsc5.sym
+++ b/src/libnrsc5.sym
@@ -9,6 +9,8 @@ _nrsc5_close
 _nrsc5_start
 _nrsc5_stop
 _nrsc5_set_mode
+_nrsc5_set_bias_tee
+_nrsc5_set_direct_sampling
 _nrsc5_set_freq_correction
 _nrsc5_get_frequency
 _nrsc5_set_frequency

--- a/src/main.c
+++ b/src/main.c
@@ -809,6 +809,7 @@ int main(int argc, char *argv[])
     pthread_join(input_thread, NULL);
 
     nrsc5_stop(radio);
+    nrsc5_set_bias_tee(radio, 0);
     nrsc5_close(radio);
     cleanup(st);
     free(st);

--- a/src/nrsc5.c
+++ b/src/nrsc5.c
@@ -427,6 +427,40 @@ NRSC5_API int nrsc5_set_mode(nrsc5_t *st, int mode)
     return 1;
 }
 
+NRSC5_API int nrsc5_set_bias_tee(nrsc5_t *st, int on)
+{
+    if (st->dev)
+    {
+        int err = rtlsdr_set_bias_tee(st->dev, on);
+        if (err)
+            return 1;
+    }
+    else if (st->rtltcp)
+    {
+        int err = rtltcp_set_bias_tee(st->rtltcp, on);
+        if (err)
+            return 1;
+    }
+    return 0;
+}
+
+NRSC5_API int nrsc5_set_direct_sampling(nrsc5_t *st, int on)
+{
+    if (st->dev)
+    {
+        int err = rtlsdr_set_direct_sampling(st->dev, on);
+        if (err)
+            return 1;
+    }
+    else if (st->rtltcp)
+    {
+        int err = rtltcp_set_direct_sampling(st->rtltcp, on);
+        if (err)
+            return 1;
+    }
+    return 0;
+}
+
 NRSC5_API int nrsc5_set_freq_correction(nrsc5_t *st, int ppm_error)
 {
     if (st->dev)

--- a/src/rtltcp.c
+++ b/src/rtltcp.c
@@ -43,7 +43,9 @@ RTLTCP_DEFINE(set_sample_rate, 0x02)
 RTLTCP_DEFINE(set_tuner_gain_mode, 0x03)
 RTLTCP_DEFINE(set_tuner_gain, 0x04)
 RTLTCP_DEFINE(set_freq_correction, 0x05)
+RTLTCP_DEFINE(set_direct_sampling, 0x09)
 RTLTCP_DEFINE(set_offset_tuning, 0x0a)
+RTLTCP_DEFINE(set_bias_tee, 0x0e)
 
 #undef RTLTCP_DEFINE
 

--- a/src/rtltcp.h
+++ b/src/rtltcp.h
@@ -11,7 +11,9 @@ RTLTCP_DEFINE(set_sample_rate, 0x02)
 RTLTCP_DEFINE(set_tuner_gain_mode, 0x03)
 RTLTCP_DEFINE(set_tuner_gain, 0x04)
 RTLTCP_DEFINE(set_freq_correction, 0x05)
+RTLTCP_DEFINE(set_direct_sampling, 0x09)
 RTLTCP_DEFINE(set_offset_tuning, 0x0a)
+RTLTCP_DEFINE(set_bias_tee, 0x0e)
 #undef RTLTCP_DEFINE
 
 rtltcp_t *rtltcp_open(int socket);

--- a/support/cli.py
+++ b/support/cli.py
@@ -120,6 +120,7 @@ class NRSC5CLI:
             logging.error(err)
 
         self.radio.stop()
+        self.radio.set_bias_tee(0)
         self.radio.close()
 
         if self.args.r:

--- a/support/cli.py
+++ b/support/cli.py
@@ -39,6 +39,8 @@ class NRSC5CLI:
         parser.add_argument("-w", metavar="iq-output")
         parser.add_argument("-o", metavar="wav-output")
         parser.add_argument("-H", metavar="rtltcp-host")
+        parser.add_argument("-T", action="store_true")
+        parser.add_argument("-D", metavar="direct-sampling-mode", type=int, default=0)
         parser.add_argument("--dump-hdc", metavar="hdc-output")
         parser.add_argument("--dump-aas-files", metavar="directory")
         input_group.add_argument("frequency", nargs="?", type=float)
@@ -75,6 +77,9 @@ class NRSC5CLI:
 
         if self.args.am:
             self.radio.set_mode(nrsc5.Mode.AM)
+
+        self.radio.set_bias_tee(self.args.T)
+        self.radio.set_direct_sampling(self.args.D)
 
         if self.args.p is not None:
             self.radio.set_freq_correction(self.args.p)

--- a/support/nrsc5.py
+++ b/support/nrsc5.py
@@ -498,6 +498,16 @@ class NRSC5:
     def set_mode(self, mode):
         NRSC5.libnrsc5.nrsc5_set_mode(self.radio, mode.value)
 
+    def set_bias_tee(self, on):
+        result = NRSC5.libnrsc5.nrsc5_set_bias_tee(self.radio, on)
+        if result != 0:
+            raise NRSC5Error("Failed to set bias-T.")
+
+    def set_direct_sampling(self, on):
+        result = NRSC5.libnrsc5.nrsc5_set_direct_sampling(self.radio, on)
+        if result != 0:
+            raise NRSC5Error("Failed to set direct sampling.")
+
     def set_freq_correction(self, ppm_error):
         result = NRSC5.libnrsc5.nrsc5_set_freq_correction(self.radio, ppm_error)
         if result != 0:


### PR DESCRIPTION
Fixes #235.
Fixes #236.

`-T` enables the bias-T.
`-D 1` enables direct sampling on the I-ADC input
`-D 2` enables direct sampling on the Q-ADC input (which works with RTL-SDR Blog V3 dongles)

All the standard `rtl_*` utilities use `-T` for the bias-T, so that seemed like a good choice. The `rtl_power` tool uses `-D` for direct sampling, although without an argument to choose the input.