### PR TITLE
Expose stream & packet data through the API

### DIFF
--- a/include/nrsc5.h
+++ b/include/nrsc5.h
@@ -77,14 +77,14 @@ struct nrsc5_sig_component_t
             uint16_t port;  /**< distinguishes packets for this service */
             /** e.g. NRSC5_SERVICE_DATA_TYPE_AUDIO_RELATED_DATA */
             uint16_t service_data_type;
-            uint8_t type;   /**< 0 for stream,  1 for packet, 3 for LOT */
+            uint8_t type;   /**< 0 for stream, 1 for packet, 3 for LOT */
             uint32_t mime;  /**< content, e.g. NRSC5_MIME_STATION_LOGO */
         } data;
         /*! Audio service information
          */
         struct {
             uint8_t port;   /**< distinguishes packets for this service */
-            uint8_t type;   /**< 0 for stream,  1 for packet, 3 for LOT */
+            uint8_t type;   /**< 0 for stream, 1 for packet, 3 for LOT */
             uint32_t mime;  /**< content, e.g. NRSC5_MIME_HDC */
         } audio;
     };
@@ -135,7 +135,9 @@ enum
     NRSC5_EVENT_ID3,
     NRSC5_EVENT_SIG,
     NRSC5_EVENT_LOT,
-    NRSC5_EVENT_SIS
+    NRSC5_EVENT_SIS,
+    NRSC5_EVENT_STREAM,
+    NRSC5_EVENT_PACKET
 };
 
 enum
@@ -261,6 +263,8 @@ struct nrsc5_event_t
  * - `NRSC5_EVENT_ID3` : ID3 information packet arrived, see `id3` member
  *    and information in HD-Radio document SY_IDD_1028s.
  * - `NRSC5_EVENT_SIG` : service information arrived, see `sig` member
+ * - `NRSC5_EVENT_STREAM` : stream data available, see `stream` member
+ * - `NRSC5_EVENT_PACKET` : packet data available, see `packet` member
  * - `NRSC5_EVENT_LOT` : LOT file data available, see `lot` member
  * - `NRSC5_EVENT_SIS` : station information, see `sis` member
  */
@@ -304,6 +308,18 @@ struct nrsc5_event_t
                 int lot;
             } xhdr;
         } id3;
+        struct {
+            uint16_t port;
+            unsigned int size;
+            uint32_t mime;
+            const uint8_t *data;
+        } stream;
+        struct {
+            uint16_t port;
+            unsigned int size;
+            uint32_t mime;
+            const uint8_t *data;
+        } packet;
         struct {
             uint16_t port;
             unsigned int lot;

--- a/src/main.c
+++ b/src/main.c
@@ -364,6 +364,12 @@ static void callback(const nrsc5_event_t *evt, void *opaque)
             }
         }
         break;
+    case NRSC5_EVENT_STREAM:
+        log_info("Stream data: port=%04X mime=%08X size=%d", evt->stream.port, evt->stream.mime, evt->stream.size);
+        break;
+    case NRSC5_EVENT_PACKET:
+        log_info("Packet data: port=%04X mime=%08X size=%d", evt->packet.port, evt->packet.mime, evt->packet.size);
+        break;
     case NRSC5_EVENT_LOT:
         if (st->aas_files_path)
             dump_aas_file(st, evt);

--- a/src/nrsc5.c
+++ b/src/nrsc5.c
@@ -640,6 +640,30 @@ void nrsc5_report_ber(nrsc5_t *st, float cber)
     nrsc5_report(st, &evt);
 }
 
+void nrsc5_report_stream(nrsc5_t *st, uint16_t port, unsigned int size, uint32_t mime, const uint8_t *data)
+{
+    nrsc5_event_t evt;
+
+    evt.event = NRSC5_EVENT_STREAM;
+    evt.stream.port = port;
+    evt.stream.size = size;
+    evt.stream.mime = mime;
+    evt.stream.data = data;
+    nrsc5_report(st, &evt);
+}
+
+void nrsc5_report_packet(nrsc5_t *st, uint16_t port, unsigned int size, uint32_t mime, const uint8_t *data)
+{
+    nrsc5_event_t evt;
+
+    evt.event = NRSC5_EVENT_PACKET;
+    evt.packet.port = port;
+    evt.packet.size = size;
+    evt.packet.mime = mime;
+    evt.packet.data = data;
+    nrsc5_report(st, &evt);
+}
+
 void nrsc5_report_lot(nrsc5_t *st, uint16_t port, unsigned int lot, unsigned int size, uint32_t mime, const char *name, const uint8_t *data)
 {
     nrsc5_event_t evt;

--- a/src/output.h
+++ b/src/output.h
@@ -16,7 +16,6 @@
 #define LOT_FRAGMENT_SIZE 256
 #define MAX_FILE_BYTES 65536
 #define MAX_LOT_FRAGMENTS (MAX_FILE_BYTES / LOT_FRAGMENT_SIZE)
-#define MAX_STREAM_BYTES 65543
 
 #define AAS_TYPE_STREAM 0
 #define AAS_TYPE_PACKET 1
@@ -52,22 +51,7 @@ typedef struct
     uint8_t type;
     unsigned int service_number;
     uint32_t mime;
-
-    union
-    {
-        struct
-        {
-            uint8_t prev[3];
-            uint8_t type;
-            uint16_t size;
-            uint8_t *data;
-            unsigned int idx;
-        } stream;
-        struct
-        {
-            aas_file_t files[MAX_LOT_FILES];
-        } lot;
-    };
+    aas_file_t lot_files[MAX_LOT_FILES];
 } aas_port_t;
 
 typedef struct

