### PR TITLE
Expose AAS sequence numbers in the API

### DIFF
--- a/include/nrsc5.h
+++ b/include/nrsc5.h
@@ -311,12 +311,14 @@ struct nrsc5_event_t
         } id3;
         struct {
             uint16_t port;
+            uint16_t seq;
             unsigned int size;
             uint32_t mime;
             const uint8_t *data;
         } stream;
         struct {
             uint16_t port;
+            uint16_t seq;
             unsigned int size;
             uint32_t mime;
             const uint8_t *data;

--- a/src/main.c
+++ b/src/main.c
@@ -365,10 +365,10 @@ static void callback(const nrsc5_event_t *evt, void *opaque)
         }
         break;
     case NRSC5_EVENT_STREAM:
-        log_info("Stream data: port=%04X mime=%08X size=%d", evt->stream.port, evt->stream.mime, evt->stream.size);
+        log_info("Stream data: port=%04X seq=%04X mime=%08X size=%d", evt->stream.port, evt->stream.seq, evt->stream.mime, evt->stream.size);
         break;
     case NRSC5_EVENT_PACKET:
-        log_info("Packet data: port=%04X mime=%08X size=%d", evt->packet.port, evt->packet.mime, evt->packet.size);
+        log_info("Packet data: port=%04X seq=%04X mime=%08X size=%d", evt->packet.port, evt->packet.seq, evt->packet.mime, evt->packet.size);
         break;
     case NRSC5_EVENT_LOT:
         if (st->aas_files_path)

--- a/src/nrsc5.c
+++ b/src/nrsc5.c
@@ -640,24 +640,26 @@ void nrsc5_report_ber(nrsc5_t *st, float cber)
     nrsc5_report(st, &evt);
 }
 
-void nrsc5_report_stream(nrsc5_t *st, uint16_t port, unsigned int size, uint32_t mime, const uint8_t *data)
+void nrsc5_report_stream(nrsc5_t *st, uint16_t port, uint16_t seq, unsigned int size, uint32_t mime, const uint8_t *data)
 {
     nrsc5_event_t evt;
 
     evt.event = NRSC5_EVENT_STREAM;
     evt.stream.port = port;
+    evt.stream.seq = seq;
     evt.stream.size = size;
     evt.stream.mime = mime;
     evt.stream.data = data;
     nrsc5_report(st, &evt);
 }
 
-void nrsc5_report_packet(nrsc5_t *st, uint16_t port, unsigned int size, uint32_t mime, const uint8_t *data)
+void nrsc5_report_packet(nrsc5_t *st, uint16_t port, uint16_t seq, unsigned int size, uint32_t mime, const uint8_t *data)
 {
     nrsc5_event_t evt;
 
     evt.event = NRSC5_EVENT_PACKET;
     evt.packet.port = port;
+    evt.packet.seq = seq;
     evt.packet.size = size;
     evt.packet.mime = mime;
     evt.packet.data = data;

--- a/src/output.c
+++ b/src/output.c
@@ -452,7 +452,7 @@ static aas_file_t *find_free_lot(aas_port_t *port)
     return file;
 }
 
