### PR TITLE
Add decoding of emergency alert control bytes

### DIFF
--- a/include/nrsc5.h
+++ b/include/nrsc5.h
@@ -203,6 +203,30 @@ enum
     NRSC5_PROGRAM_TYPE_SPECIAL_READING_SERVICES = 76
 };
 
+enum
+{
+    NRSC5_LOCATION_FORMAT_SAME,
+    NRSC5_LOCATION_FORMAT_FIPS,
+    NRSC5_LOCATION_FORMAT_ZIP
+};
+
+enum
+{
+    NRSC5_ALERT_CATEGORY_NON_SPECIFIC = 1,
+    NRSC5_ALERT_CATEGORY_GEOPHYSICAL = 2,
+    NRSC5_ALERT_CATEGORY_WEATHER = 3,
+    NRSC5_ALERT_CATEGORY_SAFETY = 4,
+    NRSC5_ALERT_CATEGORY_SECURITY = 5,
+    NRSC5_ALERT_CATEGORY_RESCUE = 6,
+    NRSC5_ALERT_CATEGORY_FIRE = 7,
+    NRSC5_ALERT_CATEGORY_HEALTH = 8,
+    NRSC5_ALERT_CATEGORY_ENVIRONMENTAL = 9,
+    NRSC5_ALERT_CATEGORY_TRANSPORTATION = 10,
+    NRSC5_ALERT_CATEGORY_UTILITIES = 11,
+    NRSC5_ALERT_CATEGORY_HAZMAT = 12,
+    NRSC5_ALERT_CATEGORY_TEST = 30
+};
+
 /**
  * Station Information Service *Audio* service descriptor. This is a
  * linked list element that may point to further audio service
@@ -385,6 +409,13 @@ struct nrsc5_event_t
             int altitude;
             nrsc5_sis_asd_t *audio_services;
             nrsc5_sis_dsd_t *data_services;
+            const uint8_t *alert_cnt;
+            int alert_cnt_length;
+            int alert_category1;
+            int alert_category2;
+            int alert_location_format;
+            int alert_num_locations;
+            const int *alert_locations;
         } sis;
     };
 };
@@ -425,21 +456,31 @@ NRSC5_API void nrsc5_get_version(const char **version);
  * @param[out] name  character pointer to a string naming the service type
  *
  * This name will be quite short, e.g. "News" or "Weather". If the type is
- * not recognized, it will the string "Unknown".
+ * not recognized, it will be the string "Unknown".
  */
 NRSC5_API void nrsc5_service_data_type_name(unsigned int type, const char **name);
 
 /**
  * Retrieves a string corresponding to a program type.
- * @param[in]  type  a protram data type integer.
+ * @param[in]  type  a program data type integer.
  * @param[out] name  character pointer to a string naming the service type
  *
  * This name will be quite short, e.g. "News" or "Rock". If the type is
- * not recognized, it will the string "Unknown".
+ * not recognized, it will be the string "Unknown".
  */
 NRSC5_API void nrsc5_program_type_name(unsigned int type, const char **name);
 
 /**
+ * Retrieves a string corresponding to an alert category.
+ * @param[in]  type  an alert category integer.
+ * @param[out] name  character pointer to a string naming the alert category
+ *
+ * This name will be quite short, e.g. "Weather" or "Safety". If the type is
+ * not recognized, it will be the string "Unknown".
+ */
+ NRSC5_API void nrsc5_alert_category_name(unsigned int category, const char **name);
+ 
+ /**
  * Initializes a session for a particular RTLSDR radio dongle.
  * @param[out] st  handle for an nrsc5_t
  * @param[in]  device_index  the RTLSDR device index

--- a/src/libnrsc5.map
+++ b/src/libnrsc5.map
@@ -3,6 +3,7 @@ LIBNRSC5_1.0 {
         nrsc5_get_version;
         nrsc5_service_data_type_name;
         nrsc5_program_type_name;
+        nrsc5_alert_category_name;
         nrsc5_open;
         nrsc5_open_file;
         nrsc5_open_pipe;

--- a/src/libnrsc5.sym
+++ b/src/libnrsc5.sym
@@ -1,6 +1,7 @@
 _nrsc5_get_version
 _nrsc5_service_data_type_name
 _nrsc5_program_type_name
+_nrsc5_alert_category_name
 _nrsc5_open
 _nrsc5_open_file
 _nrsc5_open_pipe

--- a/src/main.c
+++ b/src/main.c
@@ -390,7 +390,48 @@ static void callback(const nrsc5_event_t *evt, void *opaque)
         if (evt->sis.message)
             log_info("Message: %s", evt->sis.message);
         if (evt->sis.alert)
-            log_info("Alert: %s", evt->sis.alert);
+        {
+            int i;
+            char alert_details[512] = "";
+            const char *name = NULL;
+
+            strcat(alert_details, "Category=[");
+            if (evt->sis.alert_category1 >= 1)
+            {
+                nrsc5_alert_category_name(evt->sis.alert_category1, &name);
+                strcat(alert_details, name);
+            }
+            if (evt->sis.alert_category2 >= 1)
+            {
+                nrsc5_alert_category_name(evt->sis.alert_category2, &name);
+                strcat(alert_details, ", ");
+                strcat(alert_details, name);
+            }
+            strcat(alert_details, "] ");
+
+            switch (evt->sis.alert_location_format)
+            {
+            case NRSC5_LOCATION_FORMAT_SAME:
+                strcat(alert_details, "SAME=[");
+                break;
+            case NRSC5_LOCATION_FORMAT_FIPS:
+                strcat(alert_details, "FIPS=[");
+                break;
+            case NRSC5_LOCATION_FORMAT_ZIP:
+                strcat(alert_details, "ZIP=[");
+                break;
+            }
+
+            for (i = 0; i < evt->sis.alert_num_locations; i++)
+            {
+                if (i > 0)
+                    strcat(alert_details, ", ");
+                sprintf(alert_details + strlen(alert_details), "%d", evt->sis.alert_locations[i]);
+            }
+            strcat(alert_details, "]");
+
+            log_info("Alert: %s %s", alert_details, evt->sis.alert);
+        }
         if (!isnan(evt->sis.latitude))
             log_info("Station location: %.4f, %.4f, %dm", evt->sis.latitude, evt->sis.longitude, evt->sis.altitude);
         for (audio_service = evt->sis.audio_services; audio_service != NULL; audio_service = audio_service->next)

--- a/src/nrsc5.c
+++ b/src/nrsc5.c
@@ -286,6 +286,27 @@ void nrsc5_program_type_name(unsigned int type, const char **name)
     }
 }
 
+void nrsc5_alert_category_name(unsigned int type, const char **name)
+{
+    switch (type)
+    {
+    case NRSC5_ALERT_CATEGORY_NON_SPECIFIC: *name = "Non-specific"; break;
+    case NRSC5_ALERT_CATEGORY_GEOPHYSICAL: *name = "Geophysical"; break;
+    case NRSC5_ALERT_CATEGORY_WEATHER: *name = "Weather"; break;
+    case NRSC5_ALERT_CATEGORY_SAFETY: *name = "Safety"; break;
+    case NRSC5_ALERT_CATEGORY_SECURITY: *name = "Security"; break;
+    case NRSC5_ALERT_CATEGORY_RESCUE: *name = "Rescue"; break;
+    case NRSC5_ALERT_CATEGORY_FIRE: *name = "Fire"; break;
+    case NRSC5_ALERT_CATEGORY_HEALTH: *name = "Health"; break;
+    case NRSC5_ALERT_CATEGORY_ENVIRONMENTAL: *name = "Environmental"; break;
+    case NRSC5_ALERT_CATEGORY_TRANSPORTATION: *name = "Transportation"; break;
+    case NRSC5_ALERT_CATEGORY_UTILITIES: *name = "Utilities"; break;
+    case NRSC5_ALERT_CATEGORY_HAZMAT: *name = "Hazmat"; break;
+    case NRSC5_ALERT_CATEGORY_TEST: *name = "Test"; break;
+    default: *name = "Unknown"; break;
+    }
+}
+
 static nrsc5_t *nrsc5_alloc(void)
 {
     nrsc5_t *st = calloc(1, sizeof(*st));
@@ -837,7 +858,8 @@ void nrsc5_report_sig(nrsc5_t *st, sig_service_t *services, unsigned int count)
 }
 
 void nrsc5_report_sis(nrsc5_t *st, const char *country_code, int fcc_facility_id, const char *name,
-                      const char *slogan, const char *message, const char *alert,
+                      const char *slogan, const char *message, const char *alert, const uint8_t *cnt, int cnt_length,
+                      int category1, int category2, int location_format, int num_locations, const int *locations,
                       float latitude, float longitude, int altitude, nrsc5_sis_asd_t *audio_services,
                       nrsc5_sis_dsd_t *data_services)
 {
@@ -850,6 +872,13 @@ void nrsc5_report_sis(nrsc5_t *st, const char *country_code, int fcc_facility_id
     evt.sis.slogan = slogan;
     evt.sis.message = message;
     evt.sis.alert = alert;
+    evt.sis.alert_cnt = cnt;
+    evt.sis.alert_cnt_length = cnt_length;
+    evt.sis.alert_category1 = category1;
+    evt.sis.alert_category2 = category2;
+    evt.sis.alert_location_format = location_format;
+    evt.sis.alert_num_locations = num_locations;
+    evt.sis.alert_locations = locations;
     evt.sis.latitude = latitude;
     evt.sis.longitude = longitude;
     evt.sis.altitude = altitude;

--- a/src/pids.h
+++ b/src/pids.h
@@ -15,6 +15,8 @@
 #define MAX_SLOGAN_FRAMES 16
 #define MAX_ALERT_LEN 381
 #define MAX_ALERT_FRAMES 64
+#define MAX_ALERT_CNT_LEN 63
+#define MAX_ALERT_LOCATIONS 31
 
 typedef struct
 {
@@ -87,6 +89,7 @@ typedef struct
     int alert_seq;
     encoding_t alert_encoding;
     int alert_len;
+    int alert_crc;
     int alert_cnt_len;
     int alert_displayed;
 } pids_t;

--- a/src/private.h
+++ b/src/private.h
@@ -57,6 +57,7 @@ void nrsc5_report_packet(nrsc5_t *, uint16_t port, uint16_t seq, unsigned int si
 void nrsc5_report_lot(nrsc5_t *, uint16_t port, unsigned int lot, unsigned int size, uint32_t mime, const char *name, const uint8_t *data, struct tm *expiry_utc);
 void nrsc5_report_sig(nrsc5_t *, sig_service_t *services, unsigned int count);
 void nrsc5_report_sis(nrsc5_t *, const char *country_code, int fcc_facility_id, const char *name,
-                      const char *slogan, const char *message, const char *alert,
+                      const char *slogan, const char *message, const char *alert, const uint8_t *cnt, int cnt_length,
+                      int category1, int category2, int location_format, int num_locations, const int *locations,
                       float latitude, float longitude, int altitude, nrsc5_sis_asd_t *audio_services,
                       nrsc5_sis_dsd_t *data_services);

--- a/support/cli.py
+++ b/support/cli.py
@@ -292,7 +292,8 @@ class NRSC5CLI:
             if evt.message:
                 logging.info("Message: %s", evt.message)
             if evt.alert:
-                logging.info("Alert: %s", evt.alert)
+                categories = ", ".join(self.radio.alert_category_name(category) for category in evt.alert_categories)
+                logging.info("Alert: Category=[%s] %s=%s %s", categories, evt.alert_location_format.name, str(evt.alert_locations), evt.alert)
             if evt.latitude:
                 logging.info("Station location: %.4f, %.4f, %dm",
                              evt.latitude, evt.longitude, evt.altitude)


### PR DESCRIPTION
Fixes #358.

Emergency alert messages include "control data" bytes, which until now were ignored by nrsc5. The format of the control bytes is not publicly documented, but through reverse engineering I have determined the meaning of most data fields. The following data is now decoded:

* alert categories (up to 2), e.g. "Weather", "Safety", "Test"
* location code format: [SAME](https://en.wikipedia.org/wiki/Specific_Area_Message_Encoding), [FIPS](https://en.wikipedia.org/wiki/FIPS_county_code), or [ZIP](https://en.wikipedia.org/wiki/ZIP_Code)
* list of location codes (0-31)

I made this data, as well as the raw control bytes, available through the API. I also updated the C and Python CLI applications to display the data:

```
21:50:59 Alert: Category=[Weather] SAME=[27027, 27167] The National Weather Service has issued a Severe Thunderstorm Warning for Clay, MN and Wilkin, MN beginning at 2:09 pm and ending at 3:09 pm (RADIOFM)
21:51:01 Alert: Category=[Safety] SAME=[51095, 51199] The National Weather Service has issued a Flash Flood Warning for James City, VA and York, VA beginning at 7:49 pm and ending at 11:19 pm (WWDE FM)
21:51:01 Alert: Category=[Geophysical, Test] SAME=[51000] Required Monthly Test/This is a test of the Virginia Emergency Alert system. In the event of an emergency, this system would bring you important information.
```