### PR TITLE
Ask FFTW to use heuristic planning

### DIFF
--- a/src/acquire.c
+++ b/src/acquire.c
@@ -320,8 +320,8 @@ void acquire_init(acquire_t *st, input_t *input)
     st->filter_am = firdecim_q15_create(filter_taps_am, sizeof(filter_taps_am) / sizeof(filter_taps_am[0]));
 
     pthread_mutex_lock(&fftw_mutex);
-    st->fft_plan_fm = fftwf_plan_dft_1d(FFT_FM, st->fftin, st->fftout, FFTW_FORWARD, 0);
-    st->fft_plan_am = fftwf_plan_dft_1d(FFT_AM, st->fftin, st->fftout, FFTW_FORWARD, 0);
+    st->fft_plan_fm = fftwf_plan_dft_1d(FFT_FM, st->fftin, st->fftout, FFTW_FORWARD, FFTW_ESTIMATE);
+    st->fft_plan_am = fftwf_plan_dft_1d(FFT_AM, st->fftin, st->fftout, FFTW_FORWARD, FFTW_ESTIMATE);
     pthread_mutex_unlock(&fftw_mutex);
 
     for (i = 0; i < FFTCP_FM; ++i)


### PR DESCRIPTION
nrcs5 is very slow to start on Raspberry Pi: on a Pi 5 running Debian 12.10, more than 20 seconds are spent in `fftwf_plan_dft_1d`. I'm not sure why FFTW's planning is so much slower on Raspberry Pi vs. my laptop (where planning only takes about 100 ms).

Since the amount of CPU time spent on FFTs is negligible (about 0.5% of the total) I think it's fine to skip FFTW's measurement-based planning step, and ask it to choose a plan heuristically. FFTW's planner flags are documented here: https://www.fftw.org/fftw3_doc/Planner-Flags.html

With this change, the time to compute a 2048-point transform (for FM) increases from about 12 μs to 15 μs on my Pi 5. I don't notice any change on my laptop.

While it would be possible to stick with measurement-based planning and store the resulting wisdom file for later use, I'm not sure it's worth the extra complexity (and one-time slow startup) given how little time nrsc5 spends on FFTs.