### PR TITLE
Make open and close functions thread-safe

### DIFF
--- a/src/input.c
+++ b/src/input.c
@@ -252,7 +252,10 @@ void input_init(input_t *st, nrsc5_t *radio, output_t *output)
 
     for (int i = 0; i < AM_DECIM_STAGES; i++)
         st->decim[i] = firdecim_q15_create(decim_taps, sizeof(decim_taps) / sizeof(decim_taps[0]));
+
+    pthread_mutex_lock(&fftw_mutex);
     st->snr_fft = fftwf_plan_dft_1d(SNR_FFT_LEN, st->snr_fft_in, st->snr_fft_out, FFTW_FORWARD, 0);
+    pthread_mutex_unlock(&fftw_mutex);
 
     acquire_init(&st->acq, st);
     decode_init(&st->decode, st);
@@ -275,7 +278,10 @@ void input_free(input_t *st)
 
     for (int i = 0; i < AM_DECIM_STAGES; i++)
         firdecim_q15_free(st->decim[i]);
+
+    pthread_mutex_lock(&fftw_mutex);
     fftwf_destroy_plan(st->snr_fft);
+    pthread_mutex_unlock(&fftw_mutex);
 }
 
 void input_set_sync_state(input_t *st, unsigned int new_state)

--- a/src/nrsc5.c
+++ b/src/nrsc5.c
@@ -3,6 +3,8 @@
 
 #include "private.h"
 
+pthread_mutex_t fftw_mutex = PTHREAD_MUTEX_INITIALIZER;
+
 static int snr_callback(void *arg, float snr)
 {
     nrsc5_t *st = arg;

--- a/src/private.h
+++ b/src/private.h
@@ -12,6 +12,8 @@
 #include "output.h"
 #include "rtltcp.h"
 
+extern pthread_mutex_t fftw_mutex;
+
 struct nrsc5_t
 {
     rtlsdr_dev_t *dev;


### PR DESCRIPTION
Fixes #349.

The `nrsc5_open()`, `nrsc5_open_file()`, `nrsc5_open_pipe()`, `nrsc5_open_rtltcp()`, and `nrsc5_close()` API functions call into FFTW functions which are not thread-safe. (See https://www.fftw.org/doc/Thread-safety.html for an explanation of thread safety in FFTW.)

To make nrsc5's API functions thread-safe, I have protected the affected FFTW calls with a mutex. After this change, I was able to initialize and run many instances of nrsc5 in parallel from Python without any crashes.

@luarvique I hope this change will make it simpler for OpenWebRX+ to use nrcs5.