### PR TITLE
Add data component MIME type to LOT event

### DIFF
--- a/include/nrsc5.h
+++ b/include/nrsc5.h
@@ -393,24 +393,25 @@ struct nrsc5_event_t
             uint16_t port;
             uint16_t seq;
             unsigned int size;
-            uint32_t mime;
+            uint32_t mime;       /**< MIME type of the data component this stream belongs to, e.g. NRSC5_MIME_HERE_IMAGE */
             const uint8_t *data;
         } stream;
         struct {
             uint16_t port;
             uint16_t seq;
             unsigned int size;
-            uint32_t mime;
+            uint32_t mime;       /**< MIME type of the data component this packet belongs to, e.g. NRSC5_MIME_NAVTEQ */
             const uint8_t *data;
         } packet;
         struct {
             uint16_t port;
             unsigned int lot;
             unsigned int size;
-            uint32_t mime;
+            uint32_t mime;           /**< MIME type of this file, e.g. NRSC5_MIME_PNG */
             const char *name;
             const uint8_t *data;
             struct tm *expiry_utc;
+            uint32_t component_mime; /**< MIME type of the data component this file belongs to, e.g. NRSC5_MIME_TTN_STM_WEATHER */
         } lot;
         struct {
             unsigned int program;       /**< program number 0, 1, ..., 7 */

--- a/src/main.c
+++ b/src/main.c
@@ -379,7 +379,8 @@ static void callback(const nrsc5_event_t *evt, void *opaque)
             dump_aas_file(st, evt);
         char time_str[64];
         strftime(time_str, sizeof(time_str), "%Y-%m-%dT%H:%M:%SZ", evt->lot.expiry_utc);
-        log_info("LOT file: port=%04X lot=%d name=%s size=%d mime=%08X expiry=%s", evt->lot.port, evt->lot.lot, evt->lot.name, evt->lot.size, evt->lot.mime, time_str);
+        log_info("LOT file: port=%04X lot=%d name=%s size=%d mime=%08X component_mime=%08X expiry=%s",
+                 evt->lot.port, evt->lot.lot, evt->lot.name, evt->lot.size, evt->lot.mime, evt->lot.component_mime, time_str);
         break;
     case NRSC5_EVENT_SIS:
         if (evt->sis.country_code)

--- a/src/nrsc5.c
+++ b/src/nrsc5.c
@@ -756,7 +756,8 @@ void nrsc5_report_packet(nrsc5_t *st, uint16_t port, uint16_t seq, unsigned int 
     nrsc5_report(st, &evt);
 }
 
-void nrsc5_report_lot(nrsc5_t *st, uint16_t port, unsigned int lot, unsigned int size, uint32_t mime, const char *name, const uint8_t *data, struct tm *expiry_utc)
+void nrsc5_report_lot(nrsc5_t *st, uint16_t port, unsigned int lot, unsigned int size, uint32_t mime, const char *name,
+                      const uint8_t *data, struct tm *expiry_utc, uint32_t component_mime)
 {
     nrsc5_event_t evt;
 
@@ -768,6 +769,7 @@ void nrsc5_report_lot(nrsc5_t *st, uint16_t port, unsigned int lot, unsigned int
     evt.lot.name = name;
     evt.lot.data = data;
     evt.lot.expiry_utc = expiry_utc;
+    evt.lot.component_mime = component_mime;
     nrsc5_report(st, &evt);
 }
 

--- a/src/output.c
+++ b/src/output.c
@@ -727,7 +727,7 @@ static void process_port(output_t *st, uint16_t port_id, uint16_t seq, uint8_t *
                 uint8_t *data = malloc(num_fragments * LOT_FRAGMENT_SIZE);
                 for (int i = 0; i < num_fragments; i++)
                     memcpy(data + i * LOT_FRAGMENT_SIZE, file->fragments[i], LOT_FRAGMENT_SIZE);
-                nrsc5_report_lot(st->radio, port->port, file->lot, file->size, file->mime, file->name, data, &file->expiry_utc);
+                nrsc5_report_lot(st->radio, port->port, file->lot, file->size, file->mime, file->name, data, &file->expiry_utc, port->mime);
                 free(data);
                 aas_free_lot(file);
             }

--- a/src/private.h
+++ b/src/private.h
@@ -54,7 +54,8 @@ void nrsc5_report_hdc(nrsc5_t *, unsigned int program, const uint8_t *data, size
 void nrsc5_report_audio(nrsc5_t *, unsigned int program, const int16_t *data, size_t count);
 void nrsc5_report_stream(nrsc5_t *, uint16_t port, uint16_t seq, unsigned int size, uint32_t mime, const uint8_t *data);
 void nrsc5_report_packet(nrsc5_t *, uint16_t port, uint16_t seq, unsigned int size, uint32_t mime, const uint8_t *data);
-void nrsc5_report_lot(nrsc5_t *, uint16_t port, unsigned int lot, unsigned int size, uint32_t mime, const char *name, const uint8_t *data, struct tm *expiry_utc);
+void nrsc5_report_lot(nrsc5_t *, uint16_t port, unsigned int lot, unsigned int size, uint32_t mime, const char *name,
+                      const uint8_t *data, struct tm *expiry_utc, uint32_t component_mime);
 void nrsc5_report_audio_service(nrsc5_t *, unsigned int program, unsigned int access, unsigned int type, 
                                 unsigned int codec_mode, unsigned int blend_control, int digital_audio_gain,
                                 unsigned int common_delay, unsigned int latency);

--- a/support/cli.py
+++ b/support/cli.py
@@ -275,8 +275,8 @@ class NRSC5CLI:
                          evt.port, evt.seq, evt.mime.name, len(evt.data))
         elif evt_type == nrsc5.EventType.LOT:
             time_str = evt.expiry_utc.strftime("%Y-%m-%dT%H:%M:%SZ")
-            logging.info("LOT file: port=%04X lot=%s name=%s size=%s mime=%s expiry=%s",
-                         evt.port, evt.lot, evt.name, len(evt.data), evt.mime.name, time_str)
+            logging.info("LOT file: port=%04X lot=%s name=%s size=%s mime=%s component_mime=%s expiry=%s",
+                         evt.port, evt.lot, evt.name, len(evt.data), evt.mime.name, evt.component_mime.name, time_str)
             if self.args.dump_aas_files:
                 path = os.path.join(self.args.dump_aas_files, evt.name)
                 with open(path, "wb") as file:

--- a/support/nrsc5.py
+++ b/support/nrsc5.py
@@ -175,7 +175,7 @@ SIGService = collections.namedtuple("SIGService", ["type", "number", "name", "co
 SIG = collections.namedtuple("SIG", ["services"])
 STREAM = collections.namedtuple("STREAM", ["port", "seq", "mime", "data"])
 PACKET = collections.namedtuple("PACKET", ["port", "seq", "mime", "data"])
-LOT = collections.namedtuple("LOT", ["port", "lot", "mime", "name", "data", "expiry_utc"])
+LOT = collections.namedtuple("LOT", ["port", "lot", "mime", "name", "data", "expiry_utc", "component_mime"])
 SISAudioService = collections.namedtuple("SISAudioService", ["program", "access", "type", "sound_exp"])
 SISDataService = collections.namedtuple("SISDataService", ["access", "type", "mime_type"])
 SIS = collections.namedtuple("SIS", ["country_code", "fcc_facility_id", "name", "slogan", "message", "alert",
@@ -357,6 +357,7 @@ class _LOT(ctypes.Structure):
         ("name", ctypes.c_char_p),
         ("data", ctypes.POINTER(ctypes.c_char)),
         ("expiry_utc", ctypes.POINTER(_TimeStruct)),
+        ("component_mime", ctypes.c_uint32),
     ]
 
 
@@ -557,7 +558,7 @@ class NRSC5:
                 expiry_struct.tm_sec,
                 tzinfo=datetime.timezone.utc
             )
-            evt = LOT(lot.port, lot.lot, MIMEType(lot.mime), self._decode(lot.name), lot.data[:lot.size], expiry_time)
+            evt = LOT(lot.port, lot.lot, MIMEType(lot.mime), self._decode(lot.name), lot.data[:lot.size], expiry_time, MIMEType(lot.component_mime))
         elif evt_type == EventType.SIS:
             sis = c_evt.u.sis
 


### PR DESCRIPTION
As a convenience, `NRSC5_EVENT_STREAM` and `NRSC5_EVENT_PACKET` events include the MIME type of the data component to which they belong. This makes it easier for applications to filter the data, without having to cross-reference the SIG table.

While investigating #295, I noticed that `NRSC5_EVENT_LOT` events lack this information. Here I've added a `component_mime` field to the event, which should make it easier for applications to filter LOT files.

The C and Python CLI applications now print this field:

```
[...]
19:35:48 SIG Service: type=data number=22 name=TTN STM
19:35:48   Data component: id=0 port=0810 service_data_type=66 type=3 mime=FF8422D7
19:35:48   Data component: id=2 port=0820 service_data_type=66 type=3 mime=EF042E96
[...]
19:35:48 LOT file: port=0820 lot=1633 name=DWRI_035iuu_rev04_0661.txt size=439 mime=BB492AAC component_mime=EF042E96 expiry=2024-06-12T15:42:00Z
[...]
19:35:49 LOT file: port=0820 lot=1624 name=DWRO_035iuu_rev04_20240612_1507_0658.png size=1526 mime=4F328CA0 component_mime=EF042E96 expiry=2024-06-12T15:42:00Z
[...]
```

```
[...]
9:37:56 SIG Service: type=DATA number=22 name=TTN STM
19:37:56   Data component: id=0 port=0810 service_data_type=IMAGE_MAPS type=3 mime=TTN_STM_TRAFFIC
19:37:56   Data component: id=2 port=0820 service_data_type=IMAGE_MAPS type=3 mime=TTN_STM_WEATHER
[...]
19:37:57 LOT file: port=0820 lot=1633 name=DWRI_035iuu_rev04_0661.txt size=439 mime=TEXT component_mime=TTN_STM_WEATHER expiry=2024-06-12T15:42:00Z
[...]
19:37:57 LOT file: port=0820 lot=1624 name=DWRO_035iuu_rev04_20240612_1507_0658.png size=1526 mime=PNG component_mime=TTN_STM_WEATHER expiry=2024-06-12T15:42:00Z
[...]
```