### PR TITLE
Quick fix

### DIFF
--- a/src/nrsc5.c
+++ b/src/nrsc5.c
@@ -195,7 +195,7 @@ static void *worker_thread(void *arg)
     return NULL;
 }
 
-static void nrsc5_init(nrsc5_t *st)
+static void nrsc5_init(nrsc5_t *st, int run_worker)
 {
     st->closed = 0;
     st->stopped = 1;
@@ -208,6 +208,9 @@ static void nrsc5_init(nrsc5_t *st)
 
     output_init(&st->output, st);
     input_init(&st->input, st, &st->output);
+
+    if(!run_worker)
+    	return;
 
     // Create worker thread
     pthread_mutex_init(&st->worker_mutex, NULL);
@@ -308,7 +311,7 @@ NRSC5_API int nrsc5_open(nrsc5_t **result, int device_index)
     err = rtlsdr_set_offset_tuning(st->dev, 1);
     if (err && err != -2) goto error;
 
-    nrsc5_init(st);
+    nrsc5_init(st, 1);
 
     *result = st;
     return 0;
@@ -326,7 +329,7 @@ NRSC5_API int nrsc5_open_file(nrsc5_t **result, FILE *fp)
 {
     nrsc5_t *st = nrsc5_alloc();
     st->iq_file = fp;
-    nrsc5_init(st);
+    nrsc5_init(st, 1);
 
     *result = st;
     return 0;
@@ -335,7 +338,7 @@ NRSC5_API int nrsc5_open_file(nrsc5_t **result, FILE *fp)
 NRSC5_API int nrsc5_open_pipe(nrsc5_t **result)
 {
     nrsc5_t *st = nrsc5_alloc();
-    nrsc5_init(st);
+    nrsc5_init(st, 0);
 
     *result = st;
     return 0;
@@ -357,7 +360,7 @@ NRSC5_API int nrsc5_open_rtltcp(nrsc5_t **result, int socket)
     err = rtltcp_set_offset_tuning(st->rtltcp, 1);
     if (err) goto error;
 
-    nrsc5_init(st);
+    nrsc5_init(st, 1);
 
     *result = st;
     return 0;

--- a/src/nrsc5.c
+++ b/src/nrsc5.c
@@ -209,13 +209,13 @@ static void nrsc5_init(nrsc5_t *st, int run_worker)
     output_init(&st->output, st);
     input_init(&st->input, st, &st->output);
 
-    if(!run_worker)
-    	return;
-
-    // Create worker thread
-    pthread_mutex_init(&st->worker_mutex, NULL);
-    pthread_cond_init(&st->worker_cond, NULL);
-    pthread_create(&st->worker, NULL, worker_thread, st);
+    if(run_worker)
+    {
+        // Create worker thread
+        pthread_mutex_init(&st->worker_mutex, NULL);
+        pthread_cond_init(&st->worker_cond, NULL);
+        pthread_create(&st->worker, NULL, worker_thread, st);
+    }
 }
 
 NRSC5_API void nrsc5_get_version(const char **version)


### PR DESCRIPTION
Any `nrsc5_open_*` function runs the worker thread.  

Because of that, using ``nrsc5_open_pipe`` would create a stale worker_thread.
Using a custom method of reading SDR and then using `nrsc5_pipe_samples_cs16`, the worker_thread loops, wastes CPU cycles & increases CPU usage. 

