### PR TITLE
Remove call to fftwf_cleanup

### DIFF
--- a/src/input.c
+++ b/src/input.c
@@ -276,7 +276,6 @@ void input_free(input_t *st)
     for (int i = 0; i < AM_DECIM_STAGES; i++)
         firdecim_q15_free(st->decim[i]);
     fftwf_destroy_plan(st->snr_fft);
-    fftwf_cleanup();
 }
 
 void input_set_sync_state(input_t *st, unsigned int new_state)


### PR DESCRIPTION
Fixes #329.

I had a look over the FFTW documentation, and as far as I can tell, it is not necessary to call `fftwf_cleanup`. In fact, doing so may cause trouble for API users, because `nrsc5_close` will trigger `fftwf_cleanup`, which could invalidate plans created outside nrsc5.