### PR TITLE
Clear emergency alert when the station stops sending it

### DIFF
--- a/src/pids.h
+++ b/src/pids.h
@@ -92,6 +92,7 @@ typedef struct
     int alert_crc;
     int alert_cnt_len;
     int alert_displayed;
+    int alert_timeout;
 } pids_t;
 
 void pids_frame_push(pids_t *st, uint8_t *bits);


### PR DESCRIPTION
Fixes #404.

I tested this by transmitting alerts with gr-nrsc5:

```
$ nc localhost 52000
set_alert|00679c247c5b0438c70000|Example alert
clear_alert
set_alert|00679c247c5b0438c70000|Example alert
clear_alert
set_alert|00679c247c5b0438c70000|Example alert
set_alert|00679c247c5b0438c70000|Example alert two
set_alert|00679c247c5b0438c70000|Example alert three
clear_alert
```

As expected, `clear_alert` triggers a new `NRSC5_EVENT_SIS` without the alert.

I tested against my library of recordings, and `alert_timeout` never exceeded one. This makes sense, because the SIS schedules recommended in SY_IDD_1020s section 5.2 never leave a gap of more than one block between consecutive emergency alert messages. The `ALERT_TIMEOUT_LIMIT` value of 16 seems reasonable, since the SIS schedule length is <= 16 for both FM and AM.