### PR TITLE
Only call nrsc5_set_direct_sampling if -D is specified

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -527,7 +527,7 @@ static int parse_args(state_t *st, int argc, char *argv[])
     st->mode = NRSC5_MODE_FM;
     st->gain = -1;
     st->bias_tee = 0;
-    st->direct_sampling = 0;
+    st->direct_sampling = -1;
     st->ppm_error = INT_MIN;
 
     while ((opt = getopt_long(argc, argv, "r:w:o:d:p:g:ql:vH:TD:", long_opts, NULL)) != -1)
@@ -750,10 +750,13 @@ int main(int argc, char *argv[])
         log_fatal("Set bias-T failed.");
         return 1;
     }
-    if (nrsc5_set_direct_sampling(radio, st->direct_sampling) != 0)
+    if (st->direct_sampling != -1)
     {
-        log_fatal("Set direct sampling failed.");
-        return 1;
+        if (nrsc5_set_direct_sampling(radio, st->direct_sampling) != 0)
+        {
+            log_fatal("Set direct sampling failed.");
+            return 1;
+        }
     }
     if (st->ppm_error != INT_MIN && nrsc5_set_freq_correction(radio, st->ppm_error) != 0)
     {

--- a/support/cli.py
+++ b/support/cli.py
@@ -40,7 +40,7 @@ class NRSC5CLI:
         parser.add_argument("-o", metavar="wav-output")
         parser.add_argument("-H", metavar="rtltcp-host")
         parser.add_argument("-T", action="store_true")
-        parser.add_argument("-D", metavar="direct-sampling-mode", type=int, default=0)
+        parser.add_argument("-D", metavar="direct-sampling-mode", type=int, default=-1)
         parser.add_argument("--dump-hdc", metavar="hdc-output")
         parser.add_argument("--dump-aas-files", metavar="directory")
         input_group.add_argument("frequency", nargs="?", type=float)
@@ -79,7 +79,8 @@ class NRSC5CLI:
             self.radio.set_mode(nrsc5.Mode.AM)
 
         self.radio.set_bias_tee(self.args.T)
-        self.radio.set_direct_sampling(self.args.D)
+        if self.args.D != -1:
+            self.radio.set_direct_sampling(self.args.D)
 
         if self.args.p is not None:
             self.radio.set_freq_correction(self.args.p)


### PR DESCRIPTION
Fixes #267.

It appears that calling `rtlsdr_set_direct_sampling(st->dev, 0)` on an E4000 tuner does not work properly. To avoid the problem, we can simply avoid calling this function at all if the `-D` command line option is not used, rather than defaulting to setting the direct sampling mode to zero.