### PR TITLE
Skip audio processing in PDUs that only have fixed data

### DIFF
--- a/src/frame.c
+++ b/src/frame.c
@@ -142,6 +142,14 @@ static uint16_t fcs16(const uint8_t *cp, int len)
     return (crc);
 }
 
+static int has_audio(frame_t *st)
+{
+    return (st->pci & 0xFFFFFC) == (PCI_AUDIO & 0xFFFFFC)
+           || (st->pci & 0xFFFFFC) == (PCI_AUDIO_OPP & 0xFFFFFC)
+           || (st->pci & 0xFFFFFC) == (PCI_AUDIO_FIXED & 0xFFFFFC)
+           || (st->pci & 0xFFFFFC) == (PCI_AUDIO_FIXED_OPP & 0xFFFFFC);
+}
+
 static int has_fixed(frame_t *st)
 {
     return (st->pci & 0xFFFFFC) == (PCI_AUDIO_FIXED & 0xFFFFFC)
@@ -489,6 +497,9 @@ void frame_process(frame_t *st, size_t length, logical_channel_t lc)
 
     if (has_fixed(st))
         audio_end = process_fixed_data(st, length, lc);
+    
+    if (!has_audio(st))
+        return;
 
     while (offset < audio_end - RS_CODEWORD_LEN)
     {


### PR DESCRIPTION
L2 PDUs with header sequence CW4 contain only fixed data, and no audio. Audio packets should only be processed if the header sequence is CW0, CW1, CW2, or CW3.