### PR TITLE
Implement checksum for Station Message

### DIFF
--- a/src/pids.h
+++ b/src/pids.h
@@ -54,6 +54,7 @@ typedef struct
     int message_priority;
     int message_encoding;
     int message_len;
+    unsigned int message_checksum;
     int message_displayed;
 
     asd_t audio_services[MAX_AUDIO_SERVICES];


### PR DESCRIPTION
The "Station Message" payload has a checksum, but nrsc5 was ignoring it up until now. Here I've added checksum validation. I verified that it works correctly with all stations in my collection of 85 recordings.