### PR TITLE
Split up the SIS event

### DIFF
--- a/include/nrsc5.h
+++ b/include/nrsc5.h
@@ -164,7 +164,15 @@ enum
     NRSC5_EVENT_SIS,
     NRSC5_EVENT_STREAM,
     NRSC5_EVENT_PACKET,
-    NRSC5_EVENT_AUDIO_SERVICE
+    NRSC5_EVENT_AUDIO_SERVICE,
+    NRSC5_EVENT_STATION_ID,
+    NRSC5_EVENT_STATION_NAME,
+    NRSC5_EVENT_STATION_SLOGAN,
+    NRSC5_EVENT_STATION_MESSAGE,
+    NRSC5_EVENT_STATION_LOCATION,
+    NRSC5_EVENT_AUDIO_SERVICE_DESCRIPTOR,
+    NRSC5_EVENT_DATA_SERVICE_DESCRIPTOR,
+    NRSC5_EVENT_EMERGENCY_ALERT
 };
 
 enum
@@ -255,7 +263,7 @@ struct nrsc5_sis_asd_t
     struct nrsc5_sis_asd_t *next; /**< Pointer to next element or NULL */
     unsigned int program;     /**< program number 0, 1, ..., 7 */
     unsigned int access;      /**< NRSC5_ACCESS_PUBLIC or NRSC5_ACCESS_RESTRICTED */
-    unsigned int type;        /**< audio service, e.g. NRSC5_PROGRAM_TYPE_JAZZ */
+    unsigned int type;        /**< program type, e.g. NRSC5_PROGRAM_TYPE_JAZZ */
     unsigned int sound_exp;   /**< 0 is none, 2 is Dolby Pro Logic II Surround */
 };
 /**
@@ -297,7 +305,7 @@ struct nrsc5_sis_dsd_t
 {
     struct nrsc5_sis_dsd_t *next; /**< Pointer to next element or NULL */
     unsigned int access;  /**< NRSC5_ACCESS_PUBLIC or NRSC5_ACCESS_RESTRICTED */
-    unsigned int type; /**< data service type, e.g. NRSC5_SERVICE_DATA_TYPE_TEXT */
+    unsigned int type;    /**< data service type, e.g. NRSC5_SERVICE_DATA_TYPE_TEXT */
     uint32_t mime_type;   /**< MIME type, e.g. `NRSC5_MIME_TEXT` */
 };
 /**
@@ -331,22 +339,29 @@ struct nrsc5_event_t
 {
 /*! Type of event.
  * The member `event` determines which sort of event occurred:
- * - `NRSC5_EVENT_LOST_DEVICE` : signal is over
- * - `NRSC5_EVENT_BER` : Bit Error Ratio data, see the `ber` union member
- * - `NRSC5_EVENT_MER` : modulation error ratio, see the `mer` union member,
- *    and NRSC5 document SY_TN_2646s
+ * - `NRSC5_EVENT_LOST_DEVICE` : RTL-SDR device was disconnected
  * - `NRSC5_EVENT_IQ` : IQ data, see the `iq` union member
- * - `NRSC5_EVENT_HDC` : HDC audio packet, see the `hdc` union member
- * - `NRSC5_EVENT_AUDIO` : audio buffer, see the `audio` union member
  * - `NRSC5_EVENT_SYNC` : indicates synchronization achieved
  * - `NRSC5_EVENT_LOST_SYNC` : indicates synchronization lost
- * - `NRSC5_EVENT_ID3` : ID3 information packet arrived, see `id3` member
- *    and information in HD-Radio document SY_IDD_1028s.
+ * - `NRSC5_EVENT_MER` : modulation error ratio, see the `mer` union member, and NRSC5 document SY_TN_2646s
+ * - `NRSC5_EVENT_BER` : Bit Error Ratio data, see the `ber` union member
+ * - `NRSC5_EVENT_HDC` : HDC audio packet, see the `hdc` union member
+ * - `NRSC5_EVENT_AUDIO` : audio buffer, see the `audio` union member
+ * - `NRSC5_EVENT_ID3` : ID3 information packet arrived, see `id3` member and information in HD-Radio document SY_IDD_1028s.
  * - `NRSC5_EVENT_SIG` : service information arrived, see `sig` member
+ * - `NRSC5_EVENT_LOT` : LOT file data available, see `lot` member
+ * - `NRSC5_EVENT_SIS` : DEPRECATED. Use `NRSC5_EVENT_STATION_ID`, `NRSC5_EVENT_STATION_NAME`, `NRSC5_EVENT_STATION_SLOGAN`, `NRSC5_EVENT_STATION_MESSAGE`, `NRSC5_EVENT_STATION_LOCATION`, `NRSC5_EVENT_AUDIO_SERVICE_DESCRIPTOR`, `NRSC5_EVENT_DATA_SERVICE_DESCRIPTOR`, and `NRSC5_EVENT_EMERGENCY_ALERT` instead.
  * - `NRSC5_EVENT_STREAM` : stream data available, see `stream` member
  * - `NRSC5_EVENT_PACKET` : packet data available, see `packet` member
- * - `NRSC5_EVENT_LOT` : LOT file data available, see `lot` member
- * - `NRSC5_EVENT_SIS` : station information, see `sis` member
+ * - `NRSC5_EVENT_AUDIO_SERVICE` : audio service available, see `audio_service` member
+ * - `NRSC5_EVENT_STATION_ID` : station ID number, see `station_id` member
+ * - `NRSC5_EVENT_STATION_NAME` : station name, see `station_name` member
+ * - `NRSC5_EVENT_STATION_SLOGAN` : station slogan, see `station_slogan` member
+ * - `NRSC5_EVENT_STATION_MESSAGE` : station message, see `station_message` member
+ * - `NRSC5_EVENT_STATION_LOCATION` : station location, see `station_location` member
+ * - `NRSC5_EVENT_AUDIO_SERVICE_DESCRIPTOR` : SIS audio service descriptor, see `asd` member
+ * - `NRSC5_EVENT_DATA_SERVICE_DESCRIPTOR` : SIS data service descriptor, see `dsd` member
+ * - `NRSC5_EVENT_EMERGENCY_ALERT` : emergency alert, see `emergency_alert` member
  */
     unsigned int event;
     union
