### PR TITLE
Update Costas loop state when requesting a frequency adjustment

### DIFF
--- a/src/sync.c
+++ b/src/sync.c
@@ -413,6 +413,11 @@ void sync_process_fm(sync_t *st)
 
         angle /= (partitions_per_band + 1) * 2;
         st->angle = angle;
+        for (i = 0; i < partitions_per_band * PARTITION_WIDTH + 1; i += PARTITION_WIDTH)
+        {
+            st->costas_freq[LB_START + i] -= angle;
+            st->costas_freq[UB_END - i] -= angle;
+        }
 
         // Calculate modulation error
         float error_lb = 0, error_ub = 0;


### PR DESCRIPTION
Once coarse synchronization is completed, nrsc5 uses Costas loops to track the frequencies of the reference subcarriers. It uses their frequencies to estimate the OFDM timing and frequency error, and feeds this information back to the "acquire" stage.

I noticed that oscillation or unstable behaviour occurs if the initial coarse frequency estimate is inaccurate. In this case, the "sync" stage requests a relatively large frequency adjustment, but does not update the frequencies in its Costas loops to compensate for this change.

After adding code to adjust the Costas loop frequencies, the unstable behaviour went away. I also observed slightly better performance across my suite of recordings, with some additional audio packets decoded.