### PR TITLE
Report information from audio PDU headers

### DIFF
--- a/src/frame.h
+++ b/src/frame.h
@@ -8,6 +8,17 @@
 
 typedef struct
 {
+    int access;
+    int type;
+    int codec_mode;
+    int blend_control;
+    int digital_audio_gain;
+    int common_delay;
+    int latency;
+} audio_service_t;
+
+typedef struct
+{
     uint16_t mode;
     uint16_t length;
     unsigned int block_idx;
@@ -30,6 +41,7 @@ typedef struct
 {
     struct input_t *input;
     uint8_t buffer[MAX_PDU_LEN];
+    audio_service_t services[MAX_PROGRAMS];
     uint8_t pdu[MAX_PROGRAMS][MAX_STREAMS][MAX_PDU_LEN];
     unsigned int pdu_idx[MAX_PROGRAMS][MAX_STREAMS];
     unsigned int pci;

--- a/src/main.c
+++ b/src/main.c
@@ -453,6 +453,21 @@ static void callback(const nrsc5_event_t *evt, void *opaque)
                      name, data_service->mime_type);
         }
         break;
+    case NRSC5_EVENT_AUDIO_SERVICE:
+        {
+            const char *name = NULL;
+            nrsc5_program_type_name(evt->audio_service.type, &name);
+            log_info("Audio service %d: %s, type: %s, codec: %d, blend: %d, gain: %d dB, delay: %d, latency: %d",
+                    evt->audio_service.program,
+                    evt->audio_service.access == NRSC5_ACCESS_PUBLIC ? "public" : "restricted",
+                    name,
+                    evt->audio_service.codec_mode,
+                    evt->audio_service.blend_control,
+                    evt->audio_service.digital_audio_gain,
+                    evt->audio_service.common_delay,
+                    evt->audio_service.latency);
+        }
+        break;
     }
 }
 

--- a/src/nrsc5.c
+++ b/src/nrsc5.c
@@ -795,6 +795,24 @@ static uint8_t convert_sig_service_type(uint8_t type)
     }
 }
 
+void nrsc5_report_audio_service(nrsc5_t *st, unsigned int program, unsigned int access, unsigned int type, 
+                                unsigned int codec_mode, unsigned int blend_control, int digital_audio_gain,
+                                unsigned int common_delay, unsigned int latency)
+{
+    nrsc5_event_t evt;
+
+    evt.event = NRSC5_EVENT_AUDIO_SERVICE;
+    evt.audio_service.access = access;
+    evt.audio_service.program = program;
+    evt.audio_service.type = type;
+    evt.audio_service.codec_mode = codec_mode;
+    evt.audio_service.blend_control = blend_control;
+    evt.audio_service.digital_audio_gain = digital_audio_gain;
+    evt.audio_service.common_delay = common_delay;
+    evt.audio_service.latency = latency;
+    nrsc5_report(st, &evt);
+}
+
 void nrsc5_report_sig(nrsc5_t *st, sig_service_t *services, unsigned int count)
 {
     nrsc5_sig_service_t *service = NULL;

--- a/src/private.h
+++ b/src/private.h
@@ -55,6 +55,9 @@ void nrsc5_report_audio(nrsc5_t *, unsigned int program, const int16_t *data, si
 void nrsc5_report_stream(nrsc5_t *, uint16_t port, uint16_t seq, unsigned int size, uint32_t mime, const uint8_t *data);
 void nrsc5_report_packet(nrsc5_t *, uint16_t port, uint16_t seq, unsigned int size, uint32_t mime, const uint8_t *data);
 void nrsc5_report_lot(nrsc5_t *, uint16_t port, unsigned int lot, unsigned int size, uint32_t mime, const char *name, const uint8_t *data, struct tm *expiry_utc);
+void nrsc5_report_audio_service(nrsc5_t *, unsigned int program, unsigned int access, unsigned int type, 
+                                unsigned int codec_mode, unsigned int blend_control, int digital_audio_gain,
+                                unsigned int common_delay, unsigned int latency);
 void nrsc5_report_sig(nrsc5_t *, sig_service_t *services, unsigned int count);
 void nrsc5_report_sis(nrsc5_t *, const char *country_code, int fcc_facility_id, const char *name,
                       const char *slogan, const char *message, const char *alert, const uint8_t *cnt, int cnt_length,

--- a/support/cli.py
+++ b/support/cli.py
@@ -308,6 +308,16 @@ class NRSC5CLI:
                              data_service.access.name,
                              self.radio.service_data_type_name(data_service.type),
                              data_service.mime_type)
+        elif evt_type == nrsc5.EventType.AUDIO_SERVICE:
+            logging.info("Audio service %s: %s, type: %s, codec: %d, blend: %s, gain: %d dB, delay: %d, latency: %d",
+                         evt.program,
+                         evt.access.name,
+                         self.radio.program_type_name(evt.type),
+                         evt.codec_mode,
+                         evt.blend_control.name,
+                         evt.digital_audio_gain,
+                         evt.common_delay,
+                         evt.latency)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes #374.
Fixes #398.

Neither SIS audio descriptors nor SIG are mandatory, leaving applications with no reliable way to know of the existence of an audio program. Audio PDU headers are always present, and convey useful information about audio programs, so I think it makes sense to expose this information through the API.

Here I've added a new event (`NRSC5_EVENT_AUDIO_SERVICE`) which exposes ~a linked list of~ audio services. The following information is available:

* program number
* access (public / restricted)
* program type
* codec mode
* blend control
* digital audio gain
* digital audio delay
* codec latency

The C & Python API clients display this information on "Audio service" lines:

```
16:16:36 Audio service 0: PUBLIC, type: Adult Hits, codec: 0, blend: ENABLE, gain: 0 dB, delay: 96, latency: 8
16:16:36 Audio service 1: PUBLIC, type: Talk, codec: 0, blend: DISABLE, gain: 0 dB, delay: 0, latency: 8
16:16:36 Audio service 2: PUBLIC, type: Sports, codec: 13, blend: DISABLE, gain: 0 dB, delay: 0, latency: 8
```

It is unfortunate that audio program information is provided by three separate sources (SIS, PDU headers, SIG), but I think it's best for the API to expose the information in its raw form and let applications decide how best to process it.

SIS audio descriptors are decoded very quickly because they are part of the low-latency PIDS channel. But not all stations broadcast them. PDU headers take longer to appear, but always arrive before audio is decoded. SIG typically arrives last, since the data is contained in a file which takes time to download. But stations that have only a single audio program and no data services may not broadcast SIG.