### PR TITLE
Use 32 symbols for coarse acquisition

### DIFF
--- a/src/defines.h
+++ b/src/defines.h
@@ -19,7 +19,7 @@
 // OFDM symbols per L1 block
 #define BLKSZ 32
 // symbols processed by each invocation of acquire_process
-#define ACQUIRE_SYMBOLS (BLKSZ * 2)
+#define ACQUIRE_SYMBOLS (BLKSZ)
 // index of first lower sideband subcarrier
 #define LB_START ((FFT_FM / 2) - 546)
 // index of last upper sideband subcarrier


### PR DESCRIPTION
Currently nrsc5 uses two blocks (= 64 symbols) for coarse (i.e. pre-FFT) OFDM synchronization. This seems to be overkill, as the detected correlation peak remains strong even at 0 dB SNR where the data carried in QPSK subcarriers is not decodable. Switching to a single block (= 32 symbols) has negligible impact on the number of decoded audio packets. AM reception at low SNR suffers slightly, but only because it uses a poor design. (It should switch to using the AM carrier and reference subcarriers for synchronization, as intended.)

This change also removes an obstacle to implementing elastic buffering (#343): because the "acquire" stage presently operates two blocks at a time, and because the pair of blocks is not necessarily aligned with the start of a frame, one extra block of latency can occur some of the time.