### PR TITLE
Decode HERE Images

### DIFF
--- a/include/nrsc5.h
+++ b/include/nrsc5.h
@@ -173,7 +173,8 @@ enum
     NRSC5_EVENT_STATION_LOCATION,
     NRSC5_EVENT_AUDIO_SERVICE_DESCRIPTOR,
     NRSC5_EVENT_DATA_SERVICE_DESCRIPTOR,
-    NRSC5_EVENT_EMERGENCY_ALERT
+    NRSC5_EVENT_EMERGENCY_ALERT,
+    NRSC5_EVENT_HERE_IMAGE
 };
 
 enum
@@ -247,6 +248,12 @@ enum
     NRSC5_ALERT_CATEGORY_UTILITIES = 11,
     NRSC5_ALERT_CATEGORY_HAZMAT = 12,
     NRSC5_ALERT_CATEGORY_TEST = 30
+};
+
+enum
+{
+    NRSC5_HERE_IMAGE_TRAFFIC = 8,
+    NRSC5_HERE_IMAGE_WEATHER = 13
 };
 
 /**
@@ -363,6 +370,7 @@ struct nrsc5_event_t
  * - `NRSC5_EVENT_AUDIO_SERVICE_DESCRIPTOR` : SIS audio service descriptor, see `asd` member
  * - `NRSC5_EVENT_DATA_SERVICE_DESCRIPTOR` : SIS data service descriptor, see `dsd` member
  * - `NRSC5_EVENT_EMERGENCY_ALERT` : emergency alert, see `emergency_alert` member
+ * - `NRSC5_EVENT_HERE_IMAGE` : HERE Images traffic/weather map, see `here_image` member
  */
     unsigned int event;
     union
@@ -506,6 +514,20 @@ struct nrsc5_event_t
             int num_locations;
             const int *locations;
         } emergency_alert;
