### PR TITLE
Implement elastic buffering for audio output

### DIFF
--- a/src/acquire.c
+++ b/src/acquire.c
@@ -105,6 +105,8 @@ void acquire_process(acquire_t *st)
     if (st->idx != (unsigned int)st->fftcp * (ACQUIRE_SYMBOLS + 1))
         return;
 
+    output_advance(st->input->output);
+
     if (st->input->sync_state == SYNC_STATE_FINE)
     {
         samperr = st->fftcp / 2 + st->input->sync.samperr;

--- a/src/decode.h
+++ b/src/decode.h
@@ -31,6 +31,7 @@ typedef struct
     uint8_t buffer_s[PARTITION_WIDTH_AM * BLKSZ * 8];
     uint8_t buffer_t[PARTITION_WIDTH_AM * BLKSZ * 8];
     unsigned int idx_pu_pl_s_t;
+    unsigned int am_errors;
     unsigned int am_diversity_wait;
 
     uint8_t bl[18000];
@@ -114,10 +115,12 @@ static inline void decode_push_pl_pu_s_t(decode_t *st, uint8_t sym_pl, uint8_t s
     st->buffer_s[st->idx_pu_pl_s_t] = sym_s;
     st->buffer_t[st->idx_pu_pl_s_t] = sym_t;
     st->idx_pu_pl_s_t++;
-    if (st->idx_pu_pl_s_t == PARTITION_WIDTH_AM * BLKSZ * 8)
+    if (st->idx_pu_pl_s_t % (PARTITION_WIDTH_AM * BLKSZ) == 0)
     {
         decode_process_p1_p3_am(st);
-        st->idx_pu_pl_s_t = 0;
+
+        if (st->idx_pu_pl_s_t == PARTITION_WIDTH_AM * BLKSZ * 8)
+            st->idx_pu_pl_s_t = 0;
     }
 }
 void decode_set_block(decode_t *st, unsigned int bc);

--- a/src/defines.h
+++ b/src/defines.h
@@ -65,7 +65,9 @@
 // number of programs (max)
 #define MAX_PROGRAMS 8
 // number of streams per program (max)
-#define MAX_STREAMS 4
+#define MAX_STREAMS 2
+// number of audio packets in the elastic buffer
+#define ELASTIC_BUFFER_LEN 64
 // number of subcarriers per AM partition
 #define PARTITION_WIDTH_AM 25
 

--- a/src/frame.c
+++ b/src/frame.c
@@ -288,6 +288,32 @@ static unsigned int calc_lc_bits(frame_header_t *hdr)
     }
 }
 
