### PR TITLE
Add support for primary service mode MP2

### DIFF
--- a/src/conv.h
+++ b/src/conv.h
@@ -30,7 +30,7 @@ struct lte_conv_code {
 
 int nrsc5_conv_decode_p1(const int8_t *in, uint8_t *out);
 int nrsc5_conv_decode_pids(const int8_t *in, uint8_t *out);
-int nrsc5_conv_decode_p3_p4(const int8_t *in, uint8_t *out);
+int nrsc5_conv_decode_p3_p4(const int8_t *in, uint8_t *out, int len);
 int nrsc5_conv_decode_e1(const int8_t *in, uint8_t *out, int len);
 int nrsc5_conv_decode_e2(const int8_t *in, uint8_t *out, int len);
 int nrsc5_conv_decode_e3(const int8_t *in, uint8_t *out, int len);

--- a/src/conv_dec.c
+++ b/src/conv_dec.c
@@ -462,9 +462,9 @@ int nrsc5_conv_decode_pids(const int8_t *in, uint8_t *out)
 	return nrsc5_conv_decode(in, out, 7, PIDS_FRAME_LEN, 0133, 0171, 0165);
 }
 
-int nrsc5_conv_decode_p3_p4(const int8_t *in, uint8_t *out)
+int nrsc5_conv_decode_p3_p4(const int8_t *in, uint8_t *out, int len)
 {
-	return nrsc5_conv_decode(in, out, 7, P3_FRAME_LEN_FM, 0133, 0171, 0165);
+	return nrsc5_conv_decode(in, out, 7, len, 0133, 0171, 0165);
 }
 
 int nrsc5_conv_decode_e1(const int8_t *in, uint8_t *out, int len)

--- a/src/defines.h
+++ b/src/defines.h
@@ -82,6 +82,13 @@ typedef struct {
     int16_t r, i;
 } cint16_t;
 
+typedef enum {
+    P1_LOGICAL_CHANNEL,
+    P3_LOGICAL_CHANNEL,
+    P4_LOGICAL_CHANNEL,
+    NUM_LOGICAL_CHANNELS
+} logical_channel_t;
+
 static inline cint16_t cf_to_cq15(float complex x)
 {
     cint16_t cq15;

--- a/src/frame.h
+++ b/src/frame.h
@@ -18,6 +18,16 @@ typedef struct
 
 typedef struct
 {
+    unsigned int sync_width;
+    unsigned int sync_count;
+    uint8_t ccc_buf[32];
+    int ccc_idx;
+    fixed_subchannel_t subchannel[4];
+    int fixed_ready;
+} ccc_data_t;
+
+typedef struct
+{
     struct input_t *input;
     uint8_t buffer[MAX_PDU_LEN];
     uint8_t pdu[MAX_PROGRAMS][MAX_STREAMS][0x10000];
@@ -26,17 +36,11 @@ typedef struct
     unsigned int program;
     uint8_t psd_buf[MAX_PROGRAMS][MAX_AAS_LEN];
     int psd_idx[MAX_PROGRAMS];
-
-    unsigned int sync_width;
-    unsigned int sync_count;
-    uint8_t ccc_buf[32];
-    int ccc_idx;
-    fixed_subchannel_t subchannel[4];
-    int fixed_ready;
+    ccc_data_t ccc_data[NUM_LOGICAL_CHANNELS];
     void *rs_dec;
 } frame_t;
 
-void frame_push(frame_t *st, uint8_t *bits, size_t length);
+void frame_push(frame_t *st, uint8_t *bits, size_t length, logical_channel_t lc);
 void frame_reset(frame_t *st);
 void frame_set_program(frame_t *st, unsigned int program);
 void frame_init(frame_t *st, struct input_t *input);

--- a/src/sync.c
+++ b/src/sync.c
@@ -472,6 +472,21 @@ void sync_process_fm(sync_t *st)
                     decode_push_pm(&st->input->decode, DEMOD(cimagf(c)) * mult_ub);
                 }
             }
