### PR TITLE
Elastic Buffer

### DIFF
--- a/src/defines.h
+++ b/src/defines.h
@@ -68,6 +68,8 @@
 #define MAX_STREAMS 4
 // number of subcarriers per AM partition
 #define PARTITION_WIDTH_AM 25
+// number of HDC frames in a sequence
+#define MAX_AUDIO_PACKETS 64
 
 #define log_debug(...) \
             do { if (LIBRARY_DEBUG_LEVEL <= 1) { fprintf(stderr, __VA_ARGS__); fprintf(stderr, "\n"); } } while (0)

--- a/src/frame.c
+++ b/src/frame.c
@@ -562,7 +562,7 @@ void frame_process(frame_t *st, size_t length, logical_channel_t lc)
         avg = calc_avg_packets(&hdr);
         seq = (MAX_AUDIO_PACKETS + hdr.seq - hdr.pfirst) % MAX_AUDIO_PACKETS;
 
-        output_align(st->input->output, prog, hdr.stream_id, hdr.pdu_seq, hdr.latency, avg, seq, hdr.nop);
+        output_align(st->input->output, prog, hdr.stream_id, hdr.pdu_seq, hdr.latency, avg, seq);
 
         parse_hdlc(st, aas_push, st->psd_buf[prog], &st->psd_idx[prog], MAX_AAS_LEN, st->buffer + offset, start + hdr.la_location + 1 - offset, lc);
         offset = start + hdr.la_location + 1;

--- a/src/frame.c
+++ b/src/frame.c
@@ -560,7 +560,7 @@ void frame_process(frame_t *st, size_t length, logical_channel_t lc)
             offset += parse_hef(st->buffer + offset, audio_end - offset, &hef);
         prog = hef.prog_num;
         avg = calc_avg_packets(&hdr);
-        seq = (hdr.seq - hdr.pfirst) % MAX_AUDIO_PACKETS;
+        seq = (MAX_AUDIO_PACKETS + hdr.seq - hdr.pfirst) % MAX_AUDIO_PACKETS;
 
         output_align(st->input->output, prog, hdr.stream_id, hdr.pdu_seq, hdr.latency, avg, seq, hdr.nop);
 

--- a/src/frame.h
+++ b/src/frame.h
@@ -2,6 +2,7 @@
 
 #include "defines.h"
 
+#define MAX_AUDIO_PACKETS 64
 #define MAX_AAS_LEN 8212
 #define RS_BLOCK_LEN 255
 #define RS_CODEWORD_LEN 96

--- a/src/frame.h
+++ b/src/frame.h
@@ -2,7 +2,6 @@
 
 #include "defines.h"
 
-#define MAX_AUDIO_PACKETS 64
 #define MAX_AAS_LEN 8212
 #define RS_BLOCK_LEN 255
 #define RS_CODEWORD_LEN 96

--- a/src/input.c
+++ b/src/input.c
@@ -157,7 +157,7 @@ void input_push_cu8(input_t *st, const uint8_t *buf, uint32_t len)
     }
 
     input_push(st, pos);
-    output_advance(st->output, len / 4);
+    output_advance(st->output, len / 4, NRSC5_MODE_FM);
 }
 
 void input_push_cs16(input_t *st, const int16_t *buf, uint32_t len)
@@ -173,7 +173,7 @@ void input_push_cs16(input_t *st, const int16_t *buf, uint32_t len)
     st->avail += len / 2;
 
     input_push(st, pos);
-    output_advance(st->output, len / 2);
+    output_advance(st->output, len / 2, st->radio->mode);
 }
 
 void input_reset(input_t *st)

--- a/src/input.h
+++ b/src/input.h
@@ -43,5 +43,3 @@ void input_set_sync_state(input_t *st, unsigned int new_state);
 void input_push_cu8(input_t *st, const uint8_t *buf, uint32_t len);
 void input_push_cs16(input_t *st, const int16_t *buf, uint32_t len);
 void input_set_skip(input_t *st, unsigned int skip);
