### PR TITLE
Move block synchronization to the acquire stage

### DIFF
--- a/src/acquire.c
+++ b/src/acquire.c
@@ -254,9 +254,15 @@ void acquire_process(acquire_t *st)
         sync_push(&st->input->sync, st->fftout);
     }
 
-    keep = st->fftcp + (st->fftcp / 2 - samperr);
+    keep = st->fftcp + (st->fftcp / 2 - samperr) + st->keep_extra;
+    st->keep_extra = 0;
     memmove(&st->in_buffer[0], &st->in_buffer[st->idx - keep], sizeof(cint16_t) * keep);
     st->idx = keep;
+}
+
+void acquire_keep_extra(acquire_t *st, int extra)
+{
+    st->keep_extra = extra;
 }
 
 void acquire_cfo_adjust(acquire_t *st, int cfo)
@@ -293,6 +299,7 @@ void acquire_reset(acquire_t *st)
     st->idx = 0;
     st->prev_angle = 0;
     st->phase = 1;
+    st->keep_extra = 0;
     st->cfo = 0;
 }
 

--- a/src/acquire.h
+++ b/src/acquire.h
@@ -23,6 +23,7 @@ typedef struct
     unsigned int idx;
     float prev_angle;
     float complex phase;
+    int keep_extra;
     int cfo;
 
     int mode;
@@ -32,6 +33,7 @@ typedef struct
 } acquire_t;
 
 void acquire_process(acquire_t *st);
+void acquire_keep_extra(acquire_t *st, int extra);
 void acquire_cfo_adjust(acquire_t *st, int cfo);
 unsigned int acquire_push(acquire_t *st, cint16_t *buf, unsigned int length);
 void acquire_reset(acquire_t *st);

--- a/src/input.c
+++ b/src/input.c
@@ -40,31 +40,12 @@ static float decim_taps[] = {
 
 static void input_push_to_acquire(input_t *st)
 {
-    if (st->skip)
-    {
-        if (st->skip > st->avail - st->used)
-        {
-            st->skip -= st->avail - st->used;
-            st->used = st->avail;
-        }
-        else
-        {
-            st->used += st->skip;
-            st->skip = 0;
-        }
-    }
-
     st->used += acquire_push(&st->acq, &st->buffer[st->used], st->avail - st->used);
 }
 
 void input_pdu_push(input_t *st, uint8_t *pdu, unsigned int len, unsigned int program, unsigned int stream_id)
 {
     output_push(st->output, pdu, len, program, stream_id);
-}
-
-void input_set_skip(input_t *st, unsigned int skip)
-{
-    st->skip += skip;
 }
 
 int input_shift(input_t *st, unsigned int cnt)
@@ -169,7 +150,6 @@ void input_reset(input_t *st)
 {
     st->avail = 0;
     st->used = 0;
-    st->skip = 0;
     st->offset = 0;
 
     input_set_sync_state(st, SYNC_STATE_NONE);

--- a/src/input.c
+++ b/src/input.c
@@ -38,11 +38,6 @@ static float decim_taps[] = {
     -0.00410953676328063
 };
 
-static void input_push_to_acquire(input_t *st)
-{
-    st->used += acquire_push(&st->acq, &st->buffer[st->used], st->avail - st->used);
-}
-
 void input_pdu_push(input_t *st, uint8_t *pdu, unsigned int len, unsigned int program, unsigned int stream_id)
 {
     output_push(st->output, pdu, len, program, stream_id);
@@ -78,7 +73,7 @@ void input_push(input_t *st)
 {
     while (st->avail - st->used >= (st->radio->mode == NRSC5_MODE_FM ? FFTCP_FM : FFTCP_AM))
     {
-        input_push_to_acquire(st);
+        st->used += acquire_push(&st->acq, &st->buffer[st->used], st->avail - st->used);
         acquire_process(&st->acq);
     }
 }

--- a/src/input.h
+++ b/src/input.h
@@ -26,7 +26,7 @@ typedef struct input_t
     firdecim_q15 decim[AM_DECIM_STAGES];
     cint16_t stages[AM_DECIM_STAGES][2];
     cint16_t buffer[INPUT_BUF_LEN];
-    unsigned int avail, used, skip, offset;
+    unsigned int avail, used, offset;
     unsigned int sync_state;
 
     acquire_t acq;
@@ -42,6 +42,5 @@ void input_free(input_t *st);
 void input_set_sync_state(input_t *st, unsigned int new_state);
 void input_push_cu8(input_t *st, const uint8_t *buf, uint32_t len);
 void input_push_cs16(input_t *st, const int16_t *buf, uint32_t len);
-void input_set_skip(input_t *st, unsigned int skip);
 void input_pdu_push(input_t *st, uint8_t *pdu, unsigned int len, unsigned int program, unsigned int stream_id);
 void input_aas_push(input_t *st, uint8_t *psd, unsigned int len);

--- a/src/sync.c
+++ b/src/sync.c
@@ -323,7 +323,7 @@ void detect_cfo(sync_t *st)
         if (best_offset >= 0 && best_count >= 3)
         {
             // At least three offsets matched, so this is likely the correct CFO.
-            input_set_skip(st->input, best_offset * FFTCP_FM);
+            acquire_keep_extra(&st->input->acq, ((BLKSZ - best_offset) % BLKSZ) * FFTCP_FM);
             acquire_cfo_adjust(&st->input->acq, cfo);
 
             log_debug("Block @ %d", best_offset);
@@ -625,7 +625,7 @@ void sync_process_am(sync_t *st)
         offset = find_ref_am(st, CENTER_AM + REF_INDEX_AM);
         if (offset > 0)
         {
-            input_set_skip(st->input, offset * FFTCP_AM);
+            acquire_keep_extra(&st->input->acq, ((BLKSZ - offset) % BLKSZ) * FFTCP_AM);
             log_debug("Block @ %d", offset);
             st->cfo_wait = 8;
         }


### PR DESCRIPTION
nrsc5 needs to maintain synchronization both with individual OFDM symbols, and with blocks (groups of 32 OFDM symbols). Currently the "acquire" stage takes care of the former. It has a 33-symbol buffer, and wants the first 32 of those symbols to be occupied by a block, and it carries over the 33rd symbol to the next invocation of `acquire_process`. But if the OFDM symbol alignment is off, it adjusts that carryover amount by up to +/- one half of a symbol, so that symbol alignment is restored.

https://github.com/theori-io/nrsc5/blob/4005811e2f2d95c1b37ff9f29d426f57daa3ae76/src/acquire.c#L257-L259

Meanwhile, when the "sync" stage finds which of the 32 OFDM symbols is the start of a block, it invokes `input_set_skip` to ask the "input" stage to discard that number of OFDM symbols, so that the next batch sent to the "acquire" stage will be aligned to the beginning of a block.

Unfortunately, this system causes a bug: at the time the "input" stage skips over some OFDM symbols, the "acquire" stage still has carryover samples in its buffer, and the rest of its buffer is then filled with samples from a later time. The discontinuity causes bit errors and disturbs the synchronization process.

Since the "acquire" stage is already capable of carrying over an arbitrary number of samples, we can make it responsible for block alignment. The "input" stage asks it to carry over enough additional symbols such that the first symbol will move to the beginning of its buffer.

I tested this with my collection of recordings, and the number of decoded packets increased (except for a couple MA3 recordings where synchronization is luck-of-the-draw due to #387).