### PR TITLE
Add MA3 (all digital) service mode

### DIFF
--- a/src/acquire.c
+++ b/src/acquire.c
@@ -204,7 +204,7 @@ void acquire_process(acquire_t *st)
 
             if (st->input->sync_state != SYNC_STATE_FINE)
             {
-                for (j = CENTER_AM - PIDS_2_INDEX_AM; j <= CENTER_AM + PIDS_2_INDEX_AM; j++)
+                for (j = CENTER_AM - PIDS_OUTER_INDEX_AM; j <= CENTER_AM + PIDS_OUTER_INDEX_AM; j++)
                 {
                     mag_sums[j] += cabsf(st->fftout[j]);
                 }
@@ -215,7 +215,7 @@ void acquire_process(acquire_t *st)
         {
             float max_mag = -1.0f;
             int max_index = -1;
-            for (j = CENTER_AM - PIDS_2_INDEX_AM; j <= CENTER_AM + PIDS_2_INDEX_AM; j++)
+            for (j = CENTER_AM - PIDS_OUTER_INDEX_AM; j <= CENTER_AM + PIDS_OUTER_INDEX_AM; j++)
             {
                 if (mag_sums[j] > max_mag)
                 {

--- a/src/decode.h
+++ b/src/decode.h
@@ -36,6 +36,10 @@ typedef struct
     uint8_t mu[18000 + DIVERSITY_DELAY_AM];
     uint8_t el[12000];
     uint8_t eu[24000];
+    uint8_t ebl[18000];
+    uint8_t ebu[18000];
+    uint8_t eml[18000 + DIVERSITY_DELAY_AM];
+    uint8_t emu[18000 + DIVERSITY_DELAY_AM];
 
     int8_t viterbi_p1[P1_FRAME_LEN_FM * 3];
     uint8_t scrambler_p1[P1_FRAME_LEN_FM];
@@ -51,9 +55,9 @@ typedef struct
     uint8_t p1_am[8 * P1_FRAME_LEN_ENCODED_AM];
     int8_t viterbi_p1_am[8 * P1_FRAME_LEN_AM * 3];
     uint8_t scrambler_p1_am[P1_FRAME_LEN_AM];
-    uint8_t p3_am[P3_FRAME_LEN_ENCODED_AM];
-    int8_t viterbi_p3_am[P3_FRAME_LEN_AM * 3];
-    uint8_t scrambler_p3_am[P3_FRAME_LEN_AM];
+    uint8_t p3_am[P3_FRAME_LEN_ENCODED_MA3];
+    int8_t viterbi_p3_am[P3_FRAME_LEN_MA3 * 3];
+    uint8_t scrambler_p3_am[P3_FRAME_LEN_MA3];
 
     pids_t pids;
 } decode_t;

--- a/src/defines.h
+++ b/src/defines.h
@@ -30,12 +30,15 @@
 #define CENTER_AM (FFT_AM / 2)
 // indexes of AM subcarriers
 #define REF_INDEX_AM 1
-#define PIDS_1_INDEX_AM 27
-#define PIDS_2_INDEX_AM 53
-#define TERTIARY_INDEX_AM 2
-#define SECONDARY_INDEX_AM 28
-#define PRIMARY_INDEX_AM 57
+#define PIDS_INNER_INDEX_AM 27
+#define PIDS_OUTER_INDEX_AM 53
+#define INNER_PARTITION_START_AM 2
+#define MIDDLE_PARTITION_START_AM 28
+#define OUTER_PARTITION_START_AM 57
 #define MAX_INDEX_AM 81
+// AM service modes
+#define SERVICE_MODE_MA1 1
+#define SERVICE_MODE_MA3 2
 // bits per P1 frame
 #define P1_FRAME_LEN_FM 146176
 #define P1_FRAME_LEN_AM 3750
@@ -49,10 +52,12 @@
 #define PIDS_FRAME_LEN_ENCODED_AM (PIDS_FRAME_LEN * 3)
 // bits per P3 frame
 #define P3_FRAME_LEN_FM 4608
-#define P3_FRAME_LEN_AM 24000
+#define P3_FRAME_LEN_MA1 24000
+#define P3_FRAME_LEN_MA3 30000
 // bits per encoded P3 frame
 #define P3_FRAME_LEN_ENCODED_FM (P3_FRAME_LEN_FM * 2)
-#define P3_FRAME_LEN_ENCODED_AM (P3_FRAME_LEN_AM * 3 / 2)
+#define P3_FRAME_LEN_ENCODED_MA1 (P3_FRAME_LEN_MA1 * 3 / 2)
+#define P3_FRAME_LEN_ENCODED_MA3 (P3_FRAME_LEN_MA3 * 12 / 5)
 // bits per L2 PCI
 #define PCI_LEN 24
 // bytes per L2 PDU (max)

--- a/src/frame.c
+++ b/src/frame.c
@@ -614,9 +614,14 @@ void frame_push(frame_t *st, uint8_t *bits, size_t length, logical_channel_t lc)
         offset = 160;
         pci_len = 22;
         break;
-    case P3_FRAME_LEN_AM:
+    case P3_FRAME_LEN_MA1:
         start = 120;
         offset = 992;
+        pci_len = 24;
+        break;
+    case P3_FRAME_LEN_MA3:
+        start = 120;
+        offset = 1240;
         pci_len = 24;
         break;
     default:


### PR DESCRIPTION
Fixes #240.

Here I have implemented support for MA3, the all-digital AM service mode. I tested that it is able to receive WWFD, using a recording made with W3HFU's KiwiSDR. As with the MA1 hybrid mode, only the "core" audio stream is decoded, and the "enhanced" stream is discarded. (Improvements to the HDC decoder would be needed to decode the enhanced stream. See #245 for a previous attempt at that.) I was able to decode WWFD's station logo:

![7364_SLWWFD$010001](https://github.com/theori-io/nrsc5/assets/583749/8839ef19-e935-4ccc-9e56-b5c432a34e12)

While working on this, I found a bug in gr-nrsc5's header spread calculations, which I fixed in https://github.com/argilo/gr-nrsc5/commit/c8b1b0f3deefc74ea628b683701909e03127ede6. After that change, I was also able to receive a synthesized MA3 signal generated by gr-nrsc5.