+            if (compatibility_mode[st->psmi] == 2) {
+                unsigned int j;
+                for (j = 1; j < PARTITION_WIDTH; j++)
+                {
+                    c = st->buffer[LB_START + (PM_PARTITIONS * PARTITION_WIDTH) + j][n];
+                    decode_push_px1(&st->input->decode, DEMOD(crealf(c)) * mult_lb, P3_FRAME_LEN_FM / 2);
+                    decode_push_px1(&st->input->decode, DEMOD(cimagf(c)) * mult_lb, P3_FRAME_LEN_FM / 2);
+                }
+                for (j = 1; j < PARTITION_WIDTH; j++)
+                {
+                    c = st->buffer[UB_END - (PM_PARTITIONS + 1) * PARTITION_WIDTH + j][n];
+                    decode_push_px1(&st->input->decode, DEMOD(crealf(c)) * mult_ub, P3_FRAME_LEN_FM / 2);
+                    decode_push_px1(&st->input->decode, DEMOD(cimagf(c)) * mult_ub, P3_FRAME_LEN_FM / 2);
+                }
+            }
             if ((compatibility_mode[st->psmi] == 3) || (compatibility_mode[st->psmi] == 11)) {
                 for (i = LB_START + (PM_PARTITIONS * PARTITION_WIDTH); i < LB_START + (PM_PARTITIONS + 2) * PARTITION_WIDTH; i += PARTITION_WIDTH)
                 {
@@ -479,8 +494,8 @@ void sync_process_fm(sync_t *st)
                     for (j = 1; j < PARTITION_WIDTH; j++)
                     {
                         c = st->buffer[i + j][n];
-                        decode_push_px1(&st->input->decode, DEMOD(crealf(c)) * mult_lb);
-                        decode_push_px1(&st->input->decode, DEMOD(cimagf(c)) * mult_lb);
+                        decode_push_px1(&st->input->decode, DEMOD(crealf(c)) * mult_lb, P3_FRAME_LEN_FM);
+                        decode_push_px1(&st->input->decode, DEMOD(cimagf(c)) * mult_lb, P3_FRAME_LEN_FM);
                     }
                 }
                 for (i = UB_END - (PM_PARTITIONS + 2) * PARTITION_WIDTH; i < UB_END - (PM_PARTITIONS * PARTITION_WIDTH); i += PARTITION_WIDTH)
@@ -489,8 +504,8 @@ void sync_process_fm(sync_t *st)
                     for (j = 1; j < PARTITION_WIDTH; j++)
                     {
                         c = st->buffer[i + j][n];
-                        decode_push_px1(&st->input->decode, DEMOD(crealf(c)) * mult_ub);
-                        decode_push_px1(&st->input->decode, DEMOD(cimagf(c)) * mult_ub);
+                        decode_push_px1(&st->input->decode, DEMOD(crealf(c)) * mult_ub, P3_FRAME_LEN_FM);
+                        decode_push_px1(&st->input->decode, DEMOD(cimagf(c)) * mult_ub, P3_FRAME_LEN_FM);
                     }
                 }
             }


### PR DESCRIPTION
Fixes #305.

This pull request does the following:

1. Adds support for primary service mode MP2. This mode is very similar to mode MP3, except that the P3 logical channel is only half as wide. Because of this difference, it also uses slightly different interleaver parameters. To accomodate this mode, I've added length arguments to some of the functions that process the P3 logical channel.
2. Adds support for fixed data in logical channels other than P1. To accommodate this, we need one CCC data structure per logical channel, and various functions have to pass around the current logical channel number.
3. Adds support for L2 PDUs containing only fixed data (and no audio).

All three enhancements were needed to properly receive WAMU, which uses mode MP2 and puts its station logos in data-only L2 PDUs in the P3 logical channel.