### PR TITLE
Add support for Service Mode MP11

### DIFF
--- a/src/conv.h
+++ b/src/conv.h
@@ -30,7 +30,7 @@ struct lte_conv_code {
 
 int nrsc5_conv_decode_p1(const int8_t *in, uint8_t *out);
 int nrsc5_conv_decode_pids(const int8_t *in, uint8_t *out);
-int nrsc5_conv_decode_p3(const int8_t *in, uint8_t *out);
+int nrsc5_conv_decode_p3_p4(const int8_t *in, uint8_t *out);
 int nrsc5_conv_decode_e1(const int8_t *in, uint8_t *out, int len);
 int nrsc5_conv_decode_e2(const int8_t *in, uint8_t *out, int len);
 int nrsc5_conv_decode_e3(const int8_t *in, uint8_t *out, int len);

--- a/src/conv_dec.c
+++ b/src/conv_dec.c
@@ -462,7 +462,7 @@ int nrsc5_conv_decode_pids(const int8_t *in, uint8_t *out)
 	return nrsc5_conv_decode(in, out, 7, PIDS_FRAME_LEN, 0133, 0171, 0165);
 }
 
-int nrsc5_conv_decode_p3(const int8_t *in, uint8_t *out)
+int nrsc5_conv_decode_p3_p4(const int8_t *in, uint8_t *out)
 {
 	return nrsc5_conv_decode(in, out, 7, P3_FRAME_LEN_FM, 0133, 0171, 0165);
 }

--- a/src/decode.c
+++ b/src/decode.c
@@ -264,7 +264,7 @@ void decode_process_p3_p4(decode_t *st, interleaver_iv_t *interleaver, int8_t *v
         if ((out % 6) == 1 || (out % 6) == 4) // depuncture, [1, 0, 1, 1, 0, 1]
             viterbi[out++] = 0;
 
-        interleaver->internal[interleaver->i] = interleaver->buffer[i];
+        interleaver->internal[interleaver->i] = interleaver->buffer[interleaver->buffer_number][i];
         interleaver->i++;
     }
     if (interleaver->ready)
@@ -342,6 +342,8 @@ void decode_process_p1_p3_am(decode_t *st)
 
 static void interleaver_iv_reset(interleaver_iv_t *interleaver)
 {
+    interleaver->buffer_number = 0;
+    interleaver->buffer_ready = 0;
     interleaver->idx = 0;
     interleaver->i = 0;
     memset(interleaver->pt, 0, sizeof(unsigned int) * 4);

--- a/src/decode.c
+++ b/src/decode.c
@@ -247,7 +247,7 @@ void decode_process_pids(decode_t *st)
     pids_frame_push(&st->pids, st->scrambler_pids);
 }
 
-void decode_process_p3(decode_t *st)
+void decode_process_p3_p4(decode_t *st, interleaver_iv_t *interleaver, int8_t *viterbi, uint8_t *scrambler)
 {
     const unsigned int J = 4, B = 32, C = 36, M = 2, N = 147456;
     const unsigned int bk_bits = 32 * C;
@@ -255,29 +255,29 @@ void decode_process_p3(decode_t *st)
     unsigned int i, out = 0;
     for (i = 0; i < P3_FRAME_LEN_ENCODED_FM; i++)
     {
-        int partition = ((st->i_p3 + 2 * (M / 4)) / M) % J;
-        unsigned int pti = (st->pt_p3[partition])++;
+        int partition = ((interleaver->i + 2 * (M / 4)) / M) % J;
+        unsigned int pti = interleaver->pt[partition]++;
         int block = (pti + (partition * 7) - (bk_adj * (pti / bk_bits))) % B;
         int row = ((11 * pti) % bk_bits) / C;
         int column = (pti * 11) % C;
-        st->viterbi_p3[out++] = st->internal_p3[(block * 32 + row) * 144 + partition * C + column];
+        viterbi[out++] = interleaver->internal[(block * 32 + row) * 144 + partition * C + column];
         if ((out % 6) == 1 || (out % 6) == 4) // depuncture, [1, 0, 1, 1, 0, 1]
-            st->viterbi_p3[out++] = 0;
+            viterbi[out++] = 0;
 
-        st->internal_p3[st->i_p3] = st->buffer_px1[i];
-        (st->i_p3)++;
+        interleaver->internal[interleaver->i] = interleaver->buffer[i];
+        interleaver->i++;
     }
-    if (st->ready_p3)
+    if (interleaver->ready)
     {
-        nrsc5_conv_decode_p3(st->viterbi_p3, st->scrambler_p3);
-        descramble(st->scrambler_p3, P3_FRAME_LEN_FM);
-        frame_push(&st->input->frame, st->scrambler_p3, P3_FRAME_LEN_FM);
+        nrsc5_conv_decode_p3_p4(viterbi, scrambler);
+        descramble(scrambler, P3_FRAME_LEN_FM);
+        frame_push(&st->input->frame, scrambler, P3_FRAME_LEN_FM);
     }
-    if (st->i_p3 == N)
+    if (interleaver->i == N)
     {
-        st->i_p3 = 0;
-        memset(st->pt_p3, 0, sizeof(unsigned int) * 4);
-        st->ready_p3 = 1;
+        interleaver->i = 0;
+        memset(interleaver->pt, 0, sizeof(unsigned int) * 4);
+        interleaver->ready = 1;
     }
 }
 