-void input_pdu_push(input_t *st, uint8_t *pdu, unsigned int len, unsigned int program, unsigned int stream_id);
-void input_aas_push(input_t *st, uint8_t *psd, unsigned int len);

--- a/src/output.c
+++ b/src/output.c
@@ -28,7 +28,7 @@
 #include "unicode.h"
 
 #define RADIO_FRAME_SAMPLES_FM (NRSC5_AUDIO_FRAME_SAMPLES * 135 / 8)
-#define RADIO_FRAME_SAMPLES_AM (NRSC5_AUDIO_FRAME_SAMPLES * 135 / 256)
+#define RADIO_FRAME_SAMPLES_AM (NRSC5_AUDIO_FRAME_SAMPLES * 135 / 128)
 
 static unsigned int average_acquire_samples(output_t *st, elastic_buffer_t *dec)
 {

--- a/src/output.c
+++ b/src/output.c
@@ -289,7 +289,8 @@ void output_advance(output_t *st, unsigned int len)
 
         unsigned int iq_upper = (hd_samples * 8) + dec->leftover;
         unsigned int audio_frames = (iq_upper / 135) * AUDIO_FRAME_CHANNELS;
-        unsigned int silence_frames = (delay_samples * 8 / 135) * AUDIO_FRAME_CHANNELS;
+        unsigned int silence_upper = (delay_samples * 8);
+        unsigned int silence_frames = (silence_upper / 135) * AUDIO_FRAME_CHANNELS;
         unsigned int frame_len = audio_frames + silence_frames;
 
         int16_t* audio_frame = malloc(frame_len * sizeof(*audio_frame));
@@ -312,7 +313,7 @@ void output_advance(output_t *st, unsigned int len)
 
         // Reset
         elastic->pos = -1;
-        dec->leftover = iq_upper % 135;
+        dec->leftover = (iq_upper % 135) + (silence_upper % 135);
     }
 }
 

--- a/src/output.c
+++ b/src/output.c
@@ -158,7 +158,10 @@ void output_align(output_t *st, unsigned int program, unsigned int stream_id, un
         memset(dec->output_buffer, 0, OUTPUT_BUFFER_LENGTH * sizeof(*dec->output_buffer));
 
         // FFT decode delay
-        dec->write = ((st->radio->mode == NRSC5_MODE_FM ? FFTCP_FM : FFTCP_AM) * 8 / 135) * AUDIO_FRAME_CHANNELS;
+        if (st->radio->mode == NRSC5_MODE_FM)
+            dec->write = (FFTCP_FM * 8 / 135) * AUDIO_FRAME_CHANNELS;
+        else
+            dec->write = (FFTCP_AM * 256 / 135) * AUDIO_FRAME_CHANNELS;
     }
 
     // Re-sync (lost-synchronization with reader and writer)