+static unsigned int calc_avg_packets(frame_header_t *hdr)
+{
+    switch(hdr->codec)
+    {
+        case 0:
+            return 32;
+        case 1:
+        case 2:
+        case 3:
+            if (hdr->stream_id == 0)
+                return 4;
+            else
+                return 32;
+        case 10:
+            if (hdr->stream_id == 0)
+                return 32;
+            else
+                return 4;
+        case 13:
+            return 4;
+        default:
+            log_warn("unknown codec field (%d)", hdr->codec);
+            return 32;
+    }
+}
+
 static unsigned int parse_location(uint8_t *buf, unsigned int lc_bits, unsigned int i)
 {
     if (lc_bits == 16)
@@ -337,7 +363,7 @@ static void aas_push(frame_t *st, uint8_t* psd, unsigned int length, logical_cha
     else
     {
         // remove protocol and fcs fields
-        input_aas_push(st->input, psd + 1, length - 3);
+        output_aas_push(st->input->output, psd + 1, length - 3);
     }
 }
 
@@ -503,7 +529,7 @@ void frame_process(frame_t *st, size_t length, logical_channel_t lc)
     while (offset < audio_end - RS_CODEWORD_LEN)
     {
         unsigned int start = offset;
-        unsigned int j, lc_bits, loc_bytes, prog;
+        unsigned int j, lc_bits, loc_bytes, prog, avg, seq, output_offset;
         unsigned short locations[MAX_AUDIO_PACKETS];
         frame_header_t hdr = {0};
         hef_t hef = {0};
@@ -532,9 +558,24 @@ void frame_process(frame_t *st, size_t length, logical_channel_t lc)
         }
         offset += loc_bytes;
 
+        if (hdr.stream_id >= MAX_STREAMS)
+        {
+            log_warn("invalid stream_id: %d", hdr.stream_id);
+            offset = start + locations[hdr.nop - 1] + 1;
+            continue;
+        }
+
         if (hdr.hef)
             offset += parse_hef(st->buffer + offset, audio_end - offset, &hef);
         prog = hef.prog_num;
+        avg = calc_avg_packets(&hdr);
+        seq = (ELASTIC_BUFFER_LEN + hdr.seq - hdr.pfirst) % ELASTIC_BUFFER_LEN;
+
+        output_offset = (ELASTIC_BUFFER_LEN + (hdr.pdu_seq * avg) - (hdr.latency * 2)) % ELASTIC_BUFFER_LEN;
+        if (((ELASTIC_BUFFER_LEN + seq - output_offset) % ELASTIC_BUFFER_LEN) >= (ELASTIC_BUFFER_LEN / 2))
+            output_offset = (output_offset + (ELASTIC_BUFFER_LEN / 2)) % ELASTIC_BUFFER_LEN;
+
+        output_align(st->input->output, prog, hdr.stream_id, output_offset);
 
         parse_hdlc(st, aas_push, st->psd_buf[prog], &st->psd_idx[prog], MAX_AAS_LEN, st->buffer + offset, start + hdr.la_location + 1 - offset, lc);
         offset = start + hdr.la_location + 1;
@@ -555,7 +596,7 @@ void frame_process(frame_t *st, size_t length, logical_channel_t lc)
                     if (crc == 0)
                     {
                         memcpy(&st->pdu[prog][hdr.stream_id][idx], st->buffer + offset, cnt);
-                        input_pdu_push(st->input, st->pdu[prog][hdr.stream_id], cnt + idx, prog, hdr.stream_id);
+                        output_push(st->input->output, st->pdu[prog][hdr.stream_id], cnt + idx, prog, hdr.stream_id, seq);
                     }
                     st->pdu_idx[prog][hdr.stream_id] = 0;
                 }
@@ -576,11 +617,12 @@ void frame_process(frame_t *st, size_t length, logical_channel_t lc)
             {
                 if (crc == 0)
                 {
-                    input_pdu_push(st->input, st->buffer + offset, cnt, prog, hdr.stream_id);
+                    output_push(st->input->output, st->buffer + offset, cnt, prog, hdr.stream_id, seq);
                 }
             }
 
             offset += cnt + 1;
+            seq = (seq + 1) % ELASTIC_BUFFER_LEN;
         }
     }
 

--- a/src/frame.h
+++ b/src/frame.h
@@ -30,7 +30,7 @@ typedef struct
 {
     struct input_t *input;
     uint8_t buffer[MAX_PDU_LEN];
-    uint8_t pdu[MAX_PROGRAMS][MAX_STREAMS][0x10000];
+    uint8_t pdu[MAX_PROGRAMS][MAX_STREAMS][MAX_PDU_LEN];
     unsigned int pdu_idx[MAX_PROGRAMS][MAX_STREAMS];
     unsigned int pci;
     unsigned int program;

--- a/src/input.c
+++ b/src/input.c
@@ -38,11 +38,6 @@ static float decim_taps[] = {
     -0.00410953676328063
 };
 
-void input_pdu_push(input_t *st, uint8_t *pdu, unsigned int len, unsigned int program, unsigned int stream_id)
-{
-    output_push(st->output, pdu, len, program, stream_id);
-}
-
 int input_shift(input_t *st, unsigned int cnt)
 {
     if (cnt + st->avail > INPUT_BUF_LEN)
@@ -202,9 +197,4 @@ void input_set_sync_state(input_t *st, unsigned int new_state)
     }
 
     st->sync_state = new_state;
-}
-
-void input_aas_push(input_t *st, uint8_t *psd, unsigned int len)
-{
-    output_aas_push(st->output, psd, len);
 }

