### PR TITLE
Move DLLMarkup to header 

### DIFF
--- a/include/nrsc5.h
+++ b/include/nrsc5.h
@@ -51,6 +51,16 @@
 #define NRSC5_SAMPLE_RATE_CS16_AM  46511.71875
 #define NRSC5_SAMPLE_RATE_AUDIO    44100
 
+#ifdef NRSC5_EXPORTS
+#ifdef __MINGW32__
+#define NRSC5_API __declspec(dllexport)
+#else
+#define NRSC5_API
+#endif
+#else
+#define NRSC5_API
+#endif
+
 enum
 {
     NRSC5_MODE_FM,
@@ -388,7 +398,7 @@ typedef struct nrsc5_t nrsc5_t;
  * @param[out] version character pointer that will reference the version string.
  * @return Nothing is returned
  */
-void nrsc5_get_version(const char **version);
+NRSC5_API void nrsc5_get_version(const char **version);
 
 /**
  * Retrieves a string corresponding to a service data type.
@@ -399,7 +409,7 @@ void nrsc5_get_version(const char **version);
  * This name will be quite short, e.g. "News" or "Weather". If the type is
  * not recognized, it will the string "Unknown".
  */
-void nrsc5_service_data_type_name(unsigned int type, const char **name);
+NRSC5_API void nrsc5_service_data_type_name(unsigned int type, const char **name);
 
 /**
  * Retrieves a string corresponding to a program type.
@@ -410,7 +420,7 @@ void nrsc5_service_data_type_name(unsigned int type, const char **name);
  * This name will be quite short, e.g. "News" or "Rock". If the type is
  * not recognized, it will the string "Unknown".
  */
-void nrsc5_program_type_name(unsigned int type, const char **name);
+NRSC5_API void nrsc5_program_type_name(unsigned int type, const char **name);
 
 /**
  * Initializes a session for a particular RTLSDR radio dongle.
@@ -432,7 +442,7 @@ void nrsc5_program_type_name(unsigned int type, const char **name);
  * Other session options are initialized to defaults, e.g. mode to FM.
  * It creates (but does not start) a worker thread.
  */
-int nrsc5_open(nrsc5_t **st, int device_index);
+NRSC5_API int nrsc5_open(nrsc5_t **st, int device_index);
 
 /**
  * Initializes a session given an open `FILE` pointer.
@@ -441,7 +451,7 @@ int nrsc5_open(nrsc5_t **st, int device_index);
  * @return 0 on success, nonzero on error
  *
  */
-int nrsc5_open_file(nrsc5_t **st, FILE *fp);
+NRSC5_API int nrsc5_open_file(nrsc5_t **st, FILE *fp);
 
 /**
  * Initializes a session for use with a pipe.
@@ -449,7 +459,7 @@ int nrsc5_open_file(nrsc5_t **st, FILE *fp);
  * @return 0 on success, nonzero on error
  *
  */
-int nrsc5_open_pipe(nrsc5_t **st );
+NRSC5_API int nrsc5_open_pipe(nrsc5_t **st );
 
 /**
  * Initializes a session given a TCP socket file descriptor.
@@ -458,7 +468,7 @@ int nrsc5_open_pipe(nrsc5_t **st );
  * @return 0 on success, nonzero on error
  *
  */
-int nrsc5_open_rtltcp(nrsc5_t **, int socket);
+NRSC5_API int nrsc5_open_rtltcp(nrsc5_t **, int socket);
 
 /**
  * Closes an nrsc5 session.
@@ -468,7 +478,7 @@ int nrsc5_open_rtltcp(nrsc5_t **, int socket);
  * Any worker thread is signalled to exit, files and sockets are closed,
  * and I/O buffers are freed.
  */
-void nrsc5_close(nrsc5_t *);
+NRSC5_API void nrsc5_close(nrsc5_t *);
 
 /**
  * Signals the worker to *start* demodulation.
@@ -476,7 +486,7 @@ void nrsc5_close(nrsc5_t *);
  * @return Nothing is returned.
  *
  */
-void nrsc5_start(nrsc5_t *);
+NRSC5_API void nrsc5_start(nrsc5_t *);
 
 /**
  * Signals the worker to *stop* demodulation.
@@ -485,7 +495,7 @@ void nrsc5_start(nrsc5_t *);
  *
  * This function will block until the worker is stopped.
  */
-void nrsc5_stop(nrsc5_t *);
+NRSC5_API void nrsc5_stop(nrsc5_t *);
 
 /**
  * Set the session mode to AM or FM.
@@ -494,7 +504,7 @@ void nrsc5_stop(nrsc5_t *);
  * @return 0 on success or nonzero on error.
  *
  */
-int nrsc5_set_mode(nrsc5_t *, int mode);
+NRSC5_API int nrsc5_set_mode(nrsc5_t *, int mode);
 
 /**
  * Enable or disable the bias-T for the radio.
@@ -507,7 +517,7 @@ int nrsc5_set_mode(nrsc5_t *, int mode);
  * DC on the antenna cable. Do not enable this unless you know you
  * have an LNA and compatible antenna.
  */
-int nrsc5_set_bias_tee(nrsc5_t *, int on);
+NRSC5_API int nrsc5_set_bias_tee(nrsc5_t *, int on);
 
 /**
  * Enable or disable direct sampling.
@@ -517,7 +527,7 @@ int nrsc5_set_bias_tee(nrsc5_t *, int on);
  *
  * This works with both a local SDR and over a TCP connection.
  */
-int nrsc5_set_direct_sampling(nrsc5_t *, int on);
+NRSC5_API int nrsc5_set_direct_sampling(nrsc5_t *, int on);
 
 /**
  * Adjust the radio frequency correction.
@@ -527,7 +537,7 @@ int nrsc5_set_direct_sampling(nrsc5_t *, int on);
  *
  * This works with both a local SDR and over a TCP connection.
  */
-int nrsc5_set_freq_correction(nrsc5_t *st, int ppm_error);
+NRSC5_API int nrsc5_set_freq_correction(nrsc5_t *st, int ppm_error);
 
 /**
  * Retrieve the frequency to which the device is currently tuned
@@ -537,7 +547,7 @@ int nrsc5_set_freq_correction(nrsc5_t *st, int ppm_error);
  * @param[out] freq  frequency in Hz
  * @return Nothing is returned.
  */
-void nrsc5_get_frequency(nrsc5_t *st, float *freq);
+NRSC5_API void nrsc5_get_frequency(nrsc5_t *st, float *freq);
 
 /**
  * Sets the frequency to which the receiver is tuned.
@@ -550,7 +560,7 @@ void nrsc5_get_frequency(nrsc5_t *st, float *freq);
  * Input, output are reset. Gain is reset if auto-gain is enabled.
  * Works with both a local SDR and over a TCP connection.
  */
-int nrsc5_set_frequency(nrsc5_t *st, float freq);
+NRSC5_API int nrsc5_set_frequency(nrsc5_t *st, float freq);
 
 /**
  * Retrieve the actual receiver gain.
@@ -560,7 +570,7 @@ int nrsc5_set_frequency(nrsc5_t *st, float freq);
  * @return 0 on success or nonzero on error
  *
  */
-void nrsc5_get_gain(nrsc5_t *st, float *gain);
+NRSC5_API void nrsc5_get_gain(nrsc5_t *st, float *gain);
 
 /**
  * Set the receiver gain.
@@ -570,7 +580,7 @@ void nrsc5_get_gain(nrsc5_t *st, float *gain);
  * @return 0 on success or nonzero on error
  *
  */
-int nrsc5_set_gain(nrsc5_t *st, float gain);
+NRSC5_API int nrsc5_set_gain(nrsc5_t *st, float gain);
 
 /**
  * Enable or disable receiver auto-gain control.
@@ -580,7 +590,7 @@ int nrsc5_set_gain(nrsc5_t *st, float gain);
  * @return Nothing is returned.
  *
  */
-void nrsc5_set_auto_gain(nrsc5_t *st, int enabled);
+NRSC5_API void nrsc5_set_auto_gain(nrsc5_t *st, int enabled);
 
 /**
  * Establish a callback function.
@@ -591,7 +601,7 @@ void nrsc5_set_auto_gain(nrsc5_t *st, int enabled);
  * @return Nothing is returned.
  *
  */
-void nrsc5_set_callback(nrsc5_t *st, nrsc5_callback_t callback, void *opaque);
+NRSC5_API void nrsc5_set_callback(nrsc5_t *st, nrsc5_callback_t callback, void *opaque);
 
 
 /**
@@ -604,7 +614,7 @@ void nrsc5_set_callback(nrsc5_t *st, nrsc5_callback_t callback, void *opaque);
  * @return 0 on success, nonzero on error
  *
  */
-int nrsc5_pipe_samples_cu8(nrsc5_t *st, const uint8_t *samples, unsigned int length);
+NRSC5_API int nrsc5_pipe_samples_cu8(nrsc5_t *st, const uint8_t *samples, unsigned int length);
 
 
 /**
@@ -617,6 +627,6 @@ int nrsc5_pipe_samples_cu8(nrsc5_t *st, const uint8_t *samples, unsigned int len
  * @return 0 on success, nonzero on error
  *
  */
-int nrsc5_pipe_samples_cs16(nrsc5_t *st, const int16_t *samples, unsigned int length);
+NRSC5_API int nrsc5_pipe_samples_cs16(nrsc5_t *st, const int16_t *samples, unsigned int length);
 
 #endif /* NRSC5_H_ */

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -82,6 +82,7 @@ target_link_libraries (
 )
 set_target_properties(nrsc5 PROPERTIES PUBLIC_HEADER "../include/nrsc5.h")
 set_target_properties(nrsc5 PROPERTIES LINK_FLAGS "${STATIC_LINKER_FLAGS} ${EXPORTS_LINKER_FLAGS}")
+target_compile_definitions(nrsc5 PUBLIC "-DNRSC5_EXPORTS=1")
 
 add_library (
     nrsc5_static

--- a/src/nrsc5.c
+++ b/src/nrsc5.c
@@ -3,12 +3,6 @@
 
 #include "private.h"
 
-#ifdef __MINGW32__
-#define NRSC5_API __declspec(dllexport)
-#else
-#define NRSC5_API
-#endif
-
 static int snr_callback(void *arg, float snr)
 {
     nrsc5_t *st = arg;
@@ -223,12 +217,12 @@ static void nrsc5_init(nrsc5_t *st)
     }
 }
 
-NRSC5_API void nrsc5_get_version(const char **version)
+void nrsc5_get_version(const char **version)
 {
     *version = GIT_COMMIT_HASH;
 }
 
-NRSC5_API void nrsc5_service_data_type_name(unsigned int type, const char **name)
+void nrsc5_service_data_type_name(unsigned int type, const char **name)
 {
     switch (type)
     {
@@ -255,7 +249,7 @@ NRSC5_API void nrsc5_service_data_type_name(unsigned int type, const char **name
     }
 }
 
-NRSC5_API void nrsc5_program_type_name(unsigned int type, const char **name)
+void nrsc5_program_type_name(unsigned int type, const char **name)
 {
     switch (type)
     {
@@ -301,7 +295,7 @@ static nrsc5_t *nrsc5_alloc()
     return st;
 }
 
-NRSC5_API int nrsc5_open(nrsc5_t **result, int device_index)
+int nrsc5_open(nrsc5_t **result, int device_index)
 {
     int err;
     nrsc5_t *st = nrsc5_alloc();
@@ -330,7 +324,7 @@ error_init:
     return 1;
 }
 
-NRSC5_API int nrsc5_open_file(nrsc5_t **result, FILE *fp)
+int nrsc5_open_file(nrsc5_t **result, FILE *fp)
 {
     nrsc5_t *st = nrsc5_alloc();
     st->iq_file = fp;
@@ -340,7 +334,7 @@ NRSC5_API int nrsc5_open_file(nrsc5_t **result, FILE *fp)
     return 0;
 }
 
-NRSC5_API int nrsc5_open_pipe(nrsc5_t **result)
+int nrsc5_open_pipe(nrsc5_t **result)
 {
     nrsc5_t *st = nrsc5_alloc();
     nrsc5_init(st);
@@ -349,7 +343,7 @@ NRSC5_API int nrsc5_open_pipe(nrsc5_t **result)
     return 0;
 }
 
-NRSC5_API int nrsc5_open_rtltcp(nrsc5_t **result, int socket)
+int nrsc5_open_rtltcp(nrsc5_t **result, int socket)
 {
     int err;
     nrsc5_t *st = nrsc5_alloc();
@@ -375,7 +369,7 @@ error:
     return 1;
 }
 
-NRSC5_API void nrsc5_close(nrsc5_t *st)
+void nrsc5_close(nrsc5_t *st)
 {
     if (!st)
         return;
@@ -404,7 +398,7 @@ NRSC5_API void nrsc5_close(nrsc5_t *st)
     free(st);
 }
 
-NRSC5_API void nrsc5_start(nrsc5_t *st)
+void nrsc5_start(nrsc5_t *st)
 {
     if (using_worker(st))
     {
@@ -416,7 +410,7 @@ NRSC5_API void nrsc5_start(nrsc5_t *st)
     }
 }
 
-NRSC5_API void nrsc5_stop(nrsc5_t *st)
+void nrsc5_stop(nrsc5_t *st)
 {
     if (using_worker(st))
     {
@@ -434,7 +428,7 @@ NRSC5_API void nrsc5_stop(nrsc5_t *st)
     }
 }
 
-NRSC5_API int nrsc5_set_mode(nrsc5_t *st, int mode)
+int nrsc5_set_mode(nrsc5_t *st, int mode)
 {
     if (mode == NRSC5_MODE_FM || mode == NRSC5_MODE_AM)
     {
@@ -445,7 +439,7 @@ NRSC5_API int nrsc5_set_mode(nrsc5_t *st, int mode)
     return 1;
 }
 
-NRSC5_API int nrsc5_set_bias_tee(nrsc5_t *st, int on)
+int nrsc5_set_bias_tee(nrsc5_t *st, int on)
 {
     if (st->dev)
     {
@@ -462,7 +456,7 @@ NRSC5_API int nrsc5_set_bias_tee(nrsc5_t *st, int on)
     return 0;
 }
 
-NRSC5_API int nrsc5_set_direct_sampling(nrsc5_t *st, int on)
+int nrsc5_set_direct_sampling(nrsc5_t *st, int on)
 {
     if (st->dev)
     {
@@ -479,7 +473,7 @@ NRSC5_API int nrsc5_set_direct_sampling(nrsc5_t *st, int on)
     return 0;
 }
 
-NRSC5_API int nrsc5_set_freq_correction(nrsc5_t *st, int ppm_error)
+int nrsc5_set_freq_correction(nrsc5_t *st, int ppm_error)
 {
     if (st->dev)
     {
@@ -496,7 +490,7 @@ NRSC5_API int nrsc5_set_freq_correction(nrsc5_t *st, int ppm_error)
     return 0;
 }
 
-NRSC5_API void nrsc5_get_frequency(nrsc5_t *st, float *freq)
+void nrsc5_get_frequency(nrsc5_t *st, float *freq)
 {
     if (st->dev)
         *freq = rtlsdr_get_center_freq(st->dev);
@@ -504,7 +498,7 @@ NRSC5_API void nrsc5_get_frequency(nrsc5_t *st, float *freq)
         *freq = st->freq;
 }
 
-NRSC5_API int nrsc5_set_frequency(nrsc5_t *st, float freq)
+int nrsc5_set_frequency(nrsc5_t *st, float freq)
 {
     if (st->freq == freq)
         return 0;
@@ -525,7 +519,7 @@ NRSC5_API int nrsc5_set_frequency(nrsc5_t *st, float freq)
     return 0;
 }
 
-NRSC5_API void nrsc5_get_gain(nrsc5_t *st, float *gain)
+void nrsc5_get_gain(nrsc5_t *st, float *gain)
 {
     if (st->dev)
         *gain = rtlsdr_get_tuner_gain(st->dev) / 10.0f;
@@ -533,7 +527,7 @@ NRSC5_API void nrsc5_get_gain(nrsc5_t *st, float *gain)
         *gain = st->gain;
 }
 
-NRSC5_API int nrsc5_set_gain(nrsc5_t *st, float gain)
+int nrsc5_set_gain(nrsc5_t *st, float gain)
 {
     if (st->gain == gain)
         return 0;
@@ -549,13 +543,13 @@ NRSC5_API int nrsc5_set_gain(nrsc5_t *st, float gain)
     return 0;
 }
 
-NRSC5_API void nrsc5_set_auto_gain(nrsc5_t *st, int enabled)
+void nrsc5_set_auto_gain(nrsc5_t *st, int enabled)
 {
     st->auto_gain = enabled;
     st->gain = -1;
 }
 
-NRSC5_API void nrsc5_set_callback(nrsc5_t *st, nrsc5_callback_t callback, void *opaque)
+void nrsc5_set_callback(nrsc5_t *st, nrsc5_callback_t callback, void *opaque)
 {
     if (using_worker(st))
         pthread_mutex_lock(&st->worker_mutex);
@@ -565,7 +559,7 @@ NRSC5_API void nrsc5_set_callback(nrsc5_t *st, nrsc5_callback_t callback, void *
         pthread_mutex_unlock(&st->worker_mutex);
 }
 
-NRSC5_API int nrsc5_pipe_samples_cu8(nrsc5_t *st, const uint8_t *samples, unsigned int length)
+int nrsc5_pipe_samples_cu8(nrsc5_t *st, const uint8_t *samples, unsigned int length)
 {
     unsigned int sample_groups;
 
@@ -597,7 +591,7 @@ NRSC5_API int nrsc5_pipe_samples_cu8(nrsc5_t *st, const uint8_t *samples, unsign
     return 0;
 }
 
-NRSC5_API int nrsc5_pipe_samples_cs16(nrsc5_t *st, const int16_t *samples, unsigned int length)
+int nrsc5_pipe_samples_cs16(nrsc5_t *st, const int16_t *samples, unsigned int length)
 {
     unsigned int sample_groups;
 


### PR DESCRIPTION
This deals with a warning that Clion IDE gave me. 

`__declspec(dllexport)` is meant to be used in the header. 

Although CMake's newer versions can do this automatically using `set(CMAKE_WINDOWS_EXPORT_ALL_SYMBOLS ON)`, we are still on CMake version 2.8. There is already a *DLLMarkup* so it should be okay. 