@@ -303,7 +306,8 @@ void output_advance(output_t *st, unsigned int len)
         {
             hd_samples = (len - elastic->pos);
             delay_samples = (len - hd_samples);
-        } else
+        }
+        else
         {
             hd_samples = len;
             delay_samples = 0;

--- a/src/output.c
+++ b/src/output.c
@@ -30,12 +30,12 @@
 #define RADIO_FRAME_SAMPLES_FM (NRSC5_AUDIO_FRAME_SAMPLES * 135 / 8)
 #define RADIO_FRAME_SAMPLES_AM (NRSC5_AUDIO_FRAME_SAMPLES * 135 / 128)
 
-static unsigned int average_acquire_samples(output_t *st, elastic_buffer_t *dec)
+static unsigned int average_acquire_samples(const output_t *st, const elastic_buffer_t *dec)
 {
     return dec->avg * (st->radio->mode == NRSC5_MODE_FM ? RADIO_FRAME_SAMPLES_FM : RADIO_FRAME_SAMPLES_AM);
 }
 
-static unsigned int compute_forward_sequence_position(elastic_buffer_t *elastic, unsigned int seq)
+static unsigned int compute_forward_sequence_position(const elastic_buffer_t *elastic, unsigned int seq)
 {
     return (MAX_AUDIO_PACKETS + seq - elastic->ptr[elastic->write].seq) % MAX_AUDIO_PACKETS;
 }
@@ -52,13 +52,13 @@ static void elastic_realign_forward(elastic_buffer_t *elastic, unsigned int forw
     elastic->read = (elastic->write - elastic->delay - seq + offset) % elastic->size;
 }
 
-static unsigned int elastic_write_available(elastic_buffer_t *elastic)
+static unsigned int elastic_write_available(const elastic_buffer_t *elastic)
 {
     return elastic->size - elastic->write + elastic->read - 1;
 }
 
 #ifdef USE_FAAD2
-static unsigned int decoder_buffer_write_available(decoder_t *st)
+static unsigned int decoder_buffer_write_available(const decoder_t *st)
 {
     if (st->read > st->write)
         return (st->read - st->write) - 1;
@@ -66,7 +66,7 @@ static unsigned int decoder_buffer_write_available(decoder_t *st)
         return OUTPUT_BUFFER_LENGTH - (st->write - st->read) - 1;
 }
 
-static unsigned int decoder_buffer_read_available(decoder_t *st)
+static unsigned int decoder_buffer_read_available(const decoder_t *st)
 {
     if (st->write >= st->read)
         return st->write - st->read;
@@ -74,7 +74,7 @@ static unsigned int decoder_buffer_read_available(decoder_t *st)
         return OUTPUT_BUFFER_LENGTH - (st->read - st->write);
 }
 
-static void decoder_buffer_write(decoder_t *dec, int16_t *buffer, unsigned int samples)
+static void decoder_buffer_write(decoder_t *dec, const int16_t *buffer, unsigned int samples)
 {
     if (decoder_buffer_write_available(dec) < samples)
     {

--- a/src/output.c
+++ b/src/output.c
@@ -158,7 +158,7 @@ void output_align(output_t *st, unsigned int program, unsigned int stream_id, un
         memset(dec->output_buffer, 0, OUTPUT_BUFFER_LENGTH * sizeof(*dec->output_buffer));
 
         // FFT decode delay
-        dec->write = (st->radio->mode == NRSC5_MODE_FM ? FFTCP_FM : FFTCP_AM) * 8 / 135;
+        dec->write = ((st->radio->mode == NRSC5_MODE_FM ? FFTCP_FM : FFTCP_AM) * 8 / 135) * AUDIO_FRAME_CHANNELS;
     }
 
     // Re-sync (lost-synchronization with reader and writer)

--- a/src/output.c
+++ b/src/output.c
@@ -253,9 +253,6 @@ void output_align(output_t *st, unsigned int program, unsigned int stream_id, un
             dec->write = (FFTCP_AM * 256 / 135) * AUDIO_FRAME_CHANNELS;
     }
 #endif
-
-    log_debug("program: %d seq: %d nop: %d", program, seq, nop);
-    log_debug("writeable length: %d", elastic_write_available(elastic));
 }
 
 void output_advance_elastic(output_t *st, int pos, unsigned int used)

--- a/src/output.c
+++ b/src/output.c
@@ -37,7 +37,7 @@ static unsigned int average_acquire_samples(output_t *st, elastic_buffer_t *dec)
 
 static unsigned int compute_forward_sequence_position(elastic_buffer_t *elastic, unsigned int seq)
 {
-    return (seq - elastic->ptr[elastic->write].seq) % MAX_AUDIO_PACKETS;
+    return (MAX_AUDIO_PACKETS + seq - elastic->ptr[elastic->write].seq) % MAX_AUDIO_PACKETS;
 }
 
 static void elastic_realign_forward(elastic_buffer_t *elastic, unsigned int forward, unsigned int pdu_seq, unsigned int avg, unsigned int seq)

--- a/src/output.c
+++ b/src/output.c
@@ -210,7 +210,7 @@ void output_align(output_t *st, unsigned int program, unsigned int stream_id, un
         elastic->size  = (elastic->delay * 2) + MAX_AUDIO_PACKETS;
         elastic->ptr   = malloc(elastic->size * sizeof(*elastic->ptr));
 
-        for (int i = 0; i < elastic->size; i++)
+        for (unsigned int i = 0; i < elastic->size; i++)
         {
             elastic->ptr[i].size = 0;
             elastic->ptr[i].seq = -1;
@@ -271,22 +271,22 @@ void output_advance_elastic(output_t *st, int pos, unsigned int used)
             elastic->iq_pos = pos;
 
         // Packet clock
-        elastic->clock += (int)used;
+        elastic->clock += used;
 
         // Decode packets based on average
-        while (elastic->clock >= (int)sample_avg)
+        while (elastic->clock >= sample_avg)
         {
             int16_t *audio;
             unsigned int decoded_frames;
 
-            for (int j = 0; j < elastic->avg; j++)
+            for (unsigned int j = 0; j < elastic->avg; j++)
             {
                 elastic_decode_packet(st, i, &audio, &decoded_frames);
 #ifdef USE_FAAD2
                 decoder_buffer_write(&elastic->decoder, audio, decoded_frames);
 #endif
             }
-            elastic->clock -= (int)sample_avg;
+            elastic->clock -= sample_avg;
         }
 
     }

--- a/src/output.h
+++ b/src/output.h
@@ -97,22 +97,10 @@ typedef struct
     uint8_t data[MAX_PDU_LEN];
 } packet_t;
 
-typedef struct
-{
-    packet_t *ptr;
-
-    unsigned int size, read, write;
-    unsigned int latency, avg, delay;
-
-    unsigned int clock;
-    int pos;
-} elastic_buffer_t;
-
 #ifdef HAVE_FAAD2
 typedef struct
 {
     NeAACDecHandle aacdec;
-    elastic_buffer_t elastic_buffer;
 
     int16_t* output_buffer;
     unsigned int write, read, leftover, delay;
@@ -121,12 +109,27 @@ typedef struct
 
 typedef struct
 {
+    packet_t *ptr;
+
+    unsigned int size, read, write;
+    unsigned int latency, avg, delay;
+
+    unsigned int clock;
+    int iq_pos;
+
+#ifdef HAVE_FAAD2
+    decoder_t decoder;
+#endif
+} elastic_buffer_t;
+
+typedef struct
+{
     nrsc5_t *radio;
     aas_port_t ports[MAX_PORTS];
     sig_service_t services[MAX_SIG_SERVICES];
 
+    elastic_buffer_t elastic[MAX_PROGRAMS];
 #ifdef HAVE_FAAD2
-    decoder_t decoder[MAX_PROGRAMS];
     int16_t silence[AUDIO_FRAME_LENGTH];
 #endif
 } output_t;

--- a/src/output.h
+++ b/src/output.h
@@ -103,6 +103,8 @@ typedef struct
 
     int16_t* output_buffer;
     unsigned int write, read, leftover, delay;
+
+    int input_start_pos;
 } decoder_t;
 #endif
 
@@ -114,11 +116,6 @@ typedef struct
     unsigned int latency, avg, delay;
 
     unsigned int clock;
-    int iq_pos;
-
-#ifdef HAVE_FAAD2
-    decoder_t decoder;
-#endif
 } elastic_buffer_t;
 
 typedef struct
@@ -126,9 +123,10 @@ typedef struct
     nrsc5_t *radio;
     aas_port_t ports[MAX_PORTS];
     sig_service_t services[MAX_SIG_SERVICES];
+    elastic_buffer_t elastic[MAX_PROGRAMS][MAX_STREAMS];
 
-    elastic_buffer_t elastic[MAX_PROGRAMS];
 #ifdef HAVE_FAAD2
+    decoder_t decoder[MAX_PROGRAMS];
     int16_t silence[AUDIO_FRAME_LENGTH];
 #endif
 } output_t;

