### PR TITLE
Remove non-standard MP11 interleaving

### DIFF
--- a/src/decode.c
+++ b/src/decode.c
@@ -268,7 +268,7 @@ void decode_process_p3_p4(decode_t *st, interleaver_iv_t *interleaver, int8_t *v
         if ((out % 6) == 1 || (out % 6) == 4) // depuncture, [1, 0, 1, 1, 0, 1]
             viterbi[out++] = 0;
 
-        interleaver->internal[interleaver->i] = interleaver->buffer[interleaver->buffer_number][i];
+        interleaver->internal[interleaver->i] = interleaver->buffer[i];
         interleaver->i++;
     }
     if (interleaver->ready)
@@ -346,8 +346,6 @@ void decode_process_p1_p3_am(decode_t *st)
 
 static void interleaver_iv_reset(interleaver_iv_t *interleaver)
 {
-    interleaver->buffer_number = 0;
-    interleaver->buffer_ready = 0;
     interleaver->idx = 0;
     interleaver->i = 0;
     memset(interleaver->pt, 0, sizeof(unsigned int) * 4);

--- a/src/decode.h
+++ b/src/decode.h
@@ -8,9 +8,7 @@
 
 typedef struct
 {
-  int8_t buffer[8][144 * BLKSZ * 2];
-  int buffer_number;
-  int buffer_ready;
+  int8_t buffer[144 * BLKSZ * 2];
   unsigned int idx;
   int8_t internal[P3_FRAME_LEN_FM * 32];
   unsigned int i;
@@ -84,20 +82,10 @@ static inline void decode_push_pm(decode_t *st, int8_t sbit)
 }
 static inline void decode_push_px1_px2(decode_t *st, interleaver_iv_t *interleaver, int8_t *viterbi, uint8_t *scrambler, int8_t sbit, unsigned int frame_len)
 {
-    unsigned int delay = ((interleaver == &st->interleaver_px2) && (interleaver->idx < frame_len)) ? 7 : 0;
-    interleaver->buffer[(interleaver->buffer_number + delay) % 8][interleaver->idx++] = sbit;
+    interleaver->buffer[interleaver->idx++] = sbit;
     if (interleaver->idx % (frame_len * 2) == 0)
     {
-        if (interleaver->buffer_ready)
-        {
-            decode_process_p3_p4(st, interleaver, viterbi, scrambler, frame_len, (interleaver == &st->interleaver_px1) ? P3_LOGICAL_CHANNEL : P4_LOGICAL_CHANNEL);
-        }
-        interleaver->buffer_number++;
-        if (interleaver->buffer_number == 8)
-        {
-            interleaver->buffer_number = 0;
-            interleaver->buffer_ready = 1;
-        }
+        decode_process_p3_p4(st, interleaver, viterbi, scrambler, frame_len, (interleaver == &st->interleaver_px1) ? P3_LOGICAL_CHANNEL : P4_LOGICAL_CHANNEL);
         interleaver->idx = 0;
     }
 }


### PR DESCRIPTION
This was added in d96b72c304f1902b4a762b632c8f56da6675f64a to deal with WWWT's non-standard signal.

It's necessary to remove it to receive WTUE's MP11 signal, which follows the standard. I would hope that WWWT has already fixed their signal, but if not I suppose we could consider adding a command-line option to select the non-standard interleaving.

/cc @markjfine