-static void process_port(output_t *st, uint16_t port_id, uint8_t *buf, unsigned int len)
+static void process_port(output_t *st, uint16_t port_id, uint16_t seq, uint8_t *buf, unsigned int len)
 {
     static unsigned int counter = 1;
     aas_port_t *port;
@@ -474,12 +474,12 @@ static void process_port(output_t *st, uint16_t port_id, uint8_t *buf, unsigned 
     {
     case AAS_TYPE_STREAM:
     {
-        nrsc5_report_stream(st->radio, port_id, len, port->mime, buf);
+        nrsc5_report_stream(st->radio, port_id, seq, len, port->mime, buf);
         break;
     }
     case AAS_TYPE_PACKET:
     {
-        nrsc5_report_packet(st->radio, port_id, len, port->mime, buf);
+        nrsc5_report_packet(st->radio, port_id, seq, len, port->mime, buf);
         break;
     }
     case AAS_TYPE_LOT:
@@ -615,7 +615,7 @@ void output_aas_push(output_t *st, uint8_t *buf, unsigned int len)
     }
     else if (port >= 0x401 && port <= 0x50FF)
     {
-        process_port(st, port, buf + 4, len - 4);
+        process_port(st, port, seq, buf + 4, len - 4);
     }
     else
     {

--- a/src/private.h
+++ b/src/private.h
@@ -47,8 +47,8 @@ void nrsc5_report_mer(nrsc5_t *, float lower, float upper);
 void nrsc5_report_ber(nrsc5_t *, float cber);
 void nrsc5_report_hdc(nrsc5_t *, unsigned int program, const uint8_t *data, size_t count);
 void nrsc5_report_audio(nrsc5_t *, unsigned int program, const int16_t *data, size_t count);
-void nrsc5_report_stream(nrsc5_t *, uint16_t port, unsigned int size, uint32_t mime, const uint8_t *data);
-void nrsc5_report_packet(nrsc5_t *, uint16_t port, unsigned int size, uint32_t mime, const uint8_t *data);
+void nrsc5_report_stream(nrsc5_t *, uint16_t port, uint16_t seq, unsigned int size, uint32_t mime, const uint8_t *data);
+void nrsc5_report_packet(nrsc5_t *, uint16_t port, uint16_t seq, unsigned int size, uint32_t mime, const uint8_t *data);
 void nrsc5_report_lot(nrsc5_t *, uint16_t port, unsigned int lot, unsigned int size, uint32_t mime, struct tm *expiry_utc, const char *name, const uint8_t *data);
 void nrsc5_report_sig(nrsc5_t *, sig_service_t *services, unsigned int count);
 void nrsc5_report_sis(nrsc5_t *, const char *country_code, int fcc_facility_id, const char *name,

--- a/support/cli.py
+++ b/support/cli.py
@@ -234,11 +234,11 @@ class NRSC5CLI:
                                      component.data.service_data_type,
                                      component.data.type, component.data.mime)
         elif evt_type == nrsc5.EventType.STREAM:
-            logging.info("Stream data: port=%04X mime=%s size=%s",
-                         evt.port, evt.mime, len(evt.data))
+            logging.info("Stream data: port=%04X seq=%04X mime=%s size=%s",
+                         evt.port, evt.seq, evt.mime, len(evt.data))
         elif evt_type == nrsc5.EventType.PACKET:
-            logging.info("Packet data: port=%04X mime=%s size=%s",
-                         evt.port, evt.mime, len(evt.data))
+            logging.info("Packet data: port=%04X seq=%04X mime=%s size=%s",
+                         evt.port, evt.seq, evt.mime, len(evt.data))
         elif evt_type == nrsc5.EventType.LOT:
             time_str = evt.expiry_utc.strftime("%Y-%m-%dT%H:%M:%SZ")
             logging.info("LOT file: port=%04X lot=%s name=%s size=%s mime=%s expiry=%s",

--- a/support/nrsc5.py
+++ b/support/nrsc5.py
@@ -131,8 +131,8 @@ SIGDataComponent = collections.namedtuple("SIGDataComponent", ["port", "service_
 SIGComponent = collections.namedtuple("SIGComponent", ["type", "id", "audio", "data"])
 SIGService = collections.namedtuple("SIGService", ["type", "number", "name", "components"])
 SIG = collections.namedtuple("SIG", ["services"])
-STREAM = collections.namedtuple("STREAM", ["port", "mime", "data"])
-PACKET = collections.namedtuple("PACKET", ["port", "mime", "data"])
+STREAM = collections.namedtuple("STREAM", ["port", "seq", "mime", "data"])
+PACKET = collections.namedtuple("PACKET", ["port", "seq", "mime", "data"])
 LOT = collections.namedtuple("LOT", ["port", "lot", "mime", "expiry_utc", "name", "data"])
 SISAudioService = collections.namedtuple("SISAudioService", ["program", "access", "type", "sound_exp"])
 SISDataService = collections.namedtuple("SISDataService", ["access", "type", "mime_type"])
@@ -261,6 +261,7 @@ class _SIG(ctypes.Structure):
 class _STREAM(ctypes.Structure):
     _fields_ = [
         ("port", ctypes.c_uint16),
+        ("seq", ctypes.c_uint16),
         ("size", ctypes.c_uint),
         ("mime", ctypes.c_uint32),
         ("data", ctypes.POINTER(ctypes.c_char)),
@@ -270,6 +271,7 @@ class _STREAM(ctypes.Structure):
 class _PACKET(ctypes.Structure):
     _fields_ = [
         ("port", ctypes.c_uint16),
+        ("seq", ctypes.c_uint16),
         ("size", ctypes.c_uint),
         ("mime", ctypes.c_uint32),
         ("data", ctypes.POINTER(ctypes.c_char)),
@@ -456,10 +458,10 @@ class NRSC5:
                 service_ptr = service.next
         elif evt_type == EventType.STREAM:
             stream = c_evt.u.stream
-            evt = STREAM(stream.port, MIMEType(stream.mime), stream.data[:stream.size])
+            evt = STREAM(stream.port, stream.seq, MIMEType(stream.mime), stream.data[:stream.size])
         elif evt_type == EventType.PACKET:
             packet = c_evt.u.packet
-            evt = PACKET(packet.port, MIMEType(packet.mime), packet.data[:packet.size])
+            evt = PACKET(packet.port, packet.seq, MIMEType(packet.mime), packet.data[:packet.size])
         elif evt_type == EventType.LOT:
             lot = c_evt.u.lot
             expiry_struct = lot.expiry_utc.contents


### PR DESCRIPTION
AAS sequence numbers could be of use to users of the API. For stream data in particular, they could be used to detect lost data, which could trigger a reset of the stream processing.