@@ -445,6 +460,45 @@ struct nrsc5_event_t
             int alert_num_locations;
             const int *alert_locations;
         } sis;
+        struct {
+            const char *country_code;
+            int fcc_facility_id;
+        } station_id;
+        struct {
+            const char *name;
+        } station_name;
+        struct {
+            const char *slogan;
+        } station_slogan;
+        struct {
+            const char *message;
+        } station_message;
+        struct {
+            float latitude;
+            float longitude;
+            int altitude;
+        } station_location;
+        struct {
+            unsigned int program;     /**< program number 0, 1, ..., 7 */
+            unsigned int access;      /**< NRSC5_ACCESS_PUBLIC or NRSC5_ACCESS_RESTRICTED */
+            unsigned int type;        /**< program type, e.g. NRSC5_PROGRAM_TYPE_JAZZ */
+            unsigned int sound_exp;   /**< 0 is none, 2 is Dolby Pro Logic II Surround */        
+        } asd;
+        struct {
+            unsigned int access;  /**< NRSC5_ACCESS_PUBLIC or NRSC5_ACCESS_RESTRICTED */
+            unsigned int type;    /**< data service type, e.g. NRSC5_SERVICE_DATA_TYPE_TEXT */
+            uint32_t mime_type;   /**< MIME type, e.g. `NRSC5_MIME_TEXT` */        
+        } dsd;
+        struct {
+            const char *message;
+            const uint8_t *control_data;
+            int control_data_length;
+            int category1;
+            int category2;
+            int location_format;
+            int num_locations;
+            const int *locations;
+        } emergency_alert;
     };
 };
 /**

--- a/src/nrsc5.c
+++ b/src/nrsc5.c
@@ -920,3 +920,100 @@ void nrsc5_report_sis(nrsc5_t *st, const char *country_code, int fcc_facility_id
 
     nrsc5_report(st, &evt);
 }
+
+void nrsc5_report_station_id(nrsc5_t *st, const char *country_code, int fcc_facility_id)
+{
+    nrsc5_event_t evt;
+
+    evt.event = NRSC5_EVENT_STATION_ID;
+    evt.station_id.country_code = country_code;
+    evt.station_id.fcc_facility_id = fcc_facility_id;
+
+    nrsc5_report(st, &evt);
+}
+
+void nrsc5_report_station_name(nrsc5_t *st, const char *name)
+{
+    nrsc5_event_t evt;
+
+    evt.event = NRSC5_EVENT_STATION_NAME;
+    evt.station_name.name = name;
+
+    nrsc5_report(st, &evt);
+}
+
+void nrsc5_report_station_slogan(nrsc5_t *st, const char *slogan)
+{
+    nrsc5_event_t evt;
+
+    evt.event = NRSC5_EVENT_STATION_SLOGAN;
+    evt.station_slogan.slogan = slogan;
+
+    nrsc5_report(st, &evt);
+}
+
+void nrsc5_report_station_message(nrsc5_t *st, const char *message)
+{
+    nrsc5_event_t evt;
+
+    evt.event = NRSC5_EVENT_STATION_MESSAGE;
+    evt.station_message.message = message;
+
+    nrsc5_report(st, &evt);
+}
+
+void nrsc5_report_station_location(nrsc5_t *st, float latitude, float longitude, int altitude)
+{
+    nrsc5_event_t evt;
+
+    evt.event = NRSC5_EVENT_STATION_LOCATION;
+    evt.station_location.latitude = latitude;
+    evt.station_location.longitude = longitude;
+    evt.station_location.altitude = altitude;
+
+    nrsc5_report(st, &evt);
+}
+
+void nrsc5_report_asd(nrsc5_t *st, unsigned int program, unsigned int access, unsigned int type, unsigned int sound_exp)
+{
+    nrsc5_event_t evt;
+
+    evt.event = NRSC5_EVENT_AUDIO_SERVICE_DESCRIPTOR;
+    evt.asd.program = program;
+    evt.asd.access = access;
+    evt.asd.type = type;
+    evt.asd.sound_exp = sound_exp;
+
+    nrsc5_report(st, &evt);
+}
+
+void nrsc5_report_dsd(nrsc5_t *st, unsigned int access, unsigned int type, uint32_t mime_type)
+{
+    nrsc5_event_t evt;
+
+    evt.event = NRSC5_EVENT_DATA_SERVICE_DESCRIPTOR;
+    evt.dsd.access = access;
+    evt.dsd.type = type;
+    evt.dsd.mime_type = mime_type;
+
+    nrsc5_report(st, &evt);
+}
+
+void nrsc5_report_emergency_alert(nrsc5_t *st, const char *message, const uint8_t *control_data,
+                                  int control_data_length, int category1, int category2, int location_format,
+                                  int num_locations, const int *locations)
+{
+    nrsc5_event_t evt;
+
+    evt.event = NRSC5_EVENT_EMERGENCY_ALERT;
+    evt.emergency_alert.message = message;
+    evt.emergency_alert.control_data = control_data;
+    evt.emergency_alert.control_data_length = control_data_length;
+    evt.emergency_alert.category1 = category1;
+    evt.emergency_alert.category2 = category2;
+    evt.emergency_alert.location_format = location_format;
+    evt.emergency_alert.num_locations = num_locations;
+    evt.emergency_alert.locations = locations;
+
+    nrsc5_report(st, &evt);
+}

--- a/src/private.h
+++ b/src/private.h
@@ -64,3 +64,13 @@ void nrsc5_report_sis(nrsc5_t *, const char *country_code, int fcc_facility_id, 
                       int category1, int category2, int location_format, int num_locations, const int *locations,
                       float latitude, float longitude, int altitude, nrsc5_sis_asd_t *audio_services,
                       nrsc5_sis_dsd_t *data_services);
+void nrsc5_report_station_id(nrsc5_t *st, const char *country_code, int fcc_facility_id);
+void nrsc5_report_station_name(nrsc5_t *st, const char *name);
+void nrsc5_report_station_slogan(nrsc5_t *st, const char *slogan);
+void nrsc5_report_station_message(nrsc5_t *st, const char *message);
+void nrsc5_report_station_location(nrsc5_t *st, float latitude, float longitude, int altitude);
+void nrsc5_report_asd(nrsc5_t *st, unsigned int program, unsigned int access, unsigned int type, unsigned int sound_exp);
+void nrsc5_report_dsd(nrsc5_t *st, unsigned int access, unsigned int type, uint32_t mime_type);
+void nrsc5_report_emergency_alert(nrsc5_t *st, const char *message, const uint8_t *control_data,
+                                  int control_data_length, int category1, int category2,
+                                  int location_format, int num_locations, const int *locations);

--- a/support/cli.py
+++ b/support/cli.py
@@ -281,33 +281,33 @@ class NRSC5CLI:
                 path = os.path.join(self.args.dump_aas_files, evt.name)
                 with open(path, "wb") as file:
                     file.write(evt.data)
-        elif evt_type == nrsc5.EventType.SIS:
-            if evt.country_code:
-                logging.info("Country: %s, FCC facility ID: %s",
-                             evt.country_code, evt.fcc_facility_id)
-            if evt.name:
-                logging.info("Station name: %s", evt.name)
-            if evt.slogan:
-                logging.info("Slogan: %s", evt.slogan)
-            if evt.message:
-                logging.info("Message: %s", evt.message)
-            if evt.alert:
-                categories = ", ".join(self.radio.alert_category_name(category) for category in evt.alert_categories)
-                logging.info("Alert: Category=[%s] %s=%s %s", categories, evt.alert_location_format.name, str(evt.alert_locations), evt.alert)
-            if evt.latitude:
-                logging.info("Station location: %.4f, %.4f, %dm",
-                             evt.latitude, evt.longitude, evt.altitude)
-            for audio_service in evt.audio_services:
-                logging.info("Audio program %s: %s, type: %s, sound experience %s",
-                             audio_service.program,
-                             audio_service.access.name,
-                             self.radio.program_type_name(audio_service.type),
-                             audio_service.sound_exp)
-            for data_service in evt.data_services:
-                logging.info("Data service: %s, type: %s, MIME type %03x",
-                             data_service.access.name,
-                             self.radio.service_data_type_name(data_service.type),
-                             data_service.mime_type)
+        elif evt_type == nrsc5.EventType.STATION_ID:
+            logging.info("Country: %s, FCC facility ID: %s", evt.country_code, evt.fcc_facility_id)
+        elif evt_type == nrsc5.EventType.STATION_NAME:
+            logging.info("Station name: %s", evt.name)
+        elif evt_type == nrsc5.EventType.STATION_SLOGAN:
+            logging.info("Slogan: %s", evt.slogan)
+        elif evt_type == nrsc5.EventType.STATION_MESSAGE:
+            logging.info("Message: %s", evt.message)
+        elif evt_type == nrsc5.EventType.STATION_LOCATION:
+            logging.info("Station location: %.4f, %.4f, %dm", evt.latitude, evt.longitude, evt.altitude)
+        elif evt_type == nrsc5.EventType.AUDIO_SERVICE_DESCRIPTOR:
+            logging.info("Audio program %s: %s, type: %s, sound experience %s",
+                         evt.program,
+                         evt.access.name,
+                         self.radio.program_type_name(evt.type),
+                         evt.sound_exp)
+        elif evt_type == nrsc5.EventType.DATA_SERVICE_DESCRIPTOR:
+            logging.info("Data service: %s, type: %s, MIME type %03x",
+                         evt.access.name,
+                         self.radio.service_data_type_name(evt.type),
+                         evt.mime_type)
+        elif evt_type == nrsc5.EventType.EMERGENCY_ALERT:
+            if evt.message is not None:
+                categories = ", ".join(self.radio.alert_category_name(category) for category in evt.categories)
+                logging.info("Alert: Category=[%s] %s=%s %s", categories, evt.location_format.name, str(evt.locations), evt.message)
+            else:
+                logging.info("Alert ended")
         elif evt_type == nrsc5.EventType.AUDIO_SERVICE:
             logging.info("Audio service %s: %s, type: %s, codec: %d, blend: %s, gain: %d dB, delay: %d, latency: %d",
                          evt.program,


### PR DESCRIPTION
Fixes #405.

Here I've deprecated the SIS event and broken it down into eight smaller events:

* Station ID
* Station Name
* Station Slogan
* Station Message
* Station Location
* Audio Service Descriptor
* Data Service Descriptor
* Emergency Alert

Doing so has already helped remove a lot of redundant log messages from the C and Python CLI applications.

Before:
```
14:05:03 Synchronized
14:05:03 Country: CA, FCC facility ID: 328
14:05:03 Station name: MOVE-FM
14:05:03 Country: CA, FCC facility ID: 328
14:05:03 Station name: MOVE-FM
14:05:03 Audio program 0: public, type: Adult Hits, sound experience 0
14:05:03 Data service: public, type: Image Maps, MIME type e96
14:05:03 Country: CA, FCC facility ID: 328
14:05:03 Station name: MOVE-FM
14:05:03 Station location: 99.2146, -11.9686, 128m
14:05:03 Audio program 0: public, type: Adult Hits, sound experience 0
14:05:03 Data service: public, type: Image Maps, MIME type e96
14:05:03 Country: CA, FCC facility ID: 328
14:05:03 Station name: MOVE-FM
14:05:03 Message:  
14:05:03 Station location: 99.2146, -11.9686, 128m
14:05:03 Audio program 0: public, type: Adult Hits, sound experience 0
14:05:03 Data service: public, type: Image Maps, MIME type e96
14:05:03 Country: CA, FCC facility ID: 328
14:05:03 Station name: MOVE-FM
14:05:03 Message:  
14:05:03 Station location: 99.2146, -11.9686, 128m
14:05:03 Audio program 0: public, type: Adult Hits, sound experience 0
14:05:03 Audio program 1: public, type: Talk, sound experience 0
14:05:03 Audio program 2: public, type: Sports, sound experience 0
14:05:03 Data service: public, type: Image Maps, MIME type e96
14:05:03 Country: CA, FCC facility ID: 328
14:05:03 Station name: MOVE-FM
14:05:03 Slogan: MOVE 100.3
14:05:03 Message:  
14:05:03 Station location: 99.2146, -11.9686, 128m
14:05:03 Audio program 0: public, type: Adult Hits, sound experience 0
14:05:03 Audio program 1: public, type: Talk, sound experience 0
14:05:03 Audio program 2: public, type: Sports, sound experience 0
14:05:03 Data service: public, type: Image Maps, MIME type e96
14:05:03 Country: CA, FCC facility ID: 328
14:05:03 Station name: MOVE-FM
14:05:03 Slogan: MOVE 100.3
14:05:03 Message:  
14:05:03 Station location: 99.2146, -11.9686, 128m
14:05:03 Audio program 0: public, type: Adult Hits, sound experience 0
14:05:03 Audio program 1: public, type: Talk, sound experience 0
14:05:03 Audio program 2: public, type: Sports, sound experience 0
14:05:03 Data service: public, type: Image Maps, MIME type e96
14:05:03 Data service: public, type: Navigation, MIME type eb2
14:05:03 Data service: public, type: Navigation, MIME type 469
14:05:03 MER: 10.4 dB (lower), 10.8 dB (upper)
14:05:03 Country: CA, FCC facility ID: 328
14:05:03 Station name: MOVE-FM
14:05:03 Slogan: MOVE 100.3
14:05:03 Message:  
14:05:03 Station location: 99.2146, -11.9686, 128m
14:05:03 Audio program 0: public, type: Adult Hits, sound experience 0
14:05:03 Audio program 1: public, type: Talk, sound experience 0
14:05:03 Audio program 2: public, type: Sports, sound experience 0
14:05:03 Data service: public, type: Image Maps, MIME type e96
14:05:03 Data service: public, type: Navigation, MIME type eb2
14:05:03 Data service: public, type: Navigation, MIME type 469
14:05:03 Data service: public, type: Image Maps, MIME type 2d7
```

After:

```
14:03:31 Synchronized
14:03:31 Station name: MOVE-FM
14:03:31 Country: CA, FCC facility ID: 328
14:03:31 Data service: public, type: Image Maps, MIME type e96
14:03:31 Audio program 0: public, type: Adult Hits, sound experience 0
14:03:31 Station location: 99.2146, -11.9686, 128m
14:03:31 Message:  
14:03:31 Audio program 1: public, type: Talk, sound experience 0
14:03:31 Audio program 2: public, type: Sports, sound experience 0
14:03:31 Slogan: MOVE 100.3
14:03:31 Data service: public, type: Navigation, MIME type eb2
14:03:31 Data service: public, type: Navigation, MIME type 469
14:03:31 MER: 10.4 dB (lower), 10.8 dB (upper)
14:03:31 Data service: public, type: Image Maps, MIME type 2d7
14:03:32 BER: 0.000000, avg: 0.000000, min: 0.000000, max: 0.000000
14:03:32 Audio service 0: public, type: Adult Hits, codec: 0, blend: 2, gain: 0 dB, delay: 96, latency: 8
14:03:32 Audio service 1: public, type: Talk, codec: 0, blend: 0, gain: 0 dB, delay: 0, latency: 8
14:03:32 MER: 12.0 dB (lower), 12.1 dB (upper)
14:03:32 Audio service 2: public, type: Sports, codec: 13, blend: 0, gain: 0 dB, delay: 0, latency: 8
```