### PR TITLE
Use 64-bit Unix timestamps for LOT file expiry & HERE file time

### DIFF
--- a/include/nrsc5.h
+++ b/include/nrsc5.h
@@ -438,9 +438,10 @@ struct nrsc5_event_t
             uint32_t mime;
             const char *name;
             const uint8_t *data;
-            struct tm *expiry_utc;
+            struct tm *expiry_utc;            /**< DEPRECATED: Use `expiry_timestamp` instead */
             nrsc5_sig_service_t *service;
             nrsc5_sig_component_t *component;
+            int64_t expiry_timestamp;         /**< unix timestamp of file expiry time */
         } lot;
         struct {
             unsigned int program;       /**< program number 0, 1, ..., 7 */
@@ -515,18 +516,18 @@ struct nrsc5_event_t
             const int *locations;
         } emergency_alert;
         struct {
-            int image_type;          /**< NRSC5_HERE_IMAGE_TRAFFIC or NRSC5_HERE_IMAGE_WEATHER */
-            int seq;                 /**< sequence number (1-15); increments when traffic/weather image changes */
-            int n1;                  /**< part number (1-9) for traffic, or incrementing sequence number for weather */
-            int n2;                  /**< number of parts (9) for traffic, or incrementing sequence number for weather */
-            unsigned int timestamp;  /**< unix timestamp of traffic or weather image */
-            float latitude1;         /**< latitude of north map edge */
-            float longitude1;        /**< longitude of west map edge */
-            float latitude2;         /**< latitude of south map edge */
-            float longitude2;        /**< longitude of east map edge */
-            const char *name;        /**< filename, e.g. "trafficMap_1_2_rdhs.png" or "WeatherImage_0_0_rdhs.png" */
-            unsigned int size;       /**< size of image file, in bytes */
-            const uint8_t *data;     /**< contents of image file */
+            int image_type;      /**< NRSC5_HERE_IMAGE_TRAFFIC or NRSC5_HERE_IMAGE_WEATHER */
+            int seq;             /**< sequence number (1-15); increments when traffic/weather image changes */
+            int n1;              /**< part number (1-9) for traffic, or incrementing sequence number for weather */
+            int n2;              /**< number of parts (9) for traffic, or incrementing sequence number for weather */
+            int64_t timestamp;   /**< unix timestamp of traffic or weather image */
+            float latitude1;     /**< latitude of north map edge */
+            float longitude1;    /**< longitude of west map edge */
+            float latitude2;     /**< latitude of south map edge */
+            float longitude2;    /**< longitude of east map edge */
+            const char *name;    /**< filename, e.g. "trafficMap_1_2_rdhs.png" or "WeatherImage_0_0_rdhs.png" */
+            unsigned int size;   /**< size of image file, in bytes */
+            const uint8_t *data; /**< contents of image file */
         } here_image;
     };
 };

--- a/src/here_images.c
+++ b/src/here_images.c
@@ -38,7 +38,7 @@ static void process_packet(here_images_t *st)
 
     int n1 = (st->buffer[2] << 8) | st->buffer[3];
     int n2 = (st->buffer[4] << 8) | st->buffer[5];
-    unsigned int timestamp = ((unsigned int)st->buffer[9] << 24) | (st->buffer[10] << 16)
+    int64_t timestamp = ((int64_t)st->buffer[9] << 24) | (st->buffer[10] << 16)
                            | (st->buffer[11] << 8) | st->buffer[12];
 
     int lat1 = ((st->buffer[14] & 0x7f) << 18) | (st->buffer[15] << 10) | (st->buffer[16] << 2) | (st->buffer[17] >> 6);

--- a/src/nrsc5.c
+++ b/src/nrsc5.c
@@ -778,6 +778,11 @@ void nrsc5_report_lot(nrsc5_t *st, uint16_t port, unsigned int lot, unsigned int
     evt.lot.expiry_utc = expiry_utc;
     evt.lot.service = service;
     evt.lot.component = component;
+#if defined(WIN32) || defined(_WIN32)
+    evt.lot.expiry_timestamp = _mkgmtime64(expiry_utc);
+#else
+    evt.lot.expiry_timestamp = timegm(expiry_utc);
+#endif
     nrsc5_report(st, &evt);
 }
 
