### PR TITLE
Fix compiler warnings

### DIFF
--- a/src/acquire.c
+++ b/src/acquire.c
@@ -174,7 +174,7 @@ void acquire_process(acquire_t *st)
         for (i = 0; i < ACQUIRE_SYMBOLS; ++i)
         {
             int offset = (st->mode == NRSC5_MODE_FM) ? 0 : (FFT_AM - CP_AM) / 2;
-            for (int j = 0; j < st->fftcp; ++j)
+            for (j = 0; j < st->fftcp; ++j)
             {
                 float complex sample = temp_phase * st->buffer[i * st->fftcp + j + samperr];
                 if (j < st->cp)
@@ -204,7 +204,7 @@ void acquire_process(acquire_t *st)
 
             if (st->input->sync_state != SYNC_STATE_FINE)
             {
-                for (int j = CENTER_AM - PIDS_2_INDEX_AM; j <= CENTER_AM + PIDS_2_INDEX_AM; j++)
+                for (j = CENTER_AM - PIDS_2_INDEX_AM; j <= CENTER_AM + PIDS_2_INDEX_AM; j++)
                 {
                     mag_sums[j] += cabsf(st->fftout[j]);
                 }
@@ -215,7 +215,7 @@ void acquire_process(acquire_t *st)
         {
             float max_mag = -1.0f;
             int max_index = -1;
-            for (int j = CENTER_AM - PIDS_2_INDEX_AM; j <= CENTER_AM + PIDS_2_INDEX_AM; j++)
+            for (j = CENTER_AM - PIDS_2_INDEX_AM; j <= CENTER_AM + PIDS_2_INDEX_AM; j++)
             {
                 if (mag_sums[j] > max_mag)
                 {
@@ -234,7 +234,7 @@ void acquire_process(acquire_t *st)
     for (i = 0; i < ACQUIRE_SYMBOLS; ++i)
     {
         int offset = (st->mode == NRSC5_MODE_FM) ? 0 : (FFT_AM - CP_AM) / 2;
-        for (int j = 0; j < st->fftcp; ++j)
+        for (j = 0; j < st->fftcp; ++j)
         {
             float complex sample = st->phase * st->buffer[i * st->fftcp + j + samperr];
             if (j < st->cp)

--- a/src/acquire.h
+++ b/src/acquire.h
@@ -26,9 +26,9 @@ typedef struct
     int cfo;
 
     int mode;
-    int fft;
-    int fftcp;
-    int cp;
+    unsigned int fft;
+    unsigned int fftcp;
+    unsigned int cp;
 } acquire_t;
 
 void acquire_process(acquire_t *st);

--- a/src/decode.c
+++ b/src/decode.c
@@ -134,7 +134,7 @@ static void interleaver_ma1(decode_t *st)
 }
 
 // calculate number of bit errors by re-encoding and comparing to the input
-static int bit_errors(int8_t *coded, uint8_t *decoded, int k, int frame_len,
+static int bit_errors(int8_t *coded, uint8_t *decoded, unsigned int k, unsigned int frame_len,
                       unsigned int g1, unsigned int g2, unsigned int g3,
                       uint8_t *puncture, int puncture_len)
 {
@@ -247,7 +247,7 @@ void decode_process_pids(decode_t *st)
     pids_frame_push(&st->pids, st->scrambler_pids);
 }
 
-void decode_process_p3_p4(decode_t *st, interleaver_iv_t *interleaver, int8_t *viterbi, uint8_t *scrambler, int frame_len, logical_channel_t lc)
+void decode_process_p3_p4(decode_t *st, interleaver_iv_t *interleaver, int8_t *viterbi, uint8_t *scrambler, unsigned int frame_len, logical_channel_t lc)
 {
     const unsigned int J = (frame_len == P3_FRAME_LEN_FM) ? 4 : 2;
     const unsigned int B = 32;

--- a/src/decode.h
+++ b/src/decode.h
@@ -62,7 +62,7 @@ typedef struct
 
 void decode_process_p1(decode_t *st);
 void decode_process_pids(decode_t *st);
-void decode_process_p3_p4(decode_t *st, interleaver_iv_t *interleaver, int8_t *viterbi, uint8_t *scrambler, int frame_len, logical_channel_t lc);
+void decode_process_p3_p4(decode_t *st, interleaver_iv_t *interleaver, int8_t *viterbi, uint8_t *scrambler, unsigned int frame_len, logical_channel_t lc);
 void decode_process_pids_am(decode_t *st);
 void decode_process_p1_p3_am(decode_t *st);
 static inline unsigned int decode_get_block(decode_t *st)
@@ -82,7 +82,7 @@ static inline void decode_push_pm(decode_t *st, int8_t sbit)
         st->idx_pm = 0;
     }
 }
-static inline void decode_push_px1_px2(decode_t *st, interleaver_iv_t *interleaver, int8_t *viterbi, uint8_t *scrambler, int8_t sbit, int frame_len)
+static inline void decode_push_px1_px2(decode_t *st, interleaver_iv_t *interleaver, int8_t *viterbi, uint8_t *scrambler, int8_t sbit, unsigned int frame_len)
 {
     unsigned int delay = ((interleaver == &st->interleaver_px2) && (interleaver->idx < frame_len)) ? 7 : 0;
     interleaver->buffer[(interleaver->buffer_number + delay) % 8][interleaver->idx++] = sbit;
@@ -101,7 +101,7 @@ static inline void decode_push_px1_px2(decode_t *st, interleaver_iv_t *interleav
         interleaver->idx = 0;
     }
 }
-static inline void decode_push_px1(decode_t *st, int8_t sbit, int frame_len)
+static inline void decode_push_px1(decode_t *st, int8_t sbit, unsigned int frame_len)
 {
     decode_push_px1_px2(st, &st->interleaver_px1, st->viterbi_p3, st->scrambler_p3, sbit, frame_len);
 }

--- a/src/frame.c
+++ b/src/frame.c
@@ -318,6 +318,8 @@ static int unescape_hdlc(uint8_t *data, int length)
 
 static void aas_push(frame_t *st, uint8_t* psd, unsigned int length, logical_channel_t lc)
 {
+    (void)lc; // UNUSED
+
     length = unescape_hdlc(psd, length);
 
     if (length == 0)
@@ -494,7 +496,7 @@ void frame_process(frame_t *st, size_t length, logical_channel_t lc)
 
     if (has_fixed(st))
         audio_end = process_fixed_data(st, length, lc);
-    
+
     if (!has_audio(st))
         return;
 

--- a/src/rtltcp.c
+++ b/src/rtltcp.c
@@ -183,7 +183,7 @@ int rtltcp_reset_buffer(rtltcp_t *st, size_t cnt)
     // then, read cnt bytes
     while (cnt > 0)
     {
-        int to_read = sizeof(buf);
+        size_t to_read = sizeof(buf);
         if (cnt < to_read)
             to_read = cnt;
 


### PR DESCRIPTION
Clang reports a number of warnings: one unused parameter, and many comparisons of signed and unsigned integers. I've cleaned those up here.