### PR TITLE
Change faad2 upstream and update to the latest

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -217,19 +217,19 @@ if (USE_FAAD2)
     ExternalProject_Add (
         faad2_external
         TIMEOUT 120
-        GIT_REPOSITORY "https://github.com/dsvensson/faad2.git"
-        GIT_TAG b7aa099fd3220b71180ed2b0bc19dc6209a1b418
+        GIT_REPOSITORY "https://github.com/knik0/faad2.git"
+        GIT_TAG f71b5e81f563d94fa284977a326520d269d8353e
         PREFIX ${FAAD2_PREFIX}
 
         UPDATE_COMMAND ""
         PATCH_COMMAND patch -p1 -Ni "${CMAKE_SOURCE_DIR}/support/faad2-hdc-support.patch" || exit 0
         COMMAND sh ./bootstrap
 
-        CONFIGURE_COMMAND ${FAAD2_PREFIX}/src/faad2_external/configure ${HOST_TRIPLE_ARG} ${FAAD2_CONFIGURE_ARGS} --prefix=${FAAD2_PREFIX} --with-hdc "CFLAGS=-O2 -fPIC ${CMAKE_C_FLAGS}"
+        CONFIGURE_COMMAND ${FAAD2_PREFIX}/src/faad2_external/configure ${HOST_TRIPLE_ARG} ${FAAD2_CONFIGURE_ARGS} --prefix=${FAAD2_PREFIX} "CFLAGS=-O2 -fPIC ${CMAKE_C_FLAGS}"
     )
 
     add_library (faad2 STATIC IMPORTED)
-    set_property (TARGET faad2 PROPERTY IMPORTED_LOCATION "${FAAD2_PREFIX}/lib/libfaad.a")
+    set_property (TARGET faad2 PROPERTY IMPORTED_LOCATION "${FAAD2_PREFIX}/lib/libfaad_hdc.a")
     add_dependencies (faad2 faad2_external)
 
     set (FAAD2_INCLUDE_DIRS "${FAAD2_PREFIX}/include")

--- a/support/faad2-hdc-support.patch
+++ b/support/faad2-hdc-support.patch
@@ -1,55 +1,29 @@
-From afb8a416d84bf9a7aeaf838331160880a05b6789 Mon Sep 17 00:00:00 2001
+From 973f08e16d02fea1dffc1c75f8f54eb58cb128cd Mon Sep 17 00:00:00 2001
 From: Clayton Smith <argilo@gmail.com>
-Date: Wed, 2 Sep 2020 23:02:58 -0400
+Date: Thu, 3 Sep 2020 22:08:07 -0400
 Subject: [PATCH] Support for HDC variant
 
 ---
- configure.in         |   9 ++
  frontend/main.c      |   3 +-
  include/neaacdec.h   |   4 +
+ libfaad/Makefile.am  |   7 +-
  libfaad/bits.c       |   2 +-
  libfaad/bits.h       |   2 +-
  libfaad/common.c     |   5 +
+ libfaad/common.h     |   6 ++
  libfaad/decoder.c    |  42 ++++++++
- libfaad/sbr_dec.c    |   2 +-
+ libfaad/sbr_dec.c    |   4 +
  libfaad/sbr_dec.h    |   4 +
  libfaad/sbr_syntax.c |  16 +++-
  libfaad/syntax.c     | 223 +++++++++++++++++++++++++++++++++++++++++--
  libfaad/syntax.h     |   1 +
- 12 files changed, 299 insertions(+), 14 deletions(-)
+ 13 files changed, 305 insertions(+), 14 deletions(-)
 
