### PR TITLE
Report frequency offset and service mode through the API

### DIFF
--- a/include/nrsc5.h
+++ b/include/nrsc5.h
@@ -356,7 +356,7 @@ struct nrsc5_event_t
  * The member `event` determines which sort of event occurred:
  * - `NRSC5_EVENT_LOST_DEVICE` : RTL-SDR device was disconnected
  * - `NRSC5_EVENT_IQ` : IQ data, see the `iq` union member
- * - `NRSC5_EVENT_SYNC` : indicates synchronization achieved
+ * - `NRSC5_EVENT_SYNC` : indicates synchronization achieved, see the `sync` union member
  * - `NRSC5_EVENT_LOST_SYNC` : indicates synchronization lost
  * - `NRSC5_EVENT_MER` : modulation error ratio, see the `mer` union member, and NRSC5 document SY_TN_2646s
  * - `NRSC5_EVENT_BER` : Bit Error Ratio data, see the `ber` union member
@@ -386,6 +386,10 @@ struct nrsc5_event_t
             const void *data;
             size_t count;
         } iq;
+        struct {
+            float freq_offset; /**< Frequency offset in Hz */
+            int psmi;          /**< Primary Service Mode Indicator (1, 2, 3, 5, 6, or 11 for FM; 1 or 2 for AM) */
+        } sync;
         struct {
             float cber;
         } ber;

--- a/src/acquire.c
+++ b/src/acquire.c
@@ -269,16 +269,7 @@ void acquire_keep_extra(acquire_t *st, int extra)
 
 void acquire_cfo_adjust(acquire_t *st, int cfo)
 {
-    float hz;
-
-    if (cfo == 0)
-        return;
-
     st->cfo += cfo;
-    hz = (float) st->cfo * NRSC5_SAMPLE_RATE_CU8 / st->fft;
-    hz /= (st->mode == NRSC5_MODE_FM ? DECIMATION_FACTOR_FM : DECIMATION_FACTOR_AM);
-
-    log_info("CFO: %f Hz", hz);
 }
 
 unsigned int acquire_push(acquire_t *st, cint16_t *buf, unsigned int length)

--- a/src/input.c
+++ b/src/input.c
@@ -192,8 +192,10 @@ void input_set_sync_state(input_t *st, unsigned int new_state)
         nrsc5_report_lost_sync(st->radio);
     if (new_state == SYNC_STATE_FINE)
     {
-        nrsc5_report_sync(st->radio);
-        log_debug("Primary service mode: %d", st->sync.psmi);
+        float freq_offset = (st->acq.prev_angle - 2 * M_PI * st->acq.cfo)
+                          * (st->radio->mode == NRSC5_MODE_FM ? NRSC5_SAMPLE_RATE_CS16_FM : NRSC5_SAMPLE_RATE_CS16_AM)
+                          / (2 * M_PI * st->acq.fft);
+        nrsc5_report_sync(st->radio, freq_offset, st->sync.psmi);
     }
 
     st->sync_state = new_state;

--- a/src/main.c
+++ b/src/main.c
@@ -350,6 +350,8 @@ static void callback(const nrsc5_event_t *evt, void *opaque)
         break;
     case NRSC5_EVENT_SYNC:
         log_info("Synchronized");
+        log_info("Frequency offset: %.0f Hz", evt->sync.freq_offset);
+        log_info("Primary service mode: %d", evt->sync.psmi);
         st->audio_ready = 0;
         break;
     case NRSC5_EVENT_LOST_SYNC:

--- a/src/nrsc5.c
+++ b/src/nrsc5.c
@@ -673,11 +673,13 @@ void nrsc5_report_iq(nrsc5_t *st, const void *data, size_t count)
     nrsc5_report(st, &evt);
 }
 