@@ -340,15 +340,21 @@ void decode_process_p1_p3_am(decode_t *st)
     nrsc5_report_ber(st->input->radio, (float) total_errors / (8 * P1_FRAME_LEN_ENCODED_AM + P3_FRAME_LEN_ENCODED_AM));
 }
 
+static void interleaver_iv_reset(interleaver_iv_t *interleaver)
+{
+    interleaver->idx = 0;
+    interleaver->i = 0;
+    memset(interleaver->pt, 0, sizeof(unsigned int) * 4);
+    interleaver->ready = 0;
+}
+
 void decode_reset(decode_t *st)
 {
     st->idx_pm = 0;
-    st->idx_px1 = 0;
     st->idx_pu_pl_s_t = 0;
     st->am_diversity_wait = 3;
-    st->i_p3 = 0;
-    st->ready_p3 = 0;
-    memset(st->pt_p3, 0, sizeof(unsigned int) * 4);
+    interleaver_iv_reset(&st->interleaver_px1);
+    interleaver_iv_reset(&st->interleaver_px2);
     pids_init(&st->pids, st->input);
 }
 

--- a/src/decode.h
+++ b/src/decode.h
@@ -8,7 +8,9 @@
 
 typedef struct
 {
-  int8_t buffer[144 * BLKSZ * 2];
+  int8_t buffer[8][144 * BLKSZ * 2];
+  int buffer_number;
+  int buffer_ready;
   unsigned int idx;
   int8_t internal[P3_FRAME_LEN_FM * 32];
   unsigned int i;
@@ -82,10 +84,20 @@ static inline void decode_push_pm(decode_t *st, int8_t sbit)
 }
 static inline void decode_push_px1_px2(decode_t *st, interleaver_iv_t *interleaver, int8_t *viterbi, uint8_t *scrambler, int8_t sbit)
 {
-    interleaver->buffer[interleaver->idx++] = sbit;
+    unsigned int delay = ((interleaver == &st->interleaver_px2) && (interleaver->idx < 144 * BLKSZ)) ? 7 : 0;
+    interleaver->buffer[(interleaver->buffer_number + delay) % 8][interleaver->idx++] = sbit;
     if (interleaver->idx % (144 * BLKSZ * 2) == 0)
     {
-        decode_process_p3_p4(st, interleaver, viterbi, scrambler);
+        if (interleaver->buffer_ready)
+        {
+            decode_process_p3_p4(st, interleaver, viterbi, scrambler);
+        }
+        interleaver->buffer_number++;
+        if (interleaver->buffer_number == 8)
+        {
+            interleaver->buffer_number = 0;
+            interleaver->buffer_ready = 1;
+        }
         interleaver->idx = 0;
     }
 }

--- a/src/sync.c
+++ b/src/sync.c
@@ -494,6 +494,28 @@ void sync_process_fm(sync_t *st)
                     }
                 }
             }
+            if (compatibility_mode[st->psmi] == 11) {
+                for (i = LB_START + (PM_PARTITIONS + 2) * PARTITION_WIDTH; i < LB_START + (PM_PARTITIONS + 4) * PARTITION_WIDTH; i += PARTITION_WIDTH)
+                {
+                    unsigned int j;
+                    for (j = 1; j < PARTITION_WIDTH; j++)
+                    {
+                        c = st->buffer[i + j][n];
+                        decode_push_px2(&st->input->decode, DEMOD(crealf(c)) * mult_lb);
+                        decode_push_px2(&st->input->decode, DEMOD(cimagf(c)) * mult_lb);
+                    }
+                }
+                for (i = UB_END - (PM_PARTITIONS + 4) * PARTITION_WIDTH; i < UB_END - (PM_PARTITIONS + 2) * PARTITION_WIDTH; i += PARTITION_WIDTH)
+                {
+                    unsigned int j;
+                    for (j = 1; j < PARTITION_WIDTH; j++)
+                    {
+                        c = st->buffer[i + j][n];
+                        decode_push_px2(&st->input->decode, DEMOD(crealf(c)) * mult_ub);
+                        decode_push_px2(&st->input->decode, DEMOD(cimagf(c)) * mult_ub);
+                    }
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
Fixes #287.

@markjfine noticed that WWWT is using Service Mode MP11, which includes an additional logical data channel (P4). Here I've added support for this mode in two parts:

* fcd7ea7a80f53395e2447894d5eb3ab5772da2cc adds MP11 according to my reading of the NRSC-5 specification.
* d96b72c304f1902b4a762b632c8f56da6675f64a adds an additional delay block to the PX2 interleaver, which is necessary to receive WWWT's P4 logical data channel. (I reverse engineered its properties from WWWT's signal.)

I'm not sure why there's a mismatch between the specification and what WWWT is doing. Once more stations come online with MP11 signals, we should revisit this to see whether their signals are similar to WWWT's and decodable with the additional delay block in place.

I checked the new NRSC-5-E revision which was just published, and there don't appear to be any modifications to MP11.