### PR TITLE
Fix integer overflow in partition assignment counters

### DIFF
--- a/src/decode.c
+++ b/src/decode.c
@@ -276,6 +276,7 @@ void decode_process_p3(decode_t *st)
     if (st->i_p3 == N)
     {
         st->i_p3 = 0;
+        memset(st->pt_p3, 0, sizeof(unsigned int) * 4);
         st->ready_p3 = 1;
     }
 }


### PR DESCRIPTION
The Interleaver IV (section 10.2.6 of [Layer 1 FM](https://www.nrscstandards.org/standards-and-guidelines/documents/standards/nrsc-5-d/reference-docs/1011s.pdf)) implementation has a bug: the partition assignment counters vector `pt` is subject to integer overflow. This causes the P3 logical channel to stop decoding after about 8 hours and 45 minutes.

Here I've fixed the problem by resetting the `pt` vector to zero each time the internal interleaver matrix is filled.