-void nrsc5_report_sync(nrsc5_t *st)
+void nrsc5_report_sync(nrsc5_t *st, float freq_offset, int psmi)
 {
     nrsc5_event_t evt;
 
     evt.event = NRSC5_EVENT_SYNC;
+    evt.sync.freq_offset = freq_offset;
+    evt.sync.psmi = psmi;
     nrsc5_report(st, &evt);
 }
 

--- a/src/private.h
+++ b/src/private.h
@@ -47,7 +47,7 @@ struct nrsc5_t
 void nrsc5_report(nrsc5_t *, const nrsc5_event_t *evt);
 void nrsc5_report_lost_device(nrsc5_t *st);
 void nrsc5_report_iq(nrsc5_t *, const void *data, size_t count);
-void nrsc5_report_sync(nrsc5_t *);
+void nrsc5_report_sync(nrsc5_t *, float freq_offset, int psmi);
 void nrsc5_report_lost_sync(nrsc5_t *);
 void nrsc5_report_mer(nrsc5_t *, float lower, float upper);
 void nrsc5_report_ber(nrsc5_t *, float cber);

--- a/support/cli.py
+++ b/support/cli.py
@@ -205,6 +205,8 @@ class NRSC5CLI:
                 self.iq_output.write(evt.data)
         elif evt_type == nrsc5.EventType.SYNC:
             logging.info("Synchronized")
+            logging.info("Frequency offset: %.0f Hz", evt.freq_offset)
+            logging.info("Primary service mode: %d", evt.psmi)
         elif evt_type == nrsc5.EventType.LOST_SYNC:
             logging.info("Lost synchronization")
         elif evt_type == nrsc5.EventType.MER:

--- a/support/nrsc5.py
+++ b/support/nrsc5.py
@@ -181,6 +181,7 @@ class HEREImageType(enum.Enum):
 
 
 IQ = collections.namedtuple("IQ", ["data"])
+Sync = collections.namedtuple("Sync", ["freq_offset", "psmi"])
 MER = collections.namedtuple("MER", ["lower", "upper"])
 BER = collections.namedtuple("BER", ["cber"])
 HDC = collections.namedtuple("HDC", ["program", "data"])
@@ -218,6 +219,13 @@ class _IQ(ctypes.Structure):
     _fields_ = [
         ("data", ctypes.POINTER(ctypes.c_char)),
         ("count", ctypes.c_size_t),
+    ]
+
+
+class _Sync(ctypes.Structure):
+    _fields_ = [
+        ("freq_offset", ctypes.c_float),
+        ("psmi", ctypes.c_int),
     ]
 
 
@@ -542,6 +550,7 @@ class _HEREImage(ctypes.Structure):
 class _EventUnion(ctypes.Union):
     _fields_ = [
         ("iq", _IQ),
+        ("sync", _Sync),
         ("mer", _MER),
         ("ber", _BER),
         ("hdc", _HDC),
@@ -625,6 +634,9 @@ class NRSC5:
         if evt_type == EventType.IQ:
             iq = c_evt.u.iq
             evt = IQ(iq.data[:iq.count])
+        elif evt_type == EventType.SYNC:
+            sync = c_evt.u.sync
+            evt = Sync(sync.freq_offset, sync.psmi)
         elif evt_type == EventType.MER:
             mer = c_evt.u.mer
             evt = MER(mer.lower, mer.upper)


### PR DESCRIPTION
As noted in #372, there is useful information in library debug messages which would be better conveyed through the API. Here I've moved over a couple of debug messages related to synchronization:

* The "CFO" message gave a rough estimate of the frequency offset. I replaced this with a more accurate calculation and put it into the `evt->sync.freq_offset` field.
* The Primary Service Mode Indicator (FM) / Service Mode Indicator (AM) are moved into the `evt->sync.psmi` field.

In the C and Python CLI applications, I logged these fields separately from the "Synchronized" log message so as not to break NRSC5-DUI's log parsing: https://github.com/markjfine/nrsc5-dui/blob/2d4908a8064bdcdf153303e36bb629de9bc677eb/nrsc5-dui.py#L305 (It really should switch to using the API!)