### PR TITLE
Allow additional callback arguments in Python API

### DIFF
--- a/support/nrsc5.py
+++ b/support/nrsc5.py
@@ -512,12 +512,13 @@ class NRSC5:
             evt = SIS(self._decode(sis.country_code), sis.fcc_facility_id, self._decode(sis.name),
                       self._decode(sis.slogan), self._decode(sis.message), self._decode(sis.alert),
                       latitude, longitude, altitude, audio_services, data_services)
-        self.callback(evt_type, evt)
+        self.callback(evt_type, evt, *self.callback_args)
 
-    def __init__(self, callback):
+    def __init__(self, callback, callback_args=()):
         self._load_library()
         self.radio = ctypes.c_void_p()
         self.callback = callback
+        self.callback_args = callback_args
 
     @staticmethod
     def get_version():


### PR DESCRIPTION
The C API allows additional data to be passed into the callback function through an opaque pointer:

https://github.com/theori-io/nrsc5/blob/a4b7883971a7eb1c555ff8a23194dd559abd9609/include/nrsc5.h#L589-L597

But the Python API doesn't have such a mechanism. It's possible to use closures, but that's not always convenient. So I've added an optional `callback_args` which will be passed through to the callback function. A tuple or list of arguments can be supplied.