### PR TITLE
Handle Ctrl+C on Windows

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -513,7 +513,12 @@ static void *input_main(void *arg)
     if (!isatty(STDIN_FILENO))
         return NULL;
 
-#ifndef __MINGW32__
+#ifdef __MINGW32__
+    HANDLE hStdin = GetStdHandle(STD_INPUT_HANDLE);
+    DWORD mode = 0;
+    GetConsoleMode(hStdin, &mode);
+    SetConsoleMode(hStdin, mode & (~ENABLE_ECHO_INPUT) & (~ENABLE_LINE_INPUT));
+#else
     struct termios prev_termios, t;
 
     // disable terminal canonical mode
@@ -526,14 +531,9 @@ static void *input_main(void *arg)
 
     while (!st->done)
     {
-#ifdef __MINGW32__
-        int ch;
-        ch = _getch();
-#else
         char ch;
         if (read(STDIN_FILENO, &ch, 1) != 1)
             break;
-#endif
 
         switch (ch)
         {


### PR DESCRIPTION
Pressing Ctrl+C on Windows does nothing. This happens because the input thread uses `_getch()` to receive keyboard input, and this function receives Ctrl+C, preventing the (default) signal handler from being invoked.

Instead of using `_getch()` we can do as the non-Windows version does: disable console echo, and receive keystrokes by reading from stdin. After this change, Ctrl+C works as expected.

I had hoped this change might also resolve #314, but it seems that `pthread_cancel` does not interrupt the `read` function on Windows.