+        struct {
+            int image_type;          /**< NRSC5_HERE_IMAGE_TRAFFIC or NRSC5_HERE_IMAGE_WEATHER */
+            int seq;                 /**< sequence number (1-15); increments when traffic/weather image changes */
+            int n1;                  /**< part number (1-9) for traffic, or incrementing sequence number for weather */
+            int n2;                  /**< number of parts (9) for traffic, or incrementing sequence number for weather */
+            unsigned int timestamp;  /**< unix timestamp of traffic or weather image */
+            float latitude1;         /**< latitude of north map edge */
+            float longitude1;        /**< longitude of west map edge */
+            float latitude2;         /**< latitude of south map edge */
+            float longitude2;        /**< longitude of east map edge */
+            const char *name;        /**< filename, e.g. "trafficMap_1_2_rdhs.png" or "WeatherImage_0_0_rdhs.png" */
+            unsigned int size;       /**< size of image file, in bytes */
+            const uint8_t *data;     /**< contents of image file */
+        } here_image;
     };
 };
 /**

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -37,6 +37,7 @@ add_library (
     acquire.c
     decode.c
     frame.c
+    here_images.c
     input.c
     nrsc5.c
     output.c

--- a/src/here_images.c
+++ b/src/here_images.c
@@ -120,3 +120,8 @@ void here_images_reset(here_images_t *st)
 {
     st->expected_seq = -1;
 }
+
+void here_images_init(here_images_t *st, nrsc5_t *radio)
+{
+    st->radio = radio;
+}

--- a/src/here_images.c
+++ b/src/here_images.c
@@ -73,15 +73,11 @@ static void process_packet(here_images_t *st)
         return;
     }
 
-    char *filename = malloc(filename_len + 1);
-    memcpy(filename, &st->buffer[28], filename_len);
-    filename[filename_len] = '\0';
+    st->buffer[28 + filename_len] = '\0';
 
     nrsc5_report_here_image(st->radio, image_type, seq, n1, n2, timestamp,
                             lat1 / 100000.f, lon1 / 100000.f, lat2 / 100000.f, lon2 / 100000.f,
-                            filename, file_len, &st->buffer[34 + filename_len]);
-
-    free(filename);
+                            (char *)&st->buffer[28], file_len, &st->buffer[34 + filename_len]);
 }
 
 void here_images_push(here_images_t *st, uint16_t seq, unsigned int len, uint8_t *buf)

--- a/src/here_images.c
+++ b/src/here_images.c
@@ -1,0 +1,126 @@
+/*
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+#include <string.h>
+#include <time.h>
+
+#include "here_images.h"
+#include "private.h"
+
+static void process_packet(here_images_t *st)
+{
+    if (st->payload_len < 28)
+    {
+        log_warn("HERE Image frame too short");
+        return;
+    }
+
+    int image_type = (st->buffer[0] >> 4);
+    int seq = (st->buffer[0] & 0x0f);
+
+    if ((image_type != NRSC5_HERE_IMAGE_TRAFFIC) && (image_type != NRSC5_HERE_IMAGE_WEATHER))
+    {
+        log_warn("Unknown HERE Image type: %d", image_type);
+        return;
+    }
+
+    int n1 = (st->buffer[2] << 8) | st->buffer[3];
+    int n2 = (st->buffer[4] << 8) | st->buffer[5];
+    unsigned int timestamp = ((unsigned int)st->buffer[9] << 24) | (st->buffer[10] << 16)
+                           | (st->buffer[11] << 8) | st->buffer[12];
+
+    int lat1 = ((st->buffer[14] & 0x7f) << 18) | (st->buffer[15] << 10) | (st->buffer[16] << 2) | (st->buffer[17] >> 6);
+    if (st->buffer[14] & 0x80)
+        lat1 = -lat1;
+
+    int lon1 = ((st->buffer[17] & 0x1f) << 20) | (st->buffer[18] << 12) | (st->buffer[19] << 4) | (st->buffer[20] >> 4);
+    if (st->buffer[17] & 0x20)
+        lon1 = -lon1;
+
+    int lat2 = ((st->buffer[20] & 0x07) << 22) | (st->buffer[21] << 14) | (st->buffer[22] << 6) | (st->buffer[23] >> 2);
+    if (st->buffer[20] & 0x08)
+        lat2 = -lat2;
+
+    int lon2 = ((st->buffer[23] & 0x01) << 24) | (st->buffer[24] << 16) | (st->buffer[25] << 8) | st->buffer[26];
+    if (st->buffer[23] & 0x02)
+        lon2 = -lon2;
+
+    int filename_len = st->buffer[27];
+
+    if (st->payload_len < 34 + filename_len)
+    {
+        log_warn("HERE Image frame too short");
+        return;
+    }
+
+    int file_len = (st->buffer[32 + filename_len] << 8) | st->buffer[33 + filename_len];
+
+    if (st->payload_len < 34 + filename_len + file_len)
+    {
+        log_warn("HERE Image frame too short");
+        return;
+    }
+
+    char *filename = malloc(filename_len + 1);
+    memcpy(filename, &st->buffer[28], filename_len);
+    filename[filename_len] = '\0';
+
+    nrsc5_report_here_image(st->radio, image_type, seq, n1, n2, timestamp,
+                            lat1 / 100000.f, lon1 / 100000.f, lat2 / 100000.f, lon2 / 100000.f,
+                            filename, file_len, &st->buffer[34 + filename_len]);
+
+    free(filename);
+}
+
+void here_images_push(here_images_t *st, uint16_t seq, unsigned int len, uint8_t *buf)
+{
+    if (seq != st->expected_seq)
+    {
+        memset(st->buffer, 0, sizeof(st->buffer));
+        st->payload_len = -1;
+        st->sync_state = 0;
+    }
+
+    for (unsigned int offset = 0; offset < len; offset++)
+    {
+        st->sync_state <<= 8;
+        st->sync_state |= buf[offset];
+
+        if (st->payload_len == -1) // waiting for sync
+        {
+            if (((st->sync_state >> 16) & 0xffffffff) == 0xfff7fff7)
+            {
+                st->payload_len = st->sync_state & 0xffff;
+                st->buffer_idx = 0;
+            }
+        }
+        else
+        {
+            st->buffer[st->buffer_idx++] = buf[offset];
+            if (st->buffer_idx == (st->payload_len + 2))
+            {
+                process_packet(st);
+                st->payload_len = -1;
+            }
+        }
+    }
+
+    st->expected_seq = (seq + 1) & 0xffff;
+}
+
+void here_images_reset(here_images_t *st)
+{
+    st->expected_seq = -1;
+}

--- a/src/here_images.h
+++ b/src/here_images.h
@@ -1,0 +1,19 @@
+#pragma once
+
+#include <stdint.h>
+#include <nrsc5.h>
+
+#define MAX_PAYLOAD_BYTES (65536 + 2)
+
+typedef struct
+{
+    nrsc5_t *radio;
+    uint8_t buffer[MAX_PAYLOAD_BYTES];
+    int buffer_idx;
+    int expected_seq;
+    int payload_len;
+    uint64_t sync_state;
+} here_images_t;
+
+void here_images_push(here_images_t *st, uint16_t seq, unsigned int len, uint8_t *buf);
+void here_images_reset(here_images_t *st);

--- a/src/here_images.h
+++ b/src/here_images.h
@@ -17,3 +17,4 @@ typedef struct
 
 void here_images_push(here_images_t *st, uint16_t seq, unsigned int len, uint8_t *buf);
 void here_images_reset(here_images_t *st);
+void here_images_init(here_images_t *st, nrsc5_t *radio);

--- a/src/nrsc5.c
+++ b/src/nrsc5.c
@@ -1041,3 +1041,26 @@ void nrsc5_report_emergency_alert(nrsc5_t *st, const char *message, const uint8_
 
     nrsc5_report(st, &evt);
 }
+
+void nrsc5_report_here_image(nrsc5_t *st, int image_type, int seq, int n1, int n2, unsigned int timestamp,
+                             float latitude1, float longitude1, float latitude2, float longitude2,
+                             const char *name, unsigned int size, const uint8_t *data)
+{
+    nrsc5_event_t evt;
+
+    evt.event = NRSC5_EVENT_HERE_IMAGE;
+    evt.here_image.image_type = image_type;
+    evt.here_image.seq = seq;
+    evt.here_image.n1 = n1;
+    evt.here_image.n2 = n2;
+    evt.here_image.timestamp = timestamp;
+    evt.here_image.latitude1 = latitude1;
+    evt.here_image.longitude1 = longitude1;
+    evt.here_image.latitude2 = latitude2;
+    evt.here_image.longitude2 = longitude2;
+    evt.here_image.name = name;
+    evt.here_image.size = size;
+    evt.here_image.data = data;
+
+    nrsc5_report(st, &evt);
+}

--- a/src/output.c
+++ b/src/output.c
@@ -26,6 +26,7 @@
 #include "output.h"
 #include "private.h"
 #include "unicode.h"
+#include "here_images.h"
 
 void output_align(output_t *st, unsigned int program, unsigned int stream_id, unsigned int offset)
 {
@@ -169,11 +170,14 @@ void output_reset(output_t *st)
         st->aacdec[i] = NULL;
 #endif
     }
+
+    here_images_reset(&st->here_images);
 }
 
 void output_init(output_t *st, nrsc5_t *radio)
 {
     st->radio = radio;
+    st->here_images.radio = radio;
 #ifdef USE_FAAD2
     for (int i = 0; i < MAX_PROGRAMS; i++)
         st->aacdec[i] = NULL;
@@ -649,6 +653,8 @@ static void process_port(output_t *st, uint16_t port_id, uint16_t seq, uint8_t *
     case AAS_TYPE_STREAM:
     {
         nrsc5_report_stream(st->radio, port_id, seq, len, buf, component->service_ext, component->component_ext);
+        if (component->data.mime == NRSC5_MIME_HERE_IMAGE)
+            here_images_push(&st->here_images, seq, len, buf);
         break;
     }
     case AAS_TYPE_PACKET:

--- a/src/output.c
+++ b/src/output.c
@@ -177,7 +177,6 @@ void output_reset(output_t *st)
 void output_init(output_t *st, nrsc5_t *radio)
 {
     st->radio = radio;
-    st->here_images.radio = radio;
 #ifdef USE_FAAD2
     for (int i = 0; i < MAX_PROGRAMS; i++)
         st->aacdec[i] = NULL;
@@ -185,6 +184,7 @@ void output_init(output_t *st, nrsc5_t *radio)
 #endif
 
     memset(st->services, 0, sizeof(st->services));
+    here_images_init(&st->here_images, radio);
 
     output_reset(st);
 }

--- a/src/output.h
+++ b/src/output.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "config.h"
+#include "here_images.h"
 
 #include <nrsc5.h>
 
@@ -100,6 +101,7 @@ typedef struct
     int16_t silence[NRSC5_AUDIO_FRAME_SAMPLES * 2];
 #endif
     sig_service_t services[MAX_SIG_SERVICES];
+    here_images_t here_images;
 } output_t;
 
 void output_align(output_t *st, unsigned int program, unsigned int stream_id, unsigned int offset);

--- a/src/private.h
+++ b/src/private.h
@@ -80,3 +80,6 @@ void nrsc5_report_dsd(nrsc5_t *st, unsigned int access, unsigned int type, uint3
 void nrsc5_report_emergency_alert(nrsc5_t *st, const char *message, const uint8_t *control_data,
                                   int control_data_length, int category1, int category2,
                                   int location_format, int num_locations, const int *locations);
+void nrsc5_report_here_image(nrsc5_t *st, int image_type, int seq, int n1, int n2, unsigned int timestamp,
+                             float latitude1, float longitude1, float latitude2, float longitude2,
+                             const char *name, unsigned int size, const uint8_t *data);

--- a/support/cli.py
+++ b/support/cli.py
@@ -318,6 +318,16 @@ class NRSC5CLI:
                          evt.digital_audio_gain,
                          evt.common_delay,
                          evt.latency)
+        elif evt_type == nrsc5.EventType.HERE_IMAGE:
+            time_str = evt.timestamp.strftime("%Y-%m-%dT%H:%M:%SZ")
+            logging.info("HERE Image: type=%s, seq=%d, n1=%d, n2=%d, time=%s, lat1=%.5f, lon1=%.5f, lat2=%.5f, lon2=%.5f, name=%s, size=%d",
+                         evt.image_type.name, evt.seq, evt.n1, evt.n2, time_str, evt.latitude1, evt.longitude1,
+                         evt.latitude2, evt.longitude2, evt.name, len(evt.data))
+            if self.args.dump_aas_files:
+                time_int = int(evt.timestamp.timestamp())
+                path = os.path.join(self.args.dump_aas_files, f"{time_int}_{evt.name}")
+                with open(path, "wb") as file:
+                    file.write(evt.data)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes #401.

Most of the details of the HERE Images stream were worked out in #308, so I've now added a decoder for it. Images are reported in `NRSC5_EVENT_HERE_IMAGE` API events, and logged by the C and Python command-line applications:

```
15:56:09 HERE Image: type=TRAFFIC, seq=2, n1=1, n2=9, time=2024-10-23T13:02:12Z, lat1=43.02372, lon1=-83.81881, lat2=42.82260, lon2=-83.54415, name=trafficMap_0_0_rdhs.png, size=3047
15:56:09 HERE Image: type=TRAFFIC, seq=2, n1=2, n2=9, time=2024-10-23T13:02:12Z, lat1=43.02372, lon1=-84.09347, lat2=42.82260, lon2=-83.26950, name=trafficMap_0_1_rdhs.png, size=4267
15:56:09 HERE Image: type=TRAFFIC, seq=2, n1=3, n2=9, time=2024-10-23T13:02:12Z, lat1=43.02372, lon1=-84.36813, lat2=42.82260, lon2=-82.99484, name=trafficMap_0_2_rdhs.png, size=5033
15:56:10 HERE Image: type=TRAFFIC, seq=2, n1=4, n2=9, time=2024-10-23T13:02:12Z, lat1=43.22419, lon1=-83.81881, lat2=42.62082, lon2=-83.54415, name=trafficMap_1_0_rdhs.png, size=4785
15:56:10 HERE Image: type=TRAFFIC, seq=2, n1=5, n2=9, time=2024-10-23T13:02:12Z, lat1=43.22419, lon1=-84.09347, lat2=42.62082, lon2=-83.26950, name=trafficMap_1_1_rdhs.png, size=6855
15:56:11 HERE Image: type=TRAFFIC, seq=2, n1=6, n2=9, time=2024-10-23T13:02:12Z, lat1=43.22419, lon1=-84.36813, lat2=42.62082, lon2=-82.99484, name=trafficMap_1_2_rdhs.png, size=5065
15:56:11 HERE Image: type=TRAFFIC, seq=2, n1=7, n2=9, time=2024-10-23T13:02:12Z, lat1=43.42400, lon1=-83.81881, lat2=42.41838, lon2=-83.54415, name=trafficMap_2_0_rdhs.png, size=3075
15:56:11 HERE Image: type=TRAFFIC, seq=2, n1=8, n2=9, time=2024-10-23T13:02:12Z, lat1=43.42400, lon1=-84.09347, lat2=42.41838, lon2=-83.26950, name=trafficMap_2_1_rdhs.png, size=5701
15:56:12 HERE Image: type=TRAFFIC, seq=2, n1=9, n2=9, time=2024-10-23T13:02:12Z, lat1=43.42400, lon1=-84.36813, lat2=42.41838, lon2=-82.99484, name=trafficMap_2_2_rdhs.png, size=7733
15:56:12 HERE Image: type=WEATHER, seq=1, n1=4306, n2=4306, time=2024-10-23T13:02:13Z, lat1=43.44480, lon1=-84.09350, lat2=42.62080, lon2=-83.26949, name=WeatherImage_0_0_rdhs.png, size=1535
```

If the `--dump-aas-files <dir-name>` argument is supplied, then the command-line applications also save the images to disk. A timestamp prefix is added to the filenames (e.g. `1729688532_trafficMap_0_0_rdhs.png`) because the filenames in the HERE Images stream do not change when the traffic & weather data is updated.

I would particularly appreciate feedback on the API, since that part will be difficult to change in the future (except for adding new fields).

The entire HERE Images frame is decoded and reported through the API, except for a handful of fields whose purpose is unknown, and whose values don't appear meaningful:

* offset 1: always 0x00 for traffic, or 0x02 for weather
* offset 6-7: length of the remaining portion of the frame
* offset 8: always 0x00, perhaps a tag
* offset 13: always 0x01, perhaps a tag
* 4 bytes immediately following the filename: always 0x00630000 for traffic, or 0x04210000 for weather
* last two bytes: probably a CRC or checksum over the entire frame, but I haven't managed to reverse engineer it yet