### PR TITLE
Put the new expiry_utc member at the end of the lot struct

### DIFF
--- a/include/nrsc5.h
+++ b/include/nrsc5.h
@@ -328,9 +328,9 @@ struct nrsc5_event_t
             unsigned int lot;
             unsigned int size;
             uint32_t mime;
-            struct tm *expiry_utc;
             const char *name;
             const uint8_t *data;
+            struct tm *expiry_utc;
         } lot;
         struct {
             nrsc5_sig_service_t *services;

--- a/src/nrsc5.c
+++ b/src/nrsc5.c
@@ -666,7 +666,7 @@ void nrsc5_report_packet(nrsc5_t *st, uint16_t port, uint16_t seq, unsigned int 
     nrsc5_report(st, &evt);
 }
 
-void nrsc5_report_lot(nrsc5_t *st, uint16_t port, unsigned int lot, unsigned int size, uint32_t mime, struct tm *expiry_utc, const char *name, const uint8_t *data)
+void nrsc5_report_lot(nrsc5_t *st, uint16_t port, unsigned int lot, unsigned int size, uint32_t mime, const char *name, const uint8_t *data, struct tm *expiry_utc)
 {
     nrsc5_event_t evt;
 
@@ -675,9 +675,9 @@ void nrsc5_report_lot(nrsc5_t *st, uint16_t port, unsigned int lot, unsigned int
     evt.lot.lot = lot;
     evt.lot.size = size;
     evt.lot.mime = mime;
-    evt.lot.expiry_utc = expiry_utc;
     evt.lot.name = name;
     evt.lot.data = data;
+    evt.lot.expiry_utc = expiry_utc;
     nrsc5_report(st, &evt);
 }
 

--- a/src/output.c
+++ b/src/output.c
@@ -586,7 +586,7 @@ static void process_port(output_t *st, uint16_t port_id, uint16_t seq, uint8_t *
                 uint8_t *data = malloc(num_fragments * LOT_FRAGMENT_SIZE);
                 for (int i = 0; i < num_fragments; i++)
                     memcpy(data + i * LOT_FRAGMENT_SIZE, file->fragments[i], LOT_FRAGMENT_SIZE);
-                nrsc5_report_lot(st->radio, port->port, file->lot, file->size, file->mime, &file->expiry_utc, file->name, data);
+                nrsc5_report_lot(st->radio, port->port, file->lot, file->size, file->mime, file->name, data, &file->expiry_utc);
                 free(data);
                 aas_free_lot(file);
             }

--- a/src/private.h
+++ b/src/private.h
@@ -49,7 +49,7 @@ void nrsc5_report_hdc(nrsc5_t *, unsigned int program, const uint8_t *data, size
 void nrsc5_report_audio(nrsc5_t *, unsigned int program, const int16_t *data, size_t count);
 void nrsc5_report_stream(nrsc5_t *, uint16_t port, uint16_t seq, unsigned int size, uint32_t mime, const uint8_t *data);
 void nrsc5_report_packet(nrsc5_t *, uint16_t port, uint16_t seq, unsigned int size, uint32_t mime, const uint8_t *data);
-void nrsc5_report_lot(nrsc5_t *, uint16_t port, unsigned int lot, unsigned int size, uint32_t mime, struct tm *expiry_utc, const char *name, const uint8_t *data);
+void nrsc5_report_lot(nrsc5_t *, uint16_t port, unsigned int lot, unsigned int size, uint32_t mime, const char *name, const uint8_t *data, struct tm *expiry_utc);
 void nrsc5_report_sig(nrsc5_t *, sig_service_t *services, unsigned int count);
 void nrsc5_report_sis(nrsc5_t *, const char *country_code, int fcc_facility_id, const char *name,
                       const char *slogan, const char *message, const char *alert,

--- a/support/nrsc5.py
+++ b/support/nrsc5.py
@@ -133,7 +133,7 @@ SIGService = collections.namedtuple("SIGService", ["type", "number", "name", "co
 SIG = collections.namedtuple("SIG", ["services"])
 STREAM = collections.namedtuple("STREAM", ["port", "seq", "mime", "data"])
 PACKET = collections.namedtuple("PACKET", ["port", "seq", "mime", "data"])
-LOT = collections.namedtuple("LOT", ["port", "lot", "mime", "expiry_utc", "name", "data"])
+LOT = collections.namedtuple("LOT", ["port", "lot", "mime", "name", "data", "expiry_utc"])
 SISAudioService = collections.namedtuple("SISAudioService", ["program", "access", "type", "sound_exp"])
 SISDataService = collections.namedtuple("SISDataService", ["access", "type", "mime_type"])
 SIS = collections.namedtuple("SIS", ["country_code", "fcc_facility_id", "name", "slogan", "message", "alert",
@@ -298,9 +298,9 @@ class _LOT(ctypes.Structure):
         ("lot", ctypes.c_uint),
         ("size", ctypes.c_uint),
         ("mime", ctypes.c_uint32),
-        ("expiry_utc", ctypes.POINTER(_TimeStruct)),
         ("name", ctypes.c_char_p),
         ("data", ctypes.POINTER(ctypes.c_char)),
+        ("expiry_utc", ctypes.POINTER(_TimeStruct)),
     ]
 
 


### PR DESCRIPTION
In #310 a new member was added to the middle of the `lot` struct, which inadvertently broke [nrsc5-gui](https://github.com/cmnybo/nrsc5-gui), which has a copy of the `nrsc5.py` Python API shim. By moving the `expiry_utc` member to the end of the struct, binary compatibility can be preserved.