### PR TITLE
Avoid exporting from static libraries & executables

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -32,8 +32,7 @@ link_directories (
     ${LIBUSB_LIBRARY_DIRS}
 )
 
-add_library (
-    nrsc5_object OBJECT
+set (LIBRARY_FILES
     acquire.c
     decode.c
     frame.c
@@ -57,10 +56,6 @@ add_library (
 
     strndup.c
 )
-set_property(TARGET nrsc5_object PROPERTY POSITION_INDEPENDENT_CODE ON)
-if (BUILTIN_LIBRARIES)
-    add_dependencies(nrsc5_object ${BUILTIN_LIBRARIES})
-endif ()
 
 set (
     LibraryDependencies
@@ -74,24 +69,30 @@ set (
 
 add_library (
     nrsc5 SHARED
-    $<TARGET_OBJECTS:nrsc5_object>
+    ${LIBRARY_FILES}
 )
 target_link_libraries (
     nrsc5
     ${LibraryDependencies}
 )
+if (BUILTIN_LIBRARIES)
+    add_dependencies(nrsc5 ${BUILTIN_LIBRARIES})
+endif ()
 set_target_properties(nrsc5 PROPERTIES PUBLIC_HEADER "../include/nrsc5.h")
 set_target_properties(nrsc5 PROPERTIES LINK_FLAGS "${STATIC_LINKER_FLAGS} ${EXPORTS_LINKER_FLAGS}")
-target_compile_definitions(nrsc5_object PUBLIC "-DNRSC5_EXPORTS=1")
+target_compile_definitions(nrsc5 PUBLIC "-DNRSC5_EXPORTS=1")
 
 add_library (
     nrsc5_static
-    $<TARGET_OBJECTS:nrsc5_object>
+    ${LIBRARY_FILES}
 )
 target_link_libraries (
     nrsc5_static
     ${LibraryDependencies}
 )
+if (BUILTIN_LIBRARIES)
+    add_dependencies(nrsc5_static ${BUILTIN_LIBRARIES})
+endif ()
 
 add_executable (
     app

--- a/support/faad2-hdc-support.patch
+++ b/support/faad2-hdc-support.patch
@@ -1,12 +1,12 @@
-From f90b0f325f66cbcdb45bbc9239b7d0889cb140e9 Mon Sep 17 00:00:00 2001
+From 0b14753ede5c3567d3d5e90801bfedda67bc26b0 Mon Sep 17 00:00:00 2001
 From: Clayton Smith <argilo@gmail.com>
-Date: Fri, 11 Apr 2025 15:53:22 -0400
+Date: Mon, 2 Jun 2025 23:02:44 -0400
 Subject: [PATCH] Support for HDC variant
 
 ---
  CMakeLists.txt       |  10 +-
  frontend/main.c      |   3 +-
- include/neaacdec.h   |   4 +
+ include/neaacdec.h   |   6 +-
  libfaad/bits.c       |   2 +-
  libfaad/bits.h       |   2 +-
  libfaad/common.c     |   5 +
@@ -19,7 +19,7 @@ Subject: [PATCH] Support for HDC variant
  libfaad/sbr_syntax.c |  24 ++++-
  libfaad/syntax.c     | 224 +++++++++++++++++++++++++++++++++++++++++--
  libfaad/syntax.h     |   1 +
- 15 files changed, 406 insertions(+), 44 deletions(-)
+ 15 files changed, 407 insertions(+), 45 deletions(-)
 
 diff --git a/CMakeLists.txt b/CMakeLists.txt
 index 97b61cc..5956418 100644
@@ -71,9 +71,18 @@ index 895ed18..18aefb7 100644
                          showHelp = 1;
                      }
 diff --git a/include/neaacdec.h b/include/neaacdec.h
-index f7d5f67..b4f36da 100644
+index f7d5f67..e0d114d 100644
 --- a/include/neaacdec.h
 +++ b/include/neaacdec.h
+@@ -60,7 +60,7 @@ extern "C" {
+ 
+ #ifdef _WIN32
+   #pragma pack(push, 8)
+-  #define NEAACDECAPI __declspec(dllexport)
++  #define NEAACDECAPI
+ #elif defined(__GNUC__) && __GNUC__ >= 4
+   #define NEAACDECAPI __attribute__((visibility("default")))
+ #else
 @@ -81,6 +81,7 @@ extern "C" {
  #define ER_LTP    19
  #define LD        23


### PR DESCRIPTION
Fixes #424.

To avoid accidentally exporting symbols, I've done two things here:

* build libnrsc5's shared and static versions separately, and only set `NRSC5_EXPORTS` for the shared version
* remove `__declspec(dllexport)` from faad2 in our patch; we're only building static libraries so it's not needed

With these changes, nrsc5.exe no longer has the spurious exports which were causing libnrsc5.dll.a to be overwritten.

I know very little about CMake & software builds, so I'd appreciate feedback on the approach.