--- a/src/output.h
+++ b/src/output.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "config.h"
-#include "frame.h"
 
 #include <nrsc5.h>
 

--- a/src/output.h
+++ b/src/output.h
@@ -113,7 +113,7 @@ typedef struct
 {
     packet_t *ptr;
 
-    unsigned int size, read, write;
+    unsigned int size, read, last_write;
     unsigned int latency, avg, delay;
 
     unsigned int clock;

--- a/src/output.h
+++ b/src/output.h
@@ -108,6 +108,7 @@ typedef struct
     int pos;
 } elastic_buffer_t;
 
+#ifdef HAVE_FAAD2
 typedef struct
 {
     NeAACDecHandle aacdec;
@@ -116,6 +117,7 @@ typedef struct
     int16_t* output_buffer;
     unsigned int write, read, leftover, delay;
 } decoder_t;
+#endif
 
 typedef struct
 {
@@ -125,7 +127,6 @@ typedef struct
 
 #ifdef HAVE_FAAD2
     decoder_t decoder[MAX_PROGRAMS];
-
     int16_t silence[AUDIO_FRAME_LENGTH];
 #endif
 } output_t;

--- a/src/output.h
+++ b/src/output.h
@@ -134,7 +134,7 @@ typedef struct
 void output_align(output_t *st, unsigned int program, unsigned int stream_id, unsigned int pdu_seq, unsigned int latency, unsigned int avg, unsigned int seq, unsigned int nop);
 void output_push(output_t *st, uint8_t *pkt, unsigned int len, unsigned int program, unsigned int stream_id, unsigned int seq);
 void output_advance_elastic(output_t *st, int pos, unsigned int used);
