### PR TITLE
Fix use-after-free triggered by set_frequency()

### DIFF
--- a/src/nrsc5.c
+++ b/src/nrsc5.c
@@ -912,6 +912,7 @@ void nrsc5_clear_sig(nrsc5_t *st)
         service = service->next;
         free(p);
     }
+    st->sig_table = NULL;
 }
 
 void nrsc5_report_sis(nrsc5_t *st, const char *country_code, int fcc_facility_id, const char *name,


### PR DESCRIPTION
@TheDaChicken noticed that #414 introduced a use-after-free bug because `nrsc5_clear_sig` fails to set `st->sig_table` to NULL, and therefore will attempt to clear the freed table again on the next invocation.