--- a/src/input.h
+++ b/src/input.h
@@ -42,5 +42,3 @@ void input_free(input_t *st);
 void input_set_sync_state(input_t *st, unsigned int new_state);
 void input_push_cu8(input_t *st, const uint8_t *buf, uint32_t len);
 void input_push_cs16(input_t *st, const int16_t *buf, uint32_t len);
-void input_pdu_push(input_t *st, uint8_t *pdu, unsigned int len, unsigned int program, unsigned int stream_id);
-void input_aas_push(input_t *st, uint8_t *psd, unsigned int len);

--- a/src/main.c
+++ b/src/main.c
@@ -42,7 +42,7 @@
 #include "log.h"
 
 #define AUDIO_BUFFERS 128
-#define AUDIO_THRESHOLD 40
+#define AUDIO_THRESHOLD 8
 #define AUDIO_DATA_LENGTH 8192
 
 typedef struct buffer_t {

--- a/src/output.h
+++ b/src/output.h
@@ -87,16 +87,31 @@ typedef struct
 
 typedef struct
 {
+    unsigned int size;
+    uint8_t data[MAX_PDU_LEN];
+} packet_t;
+
+typedef struct
+{
+    packet_t packets[ELASTIC_BUFFER_LEN];
+    int audio_offset;
+} elastic_buffer_t;
+
+typedef struct
+{
     nrsc5_t *radio;
+    elastic_buffer_t elastic[MAX_PROGRAMS][MAX_STREAMS];
 #ifdef HAVE_FAAD2
     NeAACDecHandle aacdec[MAX_PROGRAMS];
+    int16_t silence[NRSC5_AUDIO_FRAME_SAMPLES * 2];
 #endif
     aas_port_t ports[MAX_PORTS];
     sig_service_t services[MAX_SIG_SERVICES];
 } output_t;
 
-void output_push(output_t *st, uint8_t *pkt, unsigned int len, unsigned int program, unsigned int stream_id);
-void output_begin(output_t *st);
+void output_align(output_t *st, unsigned int program, unsigned int stream_id, unsigned int offset);
+void output_push(output_t *st, uint8_t *pkt, unsigned int len, unsigned int program, unsigned int stream_id, unsigned int seq);
+void output_advance(output_t *st);
 void output_reset(output_t *st);
 void output_init(output_t *st, nrsc5_t *);
 void output_free(output_t *st);

--- a/support/cli.py
+++ b/support/cli.py
@@ -19,7 +19,7 @@ class NRSC5CLI:
         self.radio = nrsc5.NRSC5(lambda evt_type, evt: self.callback(evt_type, evt))
         self.nrsc5_version = self.radio.get_version()
         self.parse_args()
-        self.audio_queue = queue.Queue(maxsize=64)
+        self.audio_queue = queue.Queue(maxsize=16)
         self.device_condition = threading.Condition()
         self.interrupted = False
         self.iq_output = None


### PR DESCRIPTION
Replaces #343.
Fixes #177.
Fixes #261.
Fixes #330.

The NRSC-5 standard uses a variable-rate audio codec. To account for variations in the instantaneous bit rate, the standard specifies that both the transmitter and receiver use an elastic buffer, so that audio packets enter the transmitter and leave the receiver at a fixed rate, even though the number of packets sent in individual audio PDUs may vary. Unfortunately, the standard does not explain how elastic buffering is implemented, so we are left to guess many of the details.

Up until now, nrsc5 did not implement elastic buffering at all, and instead reported audio packets through its API immediately upon decoding. In this PR I have added elastic buffers (one per stream) which queue audio packets. A batch of audio packets (2 for FM, 4 for AM) is released each time an L1 block is decoded. (In a future PR, we could perhaps even shorten the cadence so that audio packets are released one at a time.)

API clients shouldn't need to make any changes to take advantage of elastic buffering. They will notice that audio packets are now produced in much smaller bursts (2 for FM, 4 for AM) and that the burst size is always identical. As a result, API clients should not need to buffer more than a handful of audio packets.

This PR is a simplified version of #343. That PR attempted to maintain an exact ratio of input RF samples to output audio samples, and I have dispensed with that requirement for now to simplify the implementation. We may need to return to that approach in the future to implement analog blending (#80).