### PR TITLE
Fix signedness bug in OFDM synchronization

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -1,4 +1,4 @@
-add_compile_options (--std=gnu11 -O3 -Wall)
+add_compile_options (--std=gnu11 -O3 -Wall -Wextra)
 
 add_definitions (-D_GNU_SOURCE)
 set (THREAD_LIBRARY pthread)

--- a/src/acquire.c
+++ b/src/acquire.c
@@ -99,9 +99,9 @@ void acquire_process(acquire_t *st)
     float complex max_v = 0, phase_increment;
     float angle, angle_diff, angle_factor, max_mag = -1.0f;
     int samperr = 0;
-    unsigned int i, j, keep;
+    int i, j, keep;
 
-    if (st->idx != st->fftcp * (ACQUIRE_SYMBOLS + 1))
+    if (st->idx != (unsigned int)st->fftcp * (ACQUIRE_SYMBOLS + 1))
         return;
 
     if (st->input->sync_state == SYNC_STATE_FINE)

--- a/src/acquire.h
+++ b/src/acquire.h
@@ -26,9 +26,9 @@ typedef struct
     int cfo;
 
     int mode;
-    unsigned int fft;
-    unsigned int fftcp;
-    unsigned int cp;
+    int fft;
+    int fftcp;
+    int cp;
 } acquire_t;
 
 void acquire_process(acquire_t *st);


### PR DESCRIPTION
I recently noticed that nrcs5 reports a non-zero BER even for very strong signals (including synthetic signals generated by gr-nrsc5). I did a git bisect and found that the problem was introduced in #326. In particular, changing `fftcp` from `int` to `unsigned int` broke the phase calculation, which works with signed integers:

https://github.com/theori-io/nrsc5/blob/e6ae705ac211d8c7a0884a88c0f01179c7e6c822/src/acquire.c#L163

Here I reverted the change to unsigned types, and changed the corresponding loop indexes to signed integers so that no new warnings are produced. Strong signals now have zero BER, as expected.