### PR TITLE
Adding ability to output raw pcm format in addition to wav

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,9 @@ Replace `32` with `64` if you want a 64-bit build. Once the build is complete, c
                                       (example: localhost:1234)
     -r iq-input                     read IQ samples from input file
     -w iq-output                    write IQ samples to output file
-    -o audio-output                 write audio to output WAV file
+    -o audio-output                 write audio to output file
+    -t audio-type                   type of audio output (wav or raw)
+                                      (default is wav. used in conjunction with -o)
     -q                              disable log output
     -l log-level                    set log level
                                       (1 = DEBUG, 2 = INFO, 3 = WARN)


### PR DESCRIPTION
Due to Issue #279 regarding wav output stopping after about 3 hours  I added a flag "-P" to allow raw pcm output which should bypass any wav file limitations. It does require that you manually set the format and sample rate for consuming programs (with ffmpeg you can use s16le for format). I'm using this command to pipe to icecast2 with great results so far:

`nrsc5 -P -q -o - 94.3 0 | ffmpeg -re -ar 44100 -vn -ac 2 -channel_layout stereo -f s16le -i - -f ogg -c:a flac  -content_type 'application/ogg' icecast://source:PASSWORD@127.0.0.1:8000/radio`