### PR TITLE
Include pointers to SIG service & component in packet/stream/LOT events

### DIFF
--- a/include/nrsc5.h
+++ b/include/nrsc5.h
@@ -408,15 +408,19 @@ struct nrsc5_event_t
             uint16_t port;
             uint16_t seq;
             unsigned int size;
-            uint32_t mime;
+            uint32_t mime;  /**< DEPRECATED: Use `component->data.mime` instead */
             const uint8_t *data;
+            nrsc5_sig_service_t *service;
+            nrsc5_sig_component_t *component;
         } stream;
         struct {
             uint16_t port;
             uint16_t seq;
             unsigned int size;
-            uint32_t mime;
+            uint32_t mime;  /**< DEPRECATED: Use `component->data.mime` instead */
             const uint8_t *data;
+            nrsc5_sig_service_t *service;
+            nrsc5_sig_component_t *component;
         } packet;
         struct {
             uint16_t port;
@@ -426,6 +430,8 @@ struct nrsc5_event_t
             const char *name;
             const uint8_t *data;
             struct tm *expiry_utc;
+            nrsc5_sig_service_t *service;
+            nrsc5_sig_component_t *component;
         } lot;
         struct {
             unsigned int program;       /**< program number 0, 1, ..., 7 */

--- a/src/main.c
+++ b/src/main.c
@@ -368,10 +368,10 @@ static void callback(const nrsc5_event_t *evt, void *opaque)
         }
         break;
     case NRSC5_EVENT_STREAM:
-        log_info("Stream data: port=%04X seq=%04X mime=%08X size=%d", evt->stream.port, evt->stream.seq, evt->stream.mime, evt->stream.size);
+        log_info("Stream data: port=%04X seq=%04X mime=%08X size=%d", evt->stream.port, evt->stream.seq, evt->stream.component->data.mime, evt->stream.size);
         break;
     case NRSC5_EVENT_PACKET:
-        log_info("Packet data: port=%04X seq=%04X mime=%08X size=%d", evt->packet.port, evt->packet.seq, evt->packet.mime, evt->packet.size);
+        log_info("Packet data: port=%04X seq=%04X mime=%08X size=%d", evt->packet.port, evt->packet.seq, evt->packet.component->data.mime, evt->packet.size);
         break;
     case NRSC5_EVENT_LOT:
         if (st->aas_files_path)

--- a/src/output.c
+++ b/src/output.c
@@ -146,6 +146,7 @@ static void aas_reset(output_t *st)
     }
 
     memset(st->services, 0, sizeof(st->services));
+    nrsc5_clear_sig(st->radio);
 }
 
 void output_reset(output_t *st)
