### PR TITLE
Allow all eight programs to be selected at runtime

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,7 +132,7 @@ Tune to 90.5 MHz and convert audio program 0 to WAV format for playback in an ex
 
 ### Keyboard commands:
 
-To switch between audio programs at runtime, press <kbd>0</kbd>, <kbd>1</kbd>, <kbd>2</kbd>, or <kbd>3</kbd>.
+To switch between audio programs at runtime, press <kbd>0</kbd> through <kbd>7</kbd>.
 
 To quit, press <kbd>Q</kbd>.
 

--- a/src/main.c
+++ b/src/main.c
@@ -493,6 +493,10 @@ static void *input_main(void *arg)
         case '1':
         case '2':
         case '3':
+        case '4':
+        case '5':
+        case '6':
+        case '7':
             change_program(st, ch - '0');
             break;
         }


### PR DESCRIPTION
As noted in #287, stations can have up to eight audio programs, but only the first four can be selected at runtime. Here I've added the remaining four.