### PR TITLE
Convert long name & SIG service name to UTF-8

### DIFF
--- a/src/output.c
+++ b/src/output.c
@@ -348,10 +348,7 @@ static void parse_sig(output_t *st, uint8_t *buf, unsigned int len)
             }
             else if (type == 0x69)
             {
-                char *name = malloc(l - 1);
-                memcpy(name, p + 1, l - 2);
-                name[l - 2] = 0;
-                service->name = name;
+                service->name = iso_8859_1_to_utf_8(p + 1, l - 2);
             }
             else if (type == 0x67)
             {

--- a/src/pids.c
+++ b/src/pids.c
@@ -89,11 +89,11 @@ static char decode_char7(uint8_t *bits, int *off)
     return (char) decode_int(bits, off, 7);
 }
 
-static char *utf8_encode(int encoding, char *buf, int len)
+static char *utf8_encode(encoding_t encoding, char *buf, int len)
 {
-    if (encoding == 0)
+    if (encoding == ENCODING_ISO_8859_1)
         return iso_8859_1_to_utf_8((uint8_t *) buf, len);
-    else if (encoding == 4)
+    else if (encoding == ENCODING_UCS_2)
         return ucs_2_to_utf_8((uint8_t *) buf, len);
     else
         log_warn("Invalid encoding: %d", encoding);
@@ -128,7 +128,7 @@ static void report(pids_t *st)
     if (st->slogan_displayed)
         slogan = utf8_encode(st->slogan_encoding, st->slogan, st->slogan_len);
     else if (st->long_name_displayed)
-        slogan = strdup(st->long_name);
+        slogan = utf8_encode(ENCODING_ISO_8859_1, st->long_name, strlen(st->long_name));
 
     if (st->message_displayed)
         message = utf8_encode(st->message_encoding, st->message, st->message_len);

--- a/src/pids.h
+++ b/src/pids.h
@@ -30,6 +30,12 @@ typedef struct
     int mime_type;
 } dsd_t;
 
+typedef enum
+{
+    ENCODING_ISO_8859_1 = 0,
+    ENCODING_UCS_2 = 4
+} encoding_t;
+
 typedef struct
 {
     struct input_t *input;
@@ -52,7 +58,7 @@ typedef struct
     uint8_t message_have_frame[MAX_MESSAGE_FRAMES];
     int message_seq;
     int message_priority;
-    int message_encoding;
+    encoding_t message_encoding;
     int message_len;
     unsigned int message_checksum;
     int message_displayed;
@@ -65,21 +71,21 @@ typedef struct
     char universal_short_name[MAX_UNIVERSAL_SHORT_NAME_LEN + 1];
     char universal_short_name_final[MAX_UNIVERSAL_SHORT_NAME_LEN + 4];
     uint8_t universal_short_name_have_frame[MAX_UNIVERSAL_SHORT_NAME_FRAMES];
-    int universal_short_name_encoding;
+    encoding_t universal_short_name_encoding;
     int universal_short_name_append;
     int universal_short_name_len;
     int universal_short_name_displayed;
 
     char slogan[MAX_SLOGAN_LEN + 1];
     uint8_t slogan_have_frame[MAX_SLOGAN_FRAMES];
-    int slogan_encoding;
+    encoding_t slogan_encoding;
     int slogan_len;
     int slogan_displayed;
 
     char alert[MAX_ALERT_LEN + 1];
     uint8_t alert_have_frame[MAX_ALERT_FRAMES];
     int alert_seq;
-    int alert_encoding;
+    encoding_t alert_encoding;
     int alert_len;
     int alert_cnt_len;
     int alert_displayed;


### PR DESCRIPTION
The SIS long name & SIG service name fields are encoded as ISO-8859-1, which means that they must be converted to UTF-8 for display. After making this change, both fields are displayed properly:

```
17:45:41 Slogan: ICI R-C Première
17:45:41 SIG Service: type=ServiceType.AUDIO number=1 name=ICI R-C Première
```