--- a/src/private.h
+++ b/src/private.h
@@ -47,6 +47,8 @@ void nrsc5_report_mer(nrsc5_t *, float lower, float upper);
 void nrsc5_report_ber(nrsc5_t *, float cber);
 void nrsc5_report_hdc(nrsc5_t *, unsigned int program, const uint8_t *data, size_t count);
 void nrsc5_report_audio(nrsc5_t *, unsigned int program, const int16_t *data, size_t count);
+void nrsc5_report_stream(nrsc5_t *, uint16_t port, unsigned int size, uint32_t mime, const uint8_t *data);
+void nrsc5_report_packet(nrsc5_t *, uint16_t port, unsigned int size, uint32_t mime, const uint8_t *data);
 void nrsc5_report_lot(nrsc5_t *, uint16_t port, unsigned int lot, unsigned int size, uint32_t mime, const char *name, const uint8_t *data);
 void nrsc5_report_sig(nrsc5_t *, sig_service_t *services, unsigned int count);
 void nrsc5_report_sis(nrsc5_t *, const char *country_code, int fcc_facility_id, const char *name,

--- a/support/cli.py
+++ b/support/cli.py
@@ -233,6 +233,12 @@ class NRSC5CLI:
                                      component.id, component.data.port,
                                      component.data.service_data_type,
                                      component.data.type, component.data.mime)
+        elif evt_type == nrsc5.EventType.STREAM:
+            logging.info("Stream data: port=%04X mime=%s size=%s",
+                         evt.port, evt.mime, len(evt.data))
+        elif evt_type == nrsc5.EventType.PACKET:
+            logging.info("Packet data: port=%04X mime=%s size=%s",
+                         evt.port, evt.mime, len(evt.data))
         elif evt_type == nrsc5.EventType.LOT:
             logging.info("LOT file: port=%04X lot=%s name=%s size=%s mime=%s",
                          evt.port, evt.lot, evt.name, len(evt.data), evt.mime)


### PR DESCRIPTION
There are three AAS data types used by HD Radio stations: Stream, Packet, and Large Object Transfer (LOT). Of these, only LOT files are currently exposed through the nrsc5 API. There is a bit of code in output.c aimed at decoding Stream data, but it is not functional.

Since there are various Stream data types (HERE TPEG, HERE Images, TTN TPEG) and Packet data types (HD TMC, NavteqPacketData1, NavteqAdmin) in use, I think it would make sense to expose the raw Stream & Packet payloads through the API, and make the consuming application responsible for decoding the data type(s) it cares about.

Here I've added `NRSC5_EVENT_STREAM` and `NRSC5_EVENT_PACKET` event types to the API. Each of these reports the 16-bit port number, payload size, 32-bit MIME hash (taken from the corresponding entry in the SIG table), and payload data.

For the moment, the C & Python CLI apps simply report that data is present.

C:
```
14:50:27 Packet data: port=0403 mime=2D42AC3E size=8
14:50:27 Stream data: port=0404 mime=B7F03DFC size=646
14:50:27 Stream data: port=0402 mime=82F03DFC size=814
14:50:27 Packet data: port=0403 mime=2D42AC3E size=8
14:50:27 Packet data: port=0401 mime=2D42AC3E size=928
14:50:27 Stream data: port=0404 mime=B7F03DFC size=647
```

Python:
```
14:51:13 Packet data: port=0403 mime=MIMEType.NAVTEQ size=8
14:51:13 Stream data: port=0404 mime=MIMEType.HERE_IMAGE size=646
14:51:13 Stream data: port=0402 mime=MIMEType.HERE_TPEG size=814
14:51:13 Packet data: port=0403 mime=MIMEType.NAVTEQ size=8
14:51:13 Packet data: port=0401 mime=MIMEType.NAVTEQ size=928
14:51:13 Stream data: port=0404 mime=MIMEType.HERE_IMAGE size=647
```