### PR TITLE
Target peak amplitude of -6 dBFS in automatic gain selection

### DIFF
--- a/src/input.h
+++ b/src/input.h
@@ -16,15 +16,6 @@
 #define INPUT_BUF_LEN (FFTCP_FM * 512)
 #define AM_DECIM_STAGES 5
 
-#define SNR_FFT_COUNT 256
-#define SNR_FFT_LEN 64
-#define SNR_NOISE_START 19
-#define SNR_NOISE_LEN 4
-#define SNR_SIGNAL_START 24
-#define SNR_SIGNAL_LEN 2
-
-typedef int (*input_snr_cb_t) (void *, float);
-
 enum { SYNC_STATE_NONE, SYNC_STATE_COARSE, SYNC_STATE_FINE };
 
 typedef struct input_t
@@ -37,14 +28,6 @@ typedef struct input_t
     cint16_t buffer[INPUT_BUF_LEN];
     unsigned int avail, used, skip, offset;
     unsigned int sync_state;
-
-    fftwf_plan snr_fft;
-    float complex snr_fft_in[SNR_FFT_LEN];
-    float complex snr_fft_out[SNR_FFT_LEN];
-    float snr_power[SNR_FFT_LEN];
-    int snr_cnt;
-    input_snr_cb_t snr_cb;
-    void *snr_cb_arg;
 
     acquire_t acq;
     decode_t decode;
@@ -59,7 +42,6 @@ void input_free(input_t *st);
 void input_set_sync_state(input_t *st, unsigned int new_state);
 void input_push_cu8(input_t *st, const uint8_t *buf, uint32_t len);
 void input_push_cs16(input_t *st, const int16_t *buf, uint32_t len);
-void input_set_snr_callback(input_t *st, input_snr_cb_t cb, void *);
 void input_set_skip(input_t *st, unsigned int skip);
 void input_pdu_push(input_t *st, uint8_t *pdu, unsigned int len, unsigned int program, unsigned int stream_id);
 void input_aas_push(input_t *st, uint8_t *psd, unsigned int len);

--- a/src/private.h
+++ b/src/private.h
@@ -24,8 +24,6 @@ struct nrsc5_t
     int mode;
     int gain;
     int auto_gain;
-    int auto_gain_snr_ready;
-    float auto_gain_snr;
     int stopped;
     int worker_stopped;
     int closed;


### PR DESCRIPTION
Fixes #238.
Fixes #333.

nrsc5's automatic gain selection currently works by stepping through all possible gain values, and measuring the amount of power present in the frequency ranges occupied by the HD Radio sidebands compared to the amount of power present at frequencies just below and just above the HD Radio sidebands.

This approach has some problems:

* It often chooses a gain value that nearly saturates the ADC, leaving little headroom in case the signal amplitude increases.
* The SNR measurement performs badly when adjacent-channel interference is present.
* The SNR measurement performs badly when the gain is high enough for clipping to occur.

I think it would be better to instead measure the peak amplitude of the incoming signal, and target -6 dBFS (i.e. 6 dB below full scale, where clipping would begin). So far this approach seems to work well, and selects more sensible gain values. When no interfering signals are present, the -6 dBFS signal level is more than sufficient to receive an error-free signal, while leaving a decent amount of headroom. (Bit errors only begin occurring when the signal level is below -24 dBFS.)

I'd appreciate feedback from anyone who can take this for a spin to confirm whether it works better than the old approach.