-diff --git a/configure.in b/configure.in
-index 740b056..6a53d11 100644
---- a/configure.in
-+++ b/configure.in
-@@ -33,6 +33,9 @@ AC_ARG_WITH(xmms,[  --with-xmms             compile XMMS-1 plugin],
- AC_ARG_WITH(drm,[  --with-drm              compile libfaad with DRM support],
- 	     WITHDRM=$withval, WITHDRM=no)
- 
-+AC_ARG_WITH(hdc,[  --with-hdc              compile libfaad with HDC support],
-+	     WITHHDC=$withval, WITHHDC=no)
-+
- AC_ARG_WITH(mpeg4ip, [  --with-mpeg4ip          compile mpeg4ip plugin],
- 		     WITHMPEG4IP=$withval, WITHMPEG4IP=no)
- 
-@@ -154,6 +157,12 @@ if test x$WITHDRM = xyes; then
-   AC_DEFINE(DRM_PS, 1, [Define if you want support for Digital Radio Mondiale (DRM) parametric stereo])
- fi
- 
-+if test x$WITHHDC = xyes; then
-+  AC_DEFINE(HDC, 1, [Define if you want to use libfaad with HDC])
-+  AC_DEFINE(DRM, 1, [Define if you want to use libfaad together with Digital Radio Mondiale (DRM)])
-+  AC_DEFINE(DRM_PS, 1, [Define if you want support for Digital Radio Mondiale (DRM) parametric stereo])
-+fi
-+
- AC_CONFIG_FILES(libfaad/Makefile)
- AC_CONFIG_FILES(common/Makefile)
- AC_CONFIG_FILES(common/mp4ff/Makefile)
 diff --git a/frontend/main.c b/frontend/main.c
-index f9b24ee..13daa38 100644
+index efaaccc..0430be5 100644
 --- a/frontend/main.c
 +++ b/frontend/main.c
-@@ -1141,7 +1141,8 @@ int main(int argc, char *argv[])
+@@ -1170,7 +1170,8 @@ static int faad_main(int argc, char *argv[])
                      if ((object_type != LC) &&
                          (object_type != MAIN) &&
                          (object_type != LTP) &&
@@ -60,10 +34,10 @@ index f9b24ee..13daa38 100644
                          showHelp = 1;
                      }
 diff --git a/include/neaacdec.h b/include/neaacdec.h
-index a45f1d0..4107d5b 100644
+index 8d52f74..82336b5 100644
 --- a/include/neaacdec.h
 +++ b/include/neaacdec.h
-@@ -81,6 +81,7 @@ extern "C" {
+@@ -79,6 +79,7 @@ extern "C" {
  #define ER_LTP    19
  #define LD        23
  #define DRM_ER_LC 27 /* special object type for DRM */
@@ -71,21 +45,43 @@ index a45f1d0..4107d5b 100644
  
  /* header types */
  #define RAW        0
-@@ -227,6 +228,9 @@ char NEAACDECAPI NeAACDecInit2(NeAACDecHandle hDecoder,
- char NEAACDECAPI NeAACDecInitDRM(NeAACDecHandle *hDecoder, unsigned long samplerate,
+@@ -225,6 +226,9 @@ NEAACDECAPI char NeAACDecInit2(NeAACDecHandle hDecoder,
+ NEAACDECAPI char NeAACDecInitDRM(NeAACDecHandle *hDecoder, unsigned long samplerate,
                                   unsigned char channels);
  
 +/* Init the library for HDC */
-+char NEAACDECAPI NeAACDecInitHDC(NeAACDecHandle *hDecoder, unsigned long *samplerate);
++NEAACDECAPI char NeAACDecInitHDC(NeAACDecHandle *hDecoder, unsigned long *samplerate);
 +
- void NEAACDECAPI NeAACDecPostSeekReset(NeAACDecHandle hDecoder, long frame);
+ NEAACDECAPI void NeAACDecPostSeekReset(NeAACDecHandle hDecoder, long frame);
  
- void NEAACDECAPI NeAACDecClose(NeAACDecHandle hDecoder);
+ NEAACDECAPI void NeAACDecClose(NeAACDecHandle hDecoder);
+diff --git a/libfaad/Makefile.am b/libfaad/Makefile.am
+index 9105625..02c9b44 100644
+--- a/libfaad/Makefile.am
++++ b/libfaad/Makefile.am
+@@ -1,4 +1,4 @@
+-lib_LTLIBRARIES = libfaad.la libfaad_drm.la
++lib_LTLIBRARIES = libfaad.la libfaad_drm.la libfaad_hdc.la
+ 
+ AM_CPPFLAGS	= -iquote $(top_srcdir)/include
+ include_HEADERS = $(top_srcdir)/include/faad.h \
+@@ -35,6 +35,11 @@ libfaad_drm_la_LIBADD = ${libfaad_la_LIBADD}
+ libfaad_drm_la_CFLAGS = ${libfaad_la_CFLAGS} -DDRM_SUPPORT
+ libfaad_drm_la_SOURCES = ${libfaad_la_SOURCES}
+ 
++libfaad_hdc_la_LDFLAGS = ${libfaad_la_LDFLAGS}
++libfaad_hdc_la_LIBADD = ${libfaad_la_LIBADD}
++libfaad_hdc_la_CFLAGS = ${libfaad_la_CFLAGS} -DHDC_SUPPORT
++libfaad_hdc_la_SOURCES = ${libfaad_la_SOURCES}
++
+ pkgconfigdir = $(libdir)/pkgconfig
+ pkgconfig_DATA = faad2.pc
+ 
 diff --git a/libfaad/bits.c b/libfaad/bits.c
-index dc14d7a..e76e52e 100644
+index 22c661d..f654e7a 100644
 --- a/libfaad/bits.c
 +++ b/libfaad/bits.c
-@@ -225,7 +225,7 @@ uint8_t *faad_getbitbuffer(bitfile *ld, uint32_t bits
+@@ -228,7 +228,7 @@ uint8_t *faad_getbitbuffer(bitfile *ld, uint32_t bits
      return buffer;
  }
  
@@ -95,7 +91,7 @@ index dc14d7a..e76e52e 100644
  void *faad_origbitbuffer(bitfile *ld)
  {
 diff --git a/libfaad/bits.h b/libfaad/bits.h
-index e303e8e..e9b71d6 100644
+index c34dfe7..39eaed3 100644
 --- a/libfaad/bits.h
 +++ b/libfaad/bits.h
 @@ -83,7 +83,7 @@ void faad_rewindbits(bitfile *ld);
@@ -108,7 +104,7 @@ index e303e8e..e9b71d6 100644
  uint32_t faad_origbitbuffer_size(bitfile *ld);
  #endif
 diff --git a/libfaad/common.c b/libfaad/common.c
-index be08d35..49b084c 100644
+index cdfaece..8b6231e 100644
 --- a/libfaad/common.c
 +++ b/libfaad/common.c
 @@ -166,6 +166,11 @@ int8_t can_decode_ot(const uint8_t object_type)
@@ -123,13 +119,30 @@ index be08d35..49b084c 100644
  #endif
      }
  
+diff --git a/libfaad/common.h b/libfaad/common.h
+index cacd1c4..d3b6781 100644
+--- a/libfaad/common.h
++++ b/libfaad/common.h
+@@ -95,6 +95,12 @@ extern "C" {
+ #define DRM
+ #define DRM_PS
+ #endif
++/* Allow decoding of HDC */
++#ifdef HDC_SUPPORT
++#define DRM
++#define DRM_PS
++#define HDC
++#endif
+ 
+ /* LD can't do without LTP */
+ #ifdef LD_DEC
 diff --git a/libfaad/decoder.c b/libfaad/decoder.c
-index 85dd423..afbe760 100644
+index c66c81f..060931a 100644
 --- a/libfaad/decoder.c
 +++ b/libfaad/decoder.c
-@@ -324,6 +324,13 @@ long NEAACDECAPI NeAACDecInit(NeAACDecHandle hpDecoder,
-         faad_endbits(&ld);
-     }
+@@ -349,6 +349,13 @@ long NeAACDecInit(NeAACDecHandle hpDecoder,
+     if (!*samplerate)
+         return -1;
  
 +#ifdef HDC
 +    if (hDecoder->config.defObjectType == HDC_LC)
@@ -141,12 +154,12 @@ index 85dd423..afbe760 100644
  #if (defined(PS_DEC) || defined(DRM_PS))
      /* check if we have a mono file */
      if (*channels == 1)
-@@ -503,6 +510,41 @@ char NEAACDECAPI NeAACDecInitDRM(NeAACDecHandle *hpDecoder,
+@@ -528,6 +535,41 @@ char NeAACDecInitDRM(NeAACDecHandle *hpDecoder,
  }
  #endif
  
 +#ifdef HDC
-+char NEAACDECAPI NeAACDecInitHDC(NeAACDecHandle *hpDecoder,
++char NeAACDecInitHDC(NeAACDecHandle *hpDecoder,
 +                                 unsigned long *samplerate)
 +{
 +    NeAACDecStruct** hDecoder = (NeAACDecStruct**)hpDecoder;
@@ -180,24 +193,27 @@ index 85dd423..afbe760 100644
 +}
 +#endif
 +
- void NEAACDECAPI NeAACDecClose(NeAACDecHandle hpDecoder)
+ void NeAACDecClose(NeAACDecHandle hpDecoder)
  {
      uint8_t i;
 diff --git a/libfaad/sbr_dec.c b/libfaad/sbr_dec.c
-index 0705ddd..cb103cf 100644
+index 2641c7b..e1a14ea 100644
 --- a/libfaad/sbr_dec.c
 +++ b/libfaad/sbr_dec.c
-@@ -648,7 +648,7 @@ uint8_t sbrDecodeSingleFramePS(sbr_info *sbr, real_t *left_channel, real_t *righ
+@@ -648,7 +648,11 @@ uint8_t sbrDecodeSingleFramePS(sbr_info *sbr, real_t *left_channel, real_t *righ
  
      /* perform parametric stereo */
  #ifdef DRM_PS
--    if (sbr->Is_DRM_SBR)
++#ifdef HDC
 +    if (sbr->Is_DRM_SBR || sbr->Is_HDC_SBR)
++#else
+     if (sbr->Is_DRM_SBR)
++#endif
      {
          drm_ps_decode(sbr->drm_ps, (sbr->ret > 0), X_left, X_right);
      } else {
 diff --git a/libfaad/sbr_dec.h b/libfaad/sbr_dec.h
-index 40c1d53..5693c6b 100644
+index cb8e3b9..74565f6 100644
 --- a/libfaad/sbr_dec.h
 +++ b/libfaad/sbr_dec.h
 @@ -176,6 +176,10 @@ typedef struct
@@ -212,7 +228,7 @@ index 40c1d53..5693c6b 100644
      uint8_t numTimeSlots;
      uint8_t tHFGen;
 diff --git a/libfaad/sbr_syntax.c b/libfaad/sbr_syntax.c
-index 6c9b97c..0ec7afe 100644
+index 29a6328..f61e254 100644
 --- a/libfaad/sbr_syntax.c
 +++ b/libfaad/sbr_syntax.c
 @@ -154,6 +154,9 @@ uint8_t sbr_extension_data(bitfile *ld, sbr_info *sbr, uint16_t cnt,
@@ -233,7 +249,7 @@ index 6c9b97c..0ec7afe 100644
 +#ifdef HDC
 +    if (!sbr->Is_HDC_SBR)
  #endif
-     {       
+     {
          /* -4 does not apply, bs_extension_type is re-read in this function */
 @@ -391,6 +397,12 @@ static uint8_t sbr_single_channel_element(bitfile *ld, sbr_info *sbr)
          faad_get1bit(ld);
@@ -261,7 +277,7 @@ index 6c9b97c..0ec7afe 100644
  }
  
 diff --git a/libfaad/syntax.c b/libfaad/syntax.c
-index f8e808c..963ebe1 100644
+index 5df254f..060b799 100644
 --- a/libfaad/syntax.c
 +++ b/libfaad/syntax.c
 @@ -88,7 +88,7 @@ static uint8_t spectral_data(NeAACDecStruct *hDecoder, ic_stream *ics, bitfile *
@@ -273,7 +289,7 @@ index f8e808c..963ebe1 100644
  #ifdef LTP_DEC
  static uint8_t ltp_data(NeAACDecStruct *hDecoder, ic_stream *ics, ltp_info *ltp, bitfile *ld);
  #endif
-@@ -415,6 +415,102 @@ static void decode_cpe(NeAACDecStruct *hDecoder, NeAACDecFrameInfo *hInfo, bitfi
+@@ -427,6 +427,102 @@ static void decode_cpe(NeAACDecStruct *hDecoder, NeAACDecFrameInfo *hInfo, bitfi
      hDecoder->fr_ch_ele++;
  }
  
@@ -376,7 +392,7 @@ index f8e808c..963ebe1 100644
  void raw_data_block(NeAACDecStruct *hDecoder, NeAACDecFrameInfo *hInfo,
                      bitfile *ld, program_config *pce, drc_info *drc)
  {
-@@ -426,6 +522,14 @@ void raw_data_block(NeAACDecStruct *hDecoder, NeAACDecFrameInfo *hInfo,
+@@ -438,6 +534,14 @@ void raw_data_block(NeAACDecStruct *hDecoder, NeAACDecFrameInfo *hInfo,
      hDecoder->first_syn_ele = 25;
      hDecoder->has_lfe = 0;
  
@@ -391,7 +407,7 @@ index f8e808c..963ebe1 100644
  #ifdef ERROR_RESILIENCE
      if (hDecoder->object_type < ER_OBJECT_START)
      {
-@@ -597,13 +701,33 @@ static uint8_t single_lfe_channel_element(NeAACDecStruct *hDecoder, bitfile *ld,
+@@ -609,13 +713,33 @@ static uint8_t single_lfe_channel_element(NeAACDecStruct *hDecoder, bitfile *ld,
      ic_stream *ics = &(sce.ics1);
      ALIGN int16_t spec_data[1024] = {0};
  
@@ -425,7 +441,7 @@ index f8e808c..963ebe1 100644
      retval = individual_channel_stream(hDecoder, &sce, ld, ics, 0, spec_data);
      if (retval > 0)
          return retval;
-@@ -619,6 +743,16 @@ static uint8_t single_lfe_channel_element(NeAACDecStruct *hDecoder, bitfile *ld,
+@@ -631,6 +755,16 @@ static uint8_t single_lfe_channel_element(NeAACDecStruct *hDecoder, bitfile *ld,
      {
          faad_flushbits(ld, LEN_SE_ID);
  
@@ -442,7 +458,7 @@ index f8e808c..963ebe1 100644
          /* one sbr_info describes a channel_element not a channel! */
          if ((retval = fill_element(hDecoder, ld, hDecoder->drc, hDecoder->fr_ch_ele)) > 0)
          {
-@@ -649,12 +783,27 @@ static uint8_t channel_pair_element(NeAACDecStruct *hDecoder, bitfile *ld,
+@@ -661,12 +795,27 @@ static uint8_t channel_pair_element(NeAACDecStruct *hDecoder, bitfile *ld,
      cpe.channel        = channels;
      cpe.paired_channel = channels+1;
  
@@ -472,7 +488,7 @@ index f8e808c..963ebe1 100644
      {
          /* both channels have common ics information */
          if ((result = ics_info(hDecoder, ics1, ld, cpe.common_window)) > 0)
-@@ -706,6 +855,18 @@ static uint8_t channel_pair_element(NeAACDecStruct *hDecoder, bitfile *ld,
+@@ -718,6 +867,18 @@ static uint8_t channel_pair_element(NeAACDecStruct *hDecoder, bitfile *ld,
          ics1->ms_mask_present = 0;
      }
  
@@ -491,7 +507,7 @@ index f8e808c..963ebe1 100644
      if ((result = individual_channel_stream(hDecoder, &cpe, ld, ics1,
          0, spec_data1)) > 0)
      {
-@@ -747,6 +908,16 @@ static uint8_t channel_pair_element(NeAACDecStruct *hDecoder, bitfile *ld,
+@@ -759,6 +920,16 @@ static uint8_t channel_pair_element(NeAACDecStruct *hDecoder, bitfile *ld,
      {
          faad_flushbits(ld, LEN_SE_ID);
  
@@ -508,7 +524,7 @@ index f8e808c..963ebe1 100644
          /* one sbr_info describes a channel_element not a channel! */
          if ((result = fill_element(hDecoder, ld, hDecoder->drc, hDecoder->fr_ch_ele)) > 0)
          {
-@@ -776,10 +947,21 @@ static uint8_t ics_info(NeAACDecStruct *hDecoder, ic_stream *ics, bitfile *ld,
+@@ -788,10 +959,21 @@ static uint8_t ics_info(NeAACDecStruct *hDecoder, ic_stream *ics, bitfile *ld,
          DEBUGVAR(1,43,"ics_info(): ics_reserved_bit"));
      if (ics_reserved_bit != 0)
          return 32;
@@ -530,7 +546,7 @@ index f8e808c..963ebe1 100644
  
  #ifdef LD_DEC
      /* No block switching in LD */
-@@ -808,6 +990,9 @@ static uint8_t ics_info(NeAACDecStruct *hDecoder, ic_stream *ics, bitfile *ld,
+@@ -820,6 +1002,9 @@ static uint8_t ics_info(NeAACDecStruct *hDecoder, ic_stream *ics, bitfile *ld,
      if (ics->max_sfb > ics->num_swb)
          return 16;
  
@@ -540,7 +556,7 @@ index f8e808c..963ebe1 100644
      if (ics->window_sequence != EIGHT_SHORT_SEQUENCE)
      {
          if ((ics->predictor_data_present = faad_get1bit(ld
-@@ -1102,6 +1287,14 @@ static uint8_t fill_element(NeAACDecStruct *hDecoder, bitfile *ld, drc_info *drc
+@@ -1114,6 +1299,14 @@ static uint8_t fill_element(NeAACDecStruct *hDecoder, bitfile *ld, drc_info *drc
                  hDecoder->ps_used_global = 1;
              }
  #endif
@@ -555,7 +571,7 @@ index f8e808c..963ebe1 100644
          } else {
  #endif
  #ifndef DRM
-@@ -1286,12 +1479,12 @@ void DRM_aac_scalable_main_element(NeAACDecStruct *hDecoder, NeAACDecFrameInfo *
+@@ -1298,12 +1491,12 @@ void DRM_aac_scalable_main_element(NeAACDecStruct *hDecoder, NeAACDecFrameInfo *
      }
      /* Stereo4 / Mono2 */
      if (ics1->tns_data_present)
@@ -570,7 +586,7 @@ index f8e808c..963ebe1 100644
      }
  
  #ifdef DRM
-@@ -1504,6 +1697,9 @@ static uint8_t side_info(NeAACDecStruct *hDecoder, element *ele,
+@@ -1516,6 +1709,9 @@ static uint8_t side_info(NeAACDecStruct *hDecoder, element *ele,
      ics->global_gain = (uint8_t)faad_getbits(ld, 8
          DEBUGVAR(1,67,"individual_channel_stream(): global_gain"));
  
@@ -580,7 +596,7 @@ index f8e808c..963ebe1 100644
      if (!ele->common_window && !scal_flag)
      {
          if ((result = ics_info(hDecoder, ics, ld, ele->common_window)) > 0)
-@@ -1516,6 +1712,9 @@ static uint8_t side_info(NeAACDecStruct *hDecoder, element *ele,
+@@ -1528,6 +1724,9 @@ static uint8_t side_info(NeAACDecStruct *hDecoder, element *ele,
      if ((result = scale_factor_data(hDecoder, ics, ld)) > 0)
          return result;
  
@@ -590,7 +606,7 @@ index f8e808c..963ebe1 100644
      if (!scal_flag)
      {
          /**
-@@ -1538,7 +1737,7 @@ static uint8_t side_info(NeAACDecStruct *hDecoder, element *ele,
+@@ -1550,7 +1749,7 @@ static uint8_t side_info(NeAACDecStruct *hDecoder, element *ele,
  #ifdef ERROR_RESILIENCE
              if (hDecoder->object_type < ER_OBJECT_START)
  #endif
@@ -599,14 +615,14 @@ index f8e808c..963ebe1 100644
          }
  
          /* get gain control data */
-@@ -1599,10 +1798,13 @@ static uint8_t individual_channel_stream(NeAACDecStruct *hDecoder, element *ele,
+@@ -1611,10 +1810,13 @@ static uint8_t individual_channel_stream(NeAACDecStruct *hDecoder, element *ele,
      if (result > 0)
          return result;
  
 +#ifdef HDC
 +    if (hDecoder->object_type != HDC_LC)
 +#endif
-     if (hDecoder->object_type >= ER_OBJECT_START) 
+     if (hDecoder->object_type >= ER_OBJECT_START)
      {
          if (ics->tns_data_present)
 -            tns_data(ics, &(ics->tns), ld);
@@ -614,7 +630,7 @@ index f8e808c..963ebe1 100644
      }
  
  #ifdef DRM
-@@ -1927,7 +2129,7 @@ static uint8_t scale_factor_data(NeAACDecStruct *hDecoder, ic_stream *ics, bitfi
+@@ -1939,7 +2141,7 @@ static uint8_t scale_factor_data(NeAACDecStruct *hDecoder, ic_stream *ics, bitfi
  }
  
  /* Table 4.4.27 */
@@ -623,7 +639,7 @@ index f8e808c..963ebe1 100644
  {
      uint8_t w, filt, i, start_coef_bits, coef_bits;
      uint8_t n_filt_bits = 2;
-@@ -1943,6 +2145,11 @@ static void tns_data(ic_stream *ics, tns_info *tns, bitfile *ld)
+@@ -1955,6 +2157,11 @@ static void tns_data(ic_stream *ics, tns_info *tns, bitfile *ld)
  
      for (w = 0; w < ics->num_windows; w++)
      {
@@ -636,7 +652,7 @@ index f8e808c..963ebe1 100644
              DEBUGVAR(1,74,"tns_data(): n_filt"));
  #if 0
 diff --git a/libfaad/syntax.h b/libfaad/syntax.h
-index 2a1fc6d..5361b2b 100644
+index 56bfbc4..b9dd44f 100644
 --- a/libfaad/syntax.h
 +++ b/libfaad/syntax.h
 @@ -46,6 +46,7 @@ extern "C" {


### PR DESCRIPTION
The faad2 project seems to be alive again at https://github.com/knik0/faad2, and Debian is now using this fork. So I think it's worth switching nrsc5 over as well.

It seems that instead of using `--with-drm` to add DRM support, the project now just builds a libfaad_drm library in parallel with libfaad. I've mirrored this pattern and added a libfaad_hdc library which has HDC support.