### PR TITLE
Start decoding PIDS, P3, and P4 earlier

### DIFF
--- a/src/decode.c
+++ b/src/decode.c
@@ -429,17 +429,40 @@ void decode_process_p1_p3_am(decode_t *st)
     }
 }
 
+void decode_set_block(decode_t *st, unsigned int bc)
+{
+    st->idx_pm = 720 * BLKSZ * bc;
+    if (bc == 0)
+        st->started_pm = 1;
+
+    st->interleaver_px1.idx = (st->interleaver_px1.length / 2) * (bc % 2);
+    st->interleaver_px2.idx = (st->interleaver_px2.length / 2) * (bc % 2);
+    if ((bc % 2) == 0)
+    {
+        st->interleaver_px1.started = 1;
+        st->interleaver_px2.started = 1;
+    }
+}
+
+void decode_set_px1_length(decode_t *st, unsigned int frame_len)
+{
+    st->interleaver_px1.length = frame_len;
+}
+
 static void interleaver_iv_reset(interleaver_iv_t *interleaver)
 {
     interleaver->idx = 0;
     interleaver->i = 0;
     memset(interleaver->pt, 0, sizeof(unsigned int) * 4);
+    interleaver->length = P3_FRAME_LEN_FM * 2;
+    interleaver->started = 0;
     interleaver->ready = 0;
 }
 
 void decode_reset(decode_t *st)
 {
     st->idx_pm = 0;
+    st->started_pm = 0;
     st->idx_pu_pl_s_t = 0;
     st->am_diversity_wait = 3;
     interleaver_iv_reset(&st->interleaver_px1);

--- a/src/sync.h
+++ b/src/sync.h
@@ -12,6 +12,7 @@ typedef struct
     unsigned int idx;
     int psmi;
     int cfo_wait;
+    unsigned int bc;
     unsigned int offset_history;
     int samperr;
     float angle;


### PR DESCRIPTION
Fixes #380.

Currently, nrsc5 doesn't decode data from any of the logical channels until block 0 of a 16-block transfer frame arrives. This can take up to 1.4 seconds.

PIDS data arrives one block at a time, so we can begin decoding it as soon as synchronization is achieved. SIS data appears about a second after starting nrsc5.

P3 and P4 data arrives two blocks at a time, so we can begin decoding it as soon as an even-numbered block arrives. Audio still takes a few seconds to begin playing, because these logical channels use an interleaver that is 32 blocks long.