@@ -647,12 +648,12 @@ static void process_port(output_t *st, uint16_t port_id, uint16_t seq, uint8_t *
     {
     case AAS_TYPE_STREAM:
     {
-        nrsc5_report_stream(st->radio, port_id, seq, len, component->data.mime, buf);
+        nrsc5_report_stream(st->radio, port_id, seq, len, buf, component->service_ext, component->component_ext);
         break;
     }
     case AAS_TYPE_PACKET:
     {
-        nrsc5_report_packet(st->radio, port_id, seq, len, component->data.mime, buf);
+        nrsc5_report_packet(st->radio, port_id, seq, len, buf, component->service_ext, component->component_ext);
         break;
     }
     case AAS_TYPE_LOT:
@@ -759,7 +760,9 @@ static void process_port(output_t *st, uint16_t port_id, uint16_t seq, uint8_t *
                 uint8_t *data = malloc(num_fragments * LOT_FRAGMENT_SIZE);
                 for (int i = 0; i < num_fragments; i++)
                     memcpy(data + i * LOT_FRAGMENT_SIZE, file->fragments[i], LOT_FRAGMENT_SIZE);
-                nrsc5_report_lot(st->radio, component->data.port, file->lot, file->size, file->mime, file->name, data, &file->expiry_utc);
+                nrsc5_report_lot(st->radio, component->data.port, file->lot, file->size, file->mime,
+                                 file->name, data, &file->expiry_utc,
+                                 component->service_ext, component->component_ext);
                 free(data);
                 aas_free_lot(file);
             }

--- a/src/output.h
+++ b/src/output.h
@@ -50,6 +50,9 @@ typedef struct
     uint8_t type;
     uint8_t id;
 
+    nrsc5_sig_service_t *service_ext;
+    nrsc5_sig_component_t *component_ext;
+
     union
     {
         struct {

--- a/src/private.h
+++ b/src/private.h
@@ -29,6 +29,7 @@ struct nrsc5_t
     int closed;
     nrsc5_callback_t callback;
     void *callback_opaque;
+    nrsc5_sig_service_t *sig_table;
 
     uint8_t leftover_u8[4];
     unsigned int leftover_u8_num;
@@ -52,13 +53,18 @@ void nrsc5_report_mer(nrsc5_t *, float lower, float upper);
 void nrsc5_report_ber(nrsc5_t *, float cber);
 void nrsc5_report_hdc(nrsc5_t *, unsigned int program, const uint8_t *data, size_t count);
 void nrsc5_report_audio(nrsc5_t *, unsigned int program, const int16_t *data, size_t count);
-void nrsc5_report_stream(nrsc5_t *, uint16_t port, uint16_t seq, unsigned int size, uint32_t mime, const uint8_t *data);
-void nrsc5_report_packet(nrsc5_t *, uint16_t port, uint16_t seq, unsigned int size, uint32_t mime, const uint8_t *data);
-void nrsc5_report_lot(nrsc5_t *, uint16_t port, unsigned int lot, unsigned int size, uint32_t mime, const char *name, const uint8_t *data, struct tm *expiry_utc);
+void nrsc5_report_stream(nrsc5_t *, uint16_t port, uint16_t seq, unsigned int size, const uint8_t *data,
+                         nrsc5_sig_service_t *service, nrsc5_sig_component_t *component);
+void nrsc5_report_packet(nrsc5_t *, uint16_t port, uint16_t seq, unsigned int size, const uint8_t *data,
+                         nrsc5_sig_service_t *service, nrsc5_sig_component_t *component);
+void nrsc5_report_lot(nrsc5_t *, uint16_t port, unsigned int lot, unsigned int size, uint32_t mime,
+                      const char *name, const uint8_t *data, struct tm *expiry_utc,
+                      nrsc5_sig_service_t *service, nrsc5_sig_component_t *component);
 void nrsc5_report_audio_service(nrsc5_t *, unsigned int program, unsigned int access, unsigned int type, 
                                 unsigned int codec_mode, unsigned int blend_control, int digital_audio_gain,
                                 unsigned int common_delay, unsigned int latency);
 void nrsc5_report_sig(nrsc5_t *, sig_service_t *services);
+void nrsc5_clear_sig(nrsc5_t *);
 void nrsc5_report_sis(nrsc5_t *, const char *country_code, int fcc_facility_id, const char *name,
                       const char *slogan, const char *message, const char *alert, const uint8_t *cnt, int cnt_length,
                       int category1, int category2, int location_format, int num_locations, const int *locations,

--- a/support/cli.py
+++ b/support/cli.py
@@ -269,10 +269,10 @@ class NRSC5CLI:
                                      component.data.type, component.data.mime.name)
         elif evt_type == nrsc5.EventType.STREAM:
             logging.info("Stream data: port=%04X seq=%04X mime=%s size=%s",
-                         evt.port, evt.seq, evt.mime.name, len(evt.data))
+                         evt.port, evt.seq, evt.component.data.mime.name, len(evt.data))
         elif evt_type == nrsc5.EventType.PACKET:
             logging.info("Packet data: port=%04X seq=%04X mime=%s size=%s",
-                         evt.port, evt.seq, evt.mime.name, len(evt.data))
+                         evt.port, evt.seq, evt.component.data.mime.name, len(evt.data))
         elif evt_type == nrsc5.EventType.LOT:
             time_str = evt.expiry_utc.strftime("%Y-%m-%dT%H:%M:%SZ")
             logging.info("LOT file: port=%04X lot=%s name=%s size=%s mime=%s expiry=%s",


### PR DESCRIPTION
Replaces #407.

The libnrsc5 API provides information about available data services in a single `NRSC5_EVENT_SIG` event. Later, data arrives in `NRSC5_EVENT_LOT`, `NRSC5_EVENT_STREAM` and `NRSC5_EVENT_PACKET` events.

Applications may want to know, for instance, whether a LOT file is a station logo or album art, and which audio stream it belongs to. The only way to achieve this is to store the information from the `NRSC5_EVENT_SIG` event, and later look it up by port number when an `NRSC5_EVENT_LOT` event arrives. It would be more convenient if the `NRSC5_EVENT_LOT` event included information about the service to which it belongs.

Here I've added `service` and `component` fields to `NRSC5_EVENT_LOT`, `NRSC5_EVENT_STREAM` and `NRSC5_EVENT_PACKET` events, thereby allowing easy lookup. For instance, in C:

```c
    if (evt->lot.component->data.mime == NRSC5_MIME_STATION_LOGO)
        log_info("Station logo for program %d", evt->lot.service->components->audio.port);
    if (evt->lot.component->data.mime == NRSC5_MIME_PRIMARY_IMAGE)
        log_info("Album art for program %d", evt->lot.service->components->audio.port);
```

Or in Python:
```python
    if evt.component.data.mime == nrsc5.MIMEType.STATION_LOGO:
        logging.info("Station logo for program %d", evt.service.components[0].audio.port)
    if evt.component.data.mime == nrsc5.MIMEType.PRIMARY_IMAGE:
        logging.info("Album art for program %d", evt.service.components[0].audio.port)
```
