### PR TITLE
Reduce RTL-SDR buffer length

### DIFF
--- a/src/nrsc5.c
+++ b/src/nrsc5.c
@@ -155,7 +155,7 @@ static void *worker_thread(void *arg)
 
             if (st->dev)
             {
-                err = rtlsdr_read_async(st->dev, worker_cb, st, 8, 512 * 1024);
+                err = rtlsdr_read_async(st->dev, worker_cb, st, 120, 32768);
             }
             else if (st->rtltcp)
             {


### PR DESCRIPTION
Currently nrsc5 receives samples from the RTL-SDR in batches of 512 kB (= 262144 I/Q samples = 176 milliseconds). This adds a corresponding amount of latency (inconvenient for #380), and is somewhat problematic for elastic buffering (#343) since it forces audio output to occur in relatively large 176-ms bursts.

The RTL-SDR header file notes that the buffer length must be a multiple of 512 bytes, and should be a multiple of 16384 bytes. While testing the nrsc5 API, I found that reading samples in very small batches causes extra CPU overhead, but the effect becomes negligible once the batch size reaches 32768 bytes (= 16384 I/Q samples = 11 milliseconds). This seems like a reasonable buffer length to use.

To maintain the total amount of buffer space, I increased the number of buffers to 120. This gives 3932160 bytes (= 1.321 seconds) of buffer space, which is a slight reduction from the current 4194304 bytes (= 1.409 seconds), but matches the default value used by the RTL-SDR library (15 buffers of 262144 bytes each, which was presumably chosen so that four RTL-SDRs can be used without consuming the entire 16 MB of available USBFS buffer space, the default on Linux).