### PR TITLE
Use struct tm to represent HERE Images time

### DIFF
--- a/include/nrsc5.h
+++ b/include/nrsc5.h
@@ -515,18 +515,18 @@ struct nrsc5_event_t
             const int *locations;
         } emergency_alert;
         struct {
-            int image_type;          /**< NRSC5_HERE_IMAGE_TRAFFIC or NRSC5_HERE_IMAGE_WEATHER */
-            int seq;                 /**< sequence number (1-15); increments when traffic/weather image changes */
-            int n1;                  /**< part number (1-9) for traffic, or incrementing sequence number for weather */
-            int n2;                  /**< number of parts (9) for traffic, or incrementing sequence number for weather */
-            unsigned int timestamp;  /**< unix timestamp of traffic or weather image */
-            float latitude1;         /**< latitude of north map edge */
-            float longitude1;        /**< longitude of west map edge */
-            float latitude2;         /**< latitude of south map edge */
-            float longitude2;        /**< longitude of east map edge */
-            const char *name;        /**< filename, e.g. "trafficMap_1_2_rdhs.png" or "WeatherImage_0_0_rdhs.png" */
-            unsigned int size;       /**< size of image file, in bytes */
-            const uint8_t *data;     /**< contents of image file */
+            int image_type;      /**< NRSC5_HERE_IMAGE_TRAFFIC or NRSC5_HERE_IMAGE_WEATHER */
+            int seq;             /**< sequence number (1-15); increments when traffic/weather image changes */
+            int n1;              /**< part number (1-9) for traffic, or incrementing sequence number for weather */
+            int n2;              /**< number of parts (9) for traffic, or incrementing sequence number for weather */
+            struct tm *time_utc; /**< UTC time of traffic or weather image */
+            float latitude1;     /**< latitude of north map edge */
+            float longitude1;    /**< longitude of west map edge */
+            float latitude2;     /**< latitude of south map edge */
+            float longitude2;    /**< longitude of east map edge */
+            const char *name;    /**< filename, e.g. "trafficMap_1_2_rdhs.png" or "WeatherImage_0_0_rdhs.png" */
+            unsigned int size;   /**< size of image file, in bytes */
+            const uint8_t *data; /**< contents of image file */
         } here_image;
     };
 };

--- a/src/nrsc5.c
+++ b/src/nrsc5.c
@@ -1053,7 +1053,13 @@ void nrsc5_report_here_image(nrsc5_t *st, int image_type, int seq, int n1, int n
     evt.here_image.seq = seq;
     evt.here_image.n1 = n1;
     evt.here_image.n2 = n2;
-    evt.here_image.timestamp = timestamp;
+#if defined(WIN32) || defined(_WIN32)
+    __time64_t ts = (__time64_t) timestamp;
+    evt.here_image.time_utc = _gmtime64(&ts);
+#else
+    time_t ts = (time_t) timestamp;
+    evt.here_image.time_utc = gmtime(&ts);
+#endif
     evt.here_image.latitude1 = latitude1;
     evt.here_image.longitude1 = longitude1;
     evt.here_image.latitude2 = latitude2;

--- a/support/cli.py
+++ b/support/cli.py
@@ -319,12 +319,12 @@ class NRSC5CLI:
                          evt.common_delay,
                          evt.latency)
         elif evt_type == nrsc5.EventType.HERE_IMAGE:
-            time_str = evt.timestamp.strftime("%Y-%m-%dT%H:%M:%SZ")
+            time_str = evt.time_utc.strftime("%Y-%m-%dT%H:%M:%SZ")
             logging.info("HERE Image: type=%s, seq=%d, n1=%d, n2=%d, time=%s, lat1=%.5f, lon1=%.5f, lat2=%.5f, lon2=%.5f, name=%s, size=%d",
                          evt.image_type.name, evt.seq, evt.n1, evt.n2, time_str, evt.latitude1, evt.longitude1,
                          evt.latitude2, evt.longitude2, evt.name, len(evt.data))
             if self.args.dump_aas_files:
-                time_int = int(evt.timestamp.timestamp())
+                time_int = int(evt.time_utc.timestamp())
                 path = os.path.join(self.args.dump_aas_files, f"{time_int}_{evt.name}")
                 with open(path, "wb") as file:
                     file.write(evt.data)


### PR DESCRIPTION
Replaces #419.

It makes sense to use a consistent time format across the libnrsc5 API. The LOT expiry time (added in #310) uses `struct tm`, while the HERE Images API (recently added in #415) uses a Unix timestamp. I propose to switch the HERE Images API over to `struct tm` to match the LOT API.