### PR TITLE
Temporarily disable Python tests on macOS

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,8 +74,8 @@ jobs:
           grep -q "You're Listening to Q" sample.log
           cat sample | nrsc5 -r - -o sample.wav 0 2> sample.log
           grep -q "You're Listening to Q" sample.log
-          support/cli.py -r sample 0
-          cat sample | support/cli.py -r - 0
+          # support/cli.py -r sample 0
+          # cat sample | support/cli.py -r - 0
       - name: Windows cross-compile
         run: |
           brew install --cask xquartz wine-stable


### PR DESCRIPTION
CI currently fails on macOS with the following error:
```
Traceback (most recent call last):
  File "/Users/runner/work/nrsc5/nrsc5/support/cli.py", line 272, in <module>
    cli = NRSC5CLI()
          ^^^^^^^^^^
  File "/Users/runner/work/nrsc5/nrsc5/support/cli.py", line 18, in __init__
    self.radio = nrsc5.NRSC5(lambda evt_type, evt: self.callback(evt_type, evt))
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Users/runner/work/nrsc5/nrsc5/support/nrsc5.py", line 448, in __init__
    self._load_library()
  File "/Users/runner/work/nrsc5/nrsc5/support/nrsc5.py", line 346, in _load_library
    NRSC5.libnrsc5 = ctypes.cdll.LoadLibrary(lib_name)
                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/ctypes/__init__.py", line 454, in LoadLibrary
    return self._dlltype(name)
           ^^^^^^^^^^^^^^^^^^^
  File "/Library/Frameworks/Python.framework/Versions/3.11/lib/python3.11/ctypes/__init__.py", line 376, in __init__
    self._handle = _dlopen(self._name, mode)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^
OSError: dlopen(libnrsc5.dylib, 0x0006): tried: 'libnrsc5.dylib' (no such file), '/usr/lib/libnrsc5.dylib' (no such file), '/Users/runner/work/nrsc5/nrsc5/libnrsc5.dylib' (no such file)
Error: Process completed with exit code 1.
```
https://github.com/theori-io/nrsc5/actions/runs/3654014700/jobs/6174056836

It appears that something has changed in the GitHub Actions runner and `/usr/local/lib` is no longer in the library search path.

I made a few attempts at solving this (by setting the `DYLD_LIBRARY_PATH` and `DYLD_FALLBACK_LIBRARY_PATH` environment variables, and by attempting to install nrsc5 to `/usr` instead of `/usr/local`) but nothing has worked yet.

As a temporary workaround until a proper fix can be found, I'm proposing to disable the Python tests.