@@ -1042,7 +1047,7 @@ void nrsc5_report_emergency_alert(nrsc5_t *st, const char *message, const uint8_
     nrsc5_report(st, &evt);
 }
 
-void nrsc5_report_here_image(nrsc5_t *st, int image_type, int seq, int n1, int n2, unsigned int timestamp,
+void nrsc5_report_here_image(nrsc5_t *st, int image_type, int seq, int n1, int n2, int64_t timestamp,
                              float latitude1, float longitude1, float latitude2, float longitude2,
                              const char *name, unsigned int size, const uint8_t *data)
 {

--- a/src/private.h
+++ b/src/private.h
@@ -80,6 +80,6 @@ void nrsc5_report_dsd(nrsc5_t *st, unsigned int access, unsigned int type, uint3
 void nrsc5_report_emergency_alert(nrsc5_t *st, const char *message, const uint8_t *control_data,
                                   int control_data_length, int category1, int category2,
                                   int location_format, int num_locations, const int *locations);
-void nrsc5_report_here_image(nrsc5_t *st, int image_type, int seq, int n1, int n2, unsigned int timestamp,
+void nrsc5_report_here_image(nrsc5_t *st, int image_type, int seq, int n1, int n2, int64_t timestamp,
                              float latitude1, float longitude1, float latitude2, float longitude2,
                              const char *name, unsigned int size, const uint8_t *data);

--- a/support/nrsc5.py
+++ b/support/nrsc5.py
@@ -388,6 +388,7 @@ class _LOT(ctypes.Structure):
         ("expiry_utc", ctypes.POINTER(_TimeStruct)),
         ("service", ctypes.POINTER(_SIGService)),
         ("component", ctypes.POINTER(_SIGComponent)),
+        ("expiry_timestamp", ctypes.c_int64),
     ]
 
 
@@ -521,7 +522,7 @@ class _HEREImage(ctypes.Structure):
         ("seq", ctypes.c_int),
         ("n1", ctypes.c_int),
         ("n2", ctypes.c_int),
-        ("timestamp", ctypes.c_uint),
+        ("timestamp", ctypes.c_int64),
         ("latitude1", ctypes.c_float),
         ("longitude1", ctypes.c_float),
         ("latitude2", ctypes.c_float),
@@ -683,16 +684,7 @@ class NRSC5:
             lot = c_evt.u.lot
             service = self.services[lot.service.contents.number]
             component = self.components[(lot.service.contents.number, lot.component.contents.id)]
-            expiry_struct = lot.expiry_utc.contents
-            expiry_time = datetime.datetime(
-                expiry_struct.tm_year + 1900,
-                expiry_struct.tm_mon + 1,
-                expiry_struct.tm_mday,
-                expiry_struct.tm_hour,
-                expiry_struct.tm_min,
-                expiry_struct.tm_sec,
-                tzinfo=datetime.timezone.utc
-            )
+            expiry_time = datetime.datetime.fromtimestamp(lot.expiry_timestamp, tz=datetime.timezone.utc)
             evt = LOT(lot.port, lot.lot, MIMEType(lot.mime), self._decode(lot.name), lot.data[:lot.size], expiry_time, service, component)
         elif evt_type == EventType.SIS:
             sis = c_evt.u.sis


### PR DESCRIPTION
In the libnrsc5 API, the LOT file expiry time is currently conveyed in a `struct tm`. This has turned out to be unwieldy, and mismatches the HERE Images API (added in #415) which uses a Unix timestamp to convey file time.

I propose to add a new `expiry_timestamp` field, and deprecate the old `expiry_utc` field. This also allows the code in the Python API wrapper to be simplified.

In addition, I think it would make sense to use `int64_t` to convey Unix timestamps in the API, since that's the underlying type of modern `time_t`.