### PR TITLE
Log the primary service mode after synchronization

### DIFF
--- a/src/input.c
+++ b/src/input.c
@@ -287,7 +287,10 @@ void input_set_sync_state(input_t *st, unsigned int new_state)
     if (st->sync_state == SYNC_STATE_FINE)
         nrsc5_report_lost_sync(st->radio);
     if (new_state == SYNC_STATE_FINE)
+    {
         nrsc5_report_sync(st->radio);
+        log_debug("Primary service mode: %d", st->sync.psmi);
+    }
 
     st->sync_state = new_state;
 }


### PR DESCRIPTION
For debugging purposes, it's useful to know what the current primary service mode is, since some stations are beginning to use modes other than 1 and 3. For instance, in #287 we found that WWWT was using mode 11, and I recently noticed that WAMU is using mode 2 (which is not yet supported by nrsc5).

Here I've added a debug log message so that we'll notice new modes more quickly.