-void output_advance(output_t *st, unsigned int len);
+void output_advance(output_t *st, unsigned int len, int mode);
 void output_begin(output_t *st);
 void output_reset(output_t *st);
 void output_init(output_t *st, nrsc5_t *);

--- a/src/output.h
+++ b/src/output.h
@@ -102,7 +102,7 @@ typedef struct
     NeAACDecHandle aacdec;
 
     int16_t* output_buffer;
-    unsigned int write, read, leftover, delay;
+    unsigned int write, read, leftover;
 
     int input_start_pos;
     int started;
@@ -113,8 +113,8 @@ typedef struct
 {
     packet_t *ptr;
 
-    unsigned int size, read, last_write;
-    unsigned int latency, avg, delay;
+    unsigned int read;
+    unsigned int latency, avg;
 
     unsigned int clock;
 } elastic_buffer_t;
@@ -132,7 +132,7 @@ typedef struct
 #endif
 } output_t;
 
-void output_align(output_t *st, unsigned int program, unsigned int stream_id, unsigned int pdu_seq, unsigned int latency, unsigned int avg, unsigned int seq, unsigned int nop);
+void output_align(output_t *st, unsigned int program, unsigned int stream_id, unsigned int pdu_seq, unsigned int latency, unsigned int avg, unsigned int seq);
 void output_push(output_t *st, uint8_t *pkt, unsigned int len, unsigned int program, unsigned int stream_id, unsigned int seq);
 void output_advance_elastic(output_t *st, int pos, unsigned int used);
 void output_advance(output_t *st, unsigned int len, int mode);

--- a/src/output.h
+++ b/src/output.h
@@ -105,6 +105,7 @@ typedef struct
     unsigned int write, read, leftover, delay;
 
     int input_start_pos;
+    int started;
 } decoder_t;
 #endif
 


### PR DESCRIPTION
Fixing #330 

Use a circular buffer to store packets to be played later temporarily. This allows libnrsc5 to handle buffering properly by outputting at a fixed ratio. This allows missing packets to be silenced or handled properly. 

~~Replace audio callback with a buffering system that involves a polling function instead with any buffer size + implement latency buffering.~~ 

~~New functions:~~
~~1. `nrsc5_open_program`~~
~~2. `nrsc5_close_program`~~
~~3. `nrsc5_reset_program`~~
~~4. `nrsc5_read_program_blocking`~~
~~5. `nrsc5_read_program_nonblocking`~~

Please let me know what you think. Code review as much as you want! :D