### PR TITLE
Remove input length restrictions from pipe API

### DIFF
--- a/src/nrsc5.c
+++ b/src/nrsc5.c
@@ -548,14 +548,57 @@ NRSC5_API void nrsc5_set_callback(nrsc5_t *st, nrsc5_callback_t callback, void *
 
 NRSC5_API int nrsc5_pipe_samples_cu8(nrsc5_t *st, const uint8_t *samples, unsigned int length)
 {
-    input_push_cu8(&st->input, samples, length);
+    unsigned int sample_groups;
+
+    while (st->leftover_u8_num > 0 && length > 0)
+    {
+        st->leftover_u8[st->leftover_u8_num++] = samples[0];
+        samples++;
+        length--;
+
+        if (st->leftover_u8_num == 4) {
+            input_push_cu8(&st->input, st->leftover_u8, 4);
+            st->leftover_u8_num = 0;
+            break;
+        }
+    }
+
+    sample_groups = length / 4;
+    input_push_cu8(&st->input, samples, sample_groups * 4);
+    samples += (sample_groups * 4);
+    length -= (sample_groups * 4);
+
+    while (length > 0)
+    {
+        st->leftover_u8[st->leftover_u8_num++] = samples[0];
+        samples++;
+        length--;
+    }
 
     return 0;
 }
 
 NRSC5_API int nrsc5_pipe_samples_cs16(nrsc5_t *st, const int16_t *samples, unsigned int length)
 {
-    input_push_cs16(&st->input, samples, length);
+    unsigned int sample_groups;
+
+    if (st->leftover_s16_num == 1 && length > 0)
+    {
+        st->leftover_s16[st->leftover_s16_num++] = samples[0];
+        samples++;
+        length--;
+
+        input_push_cs16(&st->input, st->leftover_s16, 2);
+        st->leftover_s16_num = 0;
+    }
+
+    sample_groups = length / 2;
+    input_push_cs16(&st->input, samples, sample_groups * 2);
+    samples += (sample_groups * 2);
+    length -= (sample_groups * 2);
+
+    if (length == 1)
+        st->leftover_s16[st->leftover_s16_num++] = samples[0];
 
     return 0;
 }

--- a/src/private.h
+++ b/src/private.h
@@ -30,6 +30,11 @@ struct nrsc5_t
     nrsc5_callback_t callback;
     void *callback_opaque;
 
+    uint8_t leftover_u8[4];
+    unsigned int leftover_u8_num;
+    int16_t leftover_s16[2];
+    unsigned int leftover_s16_num;
+
     pthread_t worker;
     pthread_mutex_t worker_mutex;
     pthread_cond_t worker_cond;

--- a/support/cli.py
+++ b/support/cli.py
@@ -109,9 +109,9 @@ class NRSC5CLI:
                     if not data:
                         break
                     if self.args.iq_input_format == "cu8":
-                        self.radio.pipe_samples_cu8(data[:(len(data) // 4) * 4])
+                        self.radio.pipe_samples_cu8(data)
                     elif self.args.iq_input_format == "cs16":
-                        self.radio.pipe_samples_cs16(data[:(len(data) // 4) * 4])
+                        self.radio.pipe_samples_cs16(data)
             else:
                 with self.device_condition:
                     self.device_condition.wait()

--- a/support/nrsc5.py
+++ b/support/nrsc5.py
@@ -603,15 +603,13 @@ class NRSC5:
         NRSC5.libnrsc5.nrsc5_set_callback(self.radio, self.callback_func, None)
 
     def pipe_samples_cu8(self, samples):
-        if len(samples) % 4 != 0:
-            raise NRSC5Error("len(samples) must be a multiple of 4.")
         result = NRSC5.libnrsc5.nrsc5_pipe_samples_cu8(self.radio, samples, len(samples))
         if result != 0:
             raise NRSC5Error("Failed to pipe samples.")
 
     def pipe_samples_cs16(self, samples):
-        if len(samples) % 4 != 0:
-            raise NRSC5Error("len(samples) must be a multiple of 4.")
+        if len(samples) % 2 != 0:
+            raise NRSC5Error("len(samples) must be a multiple of 2.")
         result = NRSC5.libnrsc5.nrsc5_pipe_samples_cs16(self.radio, samples, len(samples) // 2)
         if result != 0:
             raise NRSC5Error("Failed to pipe samples.")


### PR DESCRIPTION
As noted in https://github.com/theori-io/nrsc5/issues/322#issuecomment-1694611094, it's annoying for API users that complex samples must be passed into `nrsc5_pipe_samples_cu8` two at a time (i.e. four bytes at a time). Here I've removed all length restrictions from `nrsc5_pipe_samples_cu8` and `nrsc5_pipe_samples_cs16` so that it's no longer even necessary to ensure that the I & Q pieces of a sample are passed in at the same time. Any leftover samples or pieces thereof are stored in a buffer until more input arrives.

@TheDaChicken Let me know if this simplifies things on your end. 