### PR TITLE
Fix undefined behaviour in keyboard input

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -473,11 +473,11 @@ static void *input_main(void *arg)
 
     while (!st->done)
     {
-        int ch;
-
 #ifdef __MINGW32__
+        int ch;
         ch = _getch();
 #else
+        char ch;
         if (read(STDIN_FILENO, &ch, 1) != 1)
             break;
 #endif


### PR DESCRIPTION
Valgrind reports several errors if a key is pressed to switch between subchannels:
```
==3495671== Thread 3:
==3495671== Conditional jump or move depends on uninitialised value(s)
==3495671==    at 0x10F1D1: callback (in /home/argilo/git/nrsc5/build/src/nrsc5)
==3495671==    by 0x111951: output_aas_push (in /home/argilo/git/nrsc5/build/src/nrsc5)
==3495671==    by 0x11E8D6: frame_process (in /home/argilo/git/nrsc5/build/src/nrsc5)
==3495671==    by 0x1174CD: sync_process_fm (in /home/argilo/git/nrsc5/build/src/nrsc5)
==3495671==    by 0x11B3C0: acquire_process (in /home/argilo/git/nrsc5/build/src/nrsc5)
==3495671==    by 0x11382F: input_push (in /home/argilo/git/nrsc5/build/src/nrsc5)
==3495671==    by 0x110895: worker_thread (in /home/argilo/git/nrsc5/build/src/nrsc5)
==3495671==    by 0x4C46B42: start_thread (pthread_create.c:442)
==3495671==    by 0x4CD7BB3: clone (clone.S:100)
==3495671== 
==3495671== Conditional jump or move depends on uninitialised value(s)
==3495671==    at 0x10F029: callback (in /home/argilo/git/nrsc5/build/src/nrsc5)
==3495671==    by 0x110C14: nrsc5_report_hdc (in /home/argilo/git/nrsc5/build/src/nrsc5)
==3495671==    by 0x11110D: output_push (in /home/argilo/git/nrsc5/build/src/nrsc5)
==3495671==    by 0x11EB33: frame_process (in /home/argilo/git/nrsc5/build/src/nrsc5)
==3495671==    by 0x1174CD: sync_process_fm (in /home/argilo/git/nrsc5/build/src/nrsc5)
==3495671==    by 0x11B3C0: acquire_process (in /home/argilo/git/nrsc5/build/src/nrsc5)
==3495671==    by 0x11382F: input_push (in /home/argilo/git/nrsc5/build/src/nrsc5)
==3495671==    by 0x110895: worker_thread (in /home/argilo/git/nrsc5/build/src/nrsc5)
==3495671==    by 0x4C46B42: start_thread (pthread_create.c:442)
==3495671==    by 0x4CD7BB3: clone (clone.S:100)
==3495671== 
==3495671== Conditional jump or move depends on uninitialised value(s)
==3495671==    at 0x10F3B4: callback (in /home/argilo/git/nrsc5/build/src/nrsc5)
==3495671==    by 0x110C64: nrsc5_report_audio (in /home/argilo/git/nrsc5/build/src/nrsc5)
==3495671==    by 0x1111BC: output_push (in /home/argilo/git/nrsc5/build/src/nrsc5)
==3495671==    by 0x11EB33: frame_process (in /home/argilo/git/nrsc5/build/src/nrsc5)
==3495671==    by 0x1174CD: sync_process_fm (in /home/argilo/git/nrsc5/build/src/nrsc5)
==3495671==    by 0x11B3C0: acquire_process (in /home/argilo/git/nrsc5/build/src/nrsc5)
==3495671==    by 0x11382F: input_push (in /home/argilo/git/nrsc5/build/src/nrsc5)
==3495671==    by 0x110895: worker_thread (in /home/argilo/git/nrsc5/build/src/nrsc5)
==3495671==    by 0x4C46B42: start_thread (pthread_create.c:442)
==3495671==    by 0x4CD7BB3: clone (clone.S:100)
==3495671== 
==3495671== Conditional jump or move depends on uninitialised value(s)
==3495671==    at 0x10F46C: callback (in /home/argilo/git/nrsc5/build/src/nrsc5)
==3495671==    by 0x110C64: nrsc5_report_audio (in /home/argilo/git/nrsc5/build/src/nrsc5)
==3495671==    by 0x1111BC: output_push (in /home/argilo/git/nrsc5/build/src/nrsc5)
==3495671==    by 0x11EB33: frame_process (in /home/argilo/git/nrsc5/build/src/nrsc5)
==3495671==    by 0x1174CD: sync_process_fm (in /home/argilo/git/nrsc5/build/src/nrsc5)
==3495671==    by 0x11B3C0: acquire_process (in /home/argilo/git/nrsc5/build/src/nrsc5)
==3495671==    by 0x11382F: input_push (in /home/argilo/git/nrsc5/build/src/nrsc5)
==3495671==    by 0x110895: worker_thread (in /home/argilo/git/nrsc5/build/src/nrsc5)
==3495671==    by 0x4C46B42: start_thread (pthread_create.c:442)
==3495671==    by 0x4CD7BB3: clone (clone.S:100)
==3495671== 
==3495671== Conditional jump or move depends on uninitialised value(s)
==3495671==    at 0x10F029: callback (in /home/argilo/git/nrsc5/build/src/nrsc5)
==3495671==    by 0x110C14: nrsc5_report_hdc (in /home/argilo/git/nrsc5/build/src/nrsc5)
==3495671==    by 0x11110D: output_push (in /home/argilo/git/nrsc5/build/src/nrsc5)
==3495671==    by 0x11EA1F: frame_process (in /home/argilo/git/nrsc5/build/src/nrsc5)
==3495671==    by 0x1174CD: sync_process_fm (in /home/argilo/git/nrsc5/build/src/nrsc5)
==3495671==    by 0x11B3C0: acquire_process (in /home/argilo/git/nrsc5/build/src/nrsc5)
==3495671==    by 0x11382F: input_push (in /home/argilo/git/nrsc5/build/src/nrsc5)
==3495671==    by 0x110895: worker_thread (in /home/argilo/git/nrsc5/build/src/nrsc5)
==3495671==    by 0x4C46B42: start_thread (pthread_create.c:442)
==3495671==    by 0x4CD7BB3: clone (clone.S:100)
==3495671== 
==3495671== Conditional jump or move depends on uninitialised value(s)
==3495671==    at 0x10F3B4: callback (in /home/argilo/git/nrsc5/build/src/nrsc5)
==3495671==    by 0x110C64: nrsc5_report_audio (in /home/argilo/git/nrsc5/build/src/nrsc5)
==3495671==    by 0x1111BC: output_push (in /home/argilo/git/nrsc5/build/src/nrsc5)
==3495671==    by 0x11EA1F: frame_process (in /home/argilo/git/nrsc5/build/src/nrsc5)
==3495671==    by 0x1174CD: sync_process_fm (in /home/argilo/git/nrsc5/build/src/nrsc5)
==3495671==    by 0x11B3C0: acquire_process (in /home/argilo/git/nrsc5/build/src/nrsc5)
==3495671==    by 0x11382F: input_push (in /home/argilo/git/nrsc5/build/src/nrsc5)
==3495671==    by 0x110895: worker_thread (in /home/argilo/git/nrsc5/build/src/nrsc5)
==3495671==    by 0x4C46B42: start_thread (pthread_create.c:442)
==3495671==    by 0x4CD7BB3: clone (clone.S:100)
==3495671== 
==3495671== Conditional jump or move depends on uninitialised value(s)
==3495671==    at 0x10F46C: callback (in /home/argilo/git/nrsc5/build/src/nrsc5)
==3495671==    by 0x110C64: nrsc5_report_audio (in /home/argilo/git/nrsc5/build/src/nrsc5)
==3495671==    by 0x1111BC: output_push (in /home/argilo/git/nrsc5/build/src/nrsc5)
==3495671==    by 0x11EA1F: frame_process (in /home/argilo/git/nrsc5/build/src/nrsc5)
==3495671==    by 0x1174CD: sync_process_fm (in /home/argilo/git/nrsc5/build/src/nrsc5)
==3495671==    by 0x11B3C0: acquire_process (in /home/argilo/git/nrsc5/build/src/nrsc5)
==3495671==    by 0x11382F: input_push (in /home/argilo/git/nrsc5/build/src/nrsc5)
==3495671==    by 0x110895: worker_thread (in /home/argilo/git/nrsc5/build/src/nrsc5)
==3495671==    by 0x4C46B42: start_thread (pthread_create.c:442)
==3495671==    by 0x4CD7BB3: clone (clone.S:100)
==3495671== 
```
These errors happen because `ch` is an `int` (so as to work with `_getch()` on Windows), but `read(STDIN_FILENO, &ch, 1)` (on non-Windows platforms) only writes to the first byte of it, leaving the other bytes uninitialized.

Even if `ch` was initialized to zero, the code would still not work properly on big-endian systems, because the most significant byte of `ch` would be written.

To solve these problems, I've changed the type of `ch` to `char` on non-Windows platforms.