### PR TITLE
Report LOT expiry time in the API

### DIFF
--- a/include/nrsc5.h
+++ b/include/nrsc5.h
@@ -19,6 +19,7 @@
 #include <stdint.h>
 #include <stdlib.h>
 #include <stdio.h>
+#include <time.h>
 
 /*
  * Definitions.
@@ -325,6 +326,7 @@ struct nrsc5_event_t
             unsigned int lot;
             unsigned int size;
             uint32_t mime;
+            struct tm *expiry_utc;
             const char *name;
             const uint8_t *data;
         } lot;

--- a/src/main.c
+++ b/src/main.c
@@ -373,7 +373,9 @@ static void callback(const nrsc5_event_t *evt, void *opaque)
     case NRSC5_EVENT_LOT:
         if (st->aas_files_path)
             dump_aas_file(st, evt);
-        log_info("LOT file: port=%04X lot=%d name=%s size=%d mime=%08X", evt->lot.port, evt->lot.lot, evt->lot.name, evt->lot.size, evt->lot.mime);
+        char time_str[64];
+        strftime(time_str, sizeof(time_str), "%Y-%m-%dT%H:%M:%SZ", evt->lot.expiry_utc);
+        log_info("LOT file: port=%04X lot=%d name=%s size=%d mime=%08X expiry=%s", evt->lot.port, evt->lot.lot, evt->lot.name, evt->lot.size, evt->lot.mime, time_str);
         break;
     case NRSC5_EVENT_SIS:
         if (evt->sis.country_code)

--- a/src/nrsc5.c
+++ b/src/nrsc5.c
@@ -664,7 +664,7 @@ void nrsc5_report_packet(nrsc5_t *st, uint16_t port, unsigned int size, uint32_t
     nrsc5_report(st, &evt);
 }
 
-void nrsc5_report_lot(nrsc5_t *st, uint16_t port, unsigned int lot, unsigned int size, uint32_t mime, const char *name, const uint8_t *data)
+void nrsc5_report_lot(nrsc5_t *st, uint16_t port, unsigned int lot, unsigned int size, uint32_t mime, struct tm *expiry_utc, const char *name, const uint8_t *data)
 {
     nrsc5_event_t evt;
 
@@ -673,6 +673,7 @@ void nrsc5_report_lot(nrsc5_t *st, uint16_t port, unsigned int lot, unsigned int
     evt.lot.lot = lot;
     evt.lot.size = size;
     evt.lot.mime = mime;
+    evt.lot.expiry_utc = expiry_utc;
     evt.lot.name = name;
     evt.lot.data = data;
     nrsc5_report(st, &evt);

--- a/src/output.h
+++ b/src/output.h
@@ -40,6 +40,7 @@ typedef struct
     unsigned int timestamp;
     char *name;
     uint32_t mime;
+    struct tm expiry_utc;
     uint16_t lot;
     uint32_t size;
     uint8_t **fragments;

--- a/src/private.h
+++ b/src/private.h
@@ -49,7 +49,7 @@ void nrsc5_report_hdc(nrsc5_t *, unsigned int program, const uint8_t *data, size
 void nrsc5_report_audio(nrsc5_t *, unsigned int program, const int16_t *data, size_t count);
 void nrsc5_report_stream(nrsc5_t *, uint16_t port, unsigned int size, uint32_t mime, const uint8_t *data);
 void nrsc5_report_packet(nrsc5_t *, uint16_t port, unsigned int size, uint32_t mime, const uint8_t *data);
-void nrsc5_report_lot(nrsc5_t *, uint16_t port, unsigned int lot, unsigned int size, uint32_t mime, const char *name, const uint8_t *data);
+void nrsc5_report_lot(nrsc5_t *, uint16_t port, unsigned int lot, unsigned int size, uint32_t mime, struct tm *expiry_utc, const char *name, const uint8_t *data);
 void nrsc5_report_sig(nrsc5_t *, sig_service_t *services, unsigned int count);
 void nrsc5_report_sis(nrsc5_t *, const char *country_code, int fcc_facility_id, const char *name,
                       const char *slogan, const char *message, const char *alert,

--- a/support/cli.py
+++ b/support/cli.py
@@ -240,8 +240,9 @@ class NRSC5CLI:
             logging.info("Packet data: port=%04X mime=%s size=%s",
                          evt.port, evt.mime, len(evt.data))
         elif evt_type == nrsc5.EventType.LOT:
-            logging.info("LOT file: port=%04X lot=%s name=%s size=%s mime=%s",
-                         evt.port, evt.lot, evt.name, len(evt.data), evt.mime)
+            time_str = evt.expiry_utc.strftime("%Y-%m-%dT%H:%M:%SZ")
+            logging.info("LOT file: port=%04X lot=%s name=%s size=%s mime=%s expiry=%s",
+                         evt.port, evt.lot, evt.name, len(evt.data), evt.mime, time_str)
             if self.args.dump_aas_files:
                 path = os.path.join(self.args.dump_aas_files, evt.name)
                 with open(path, "wb") as file:


### PR DESCRIPTION
In the initial implementation of LOT file decoding, a few fields from the protocol had unknown meaning. I've filled those in here.

One of the fields is an expiry time (in UTC) after which the file can be safely discarded. This seems useful to expose through the API, so I've added it. (In C it's provided as a `struct tm *`, and in Python it's a `datetime` object.)