### PR TITLE
Disable parametric stereo

### DIFF
--- a/support/faad2-hdc-support.patch
+++ b/support/faad2-hdc-support.patch
@@ -130,7 +130,7 @@ index cacd1c4..d3b6781 100644
 +/* Allow decoding of HDC */
 +#ifdef HDC_SUPPORT
 +#define DRM
-+#define DRM_PS
++/* #define DRM_PS */
 +#define HDC
 +#endif
  


### PR DESCRIPTION
Parametric Stereo (PS) is used to simulate stereo audio on low bandwidth
channels. Our decoding seems to cause audio distortions (#260) so
temporarily disable PS until we can fix the implementation.