### PR TITLE
Set default log level to info, and log stream & packet events at the debug level

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -649,6 +649,7 @@ static int parse_args(state_t *st, int argc, char *argv[])
     st->bias_tee = 0;
     st->direct_sampling = -1;
     st->ppm_error = INT_MIN;
+    log_set_level(LOG_INFO);
 
     while ((opt = getopt_long(argc, argv, "r:w:o:t:d:p:g:ql:vH:TD:", long_opts, NULL)) != -1)
     {

--- a/src/main.c
+++ b/src/main.c
@@ -400,10 +400,10 @@ static void callback(const nrsc5_event_t *evt, void *opaque)
         }
         break;
     case NRSC5_EVENT_STREAM:
-        log_info("Stream data: port=%04X seq=%04X mime=%08X size=%d", evt->stream.port, evt->stream.seq, evt->stream.component->data.mime, evt->stream.size);
+        log_debug("Stream data: port=%04X seq=%04X mime=%08X size=%d", evt->stream.port, evt->stream.seq, evt->stream.component->data.mime, evt->stream.size);
         break;
     case NRSC5_EVENT_PACKET:
-        log_info("Packet data: port=%04X seq=%04X mime=%08X size=%d", evt->packet.port, evt->packet.seq, evt->packet.component->data.mime, evt->packet.size);
+        log_debug("Packet data: port=%04X seq=%04X mime=%08X size=%d", evt->packet.port, evt->packet.seq, evt->packet.component->data.mime, evt->packet.size);
         break;
     case NRSC5_EVENT_LOT:
         if (st->aas_files_path)

--- a/support/cli.py
+++ b/support/cli.py
@@ -42,7 +42,7 @@ class NRSC5CLI:
         parser.add_argument("-v", action="version", version="nrsc5 revision " + self.nrsc5_version)
         parser.add_argument("-q", action="store_true")
         parser.add_argument("--am", action="store_true")
-        parser.add_argument("-l", metavar="log-level", type=int, default=1)
+        parser.add_argument("-l", metavar="log-level", type=int, default=2)
         parser.add_argument("-d", metavar="device-index", type=int, default=0)
         parser.add_argument("-H", metavar="rtltcp-host")
         parser.add_argument("-p", metavar="ppm-error", type=int)

--- a/support/cli.py
+++ b/support/cli.py
@@ -270,10 +270,10 @@ class NRSC5CLI:
                                      component.data.service_data_type.name,
                                      component.data.type.name, component.data.mime.name)
         elif evt_type == nrsc5.EventType.STREAM:
-            logging.info("Stream data: port=%04X seq=%04X mime=%s size=%s",
+            logging.debug("Stream data: port=%04X seq=%04X mime=%s size=%s",
                          evt.port, evt.seq, evt.component.data.mime.name, len(evt.data))
         elif evt_type == nrsc5.EventType.PACKET:
-            logging.info("Packet data: port=%04X seq=%04X mime=%s size=%s",
+            logging.debug("Packet data: port=%04X seq=%04X mime=%s size=%s",
                          evt.port, evt.seq, evt.component.data.mime.name, len(evt.data))
         elif evt_type == nrsc5.EventType.LOT:
             time_str = evt.expiry_utc.strftime("%Y-%m-%dT%H:%M:%SZ")


### PR DESCRIPTION
Currently the C CLI defaults to the "trace" debug level (0) while the Python CLI defaults to "debug" (1).

Logging is starting to get noisy, particularly with the addition of stream & packet events in #308. The arrival of raw stream & packet data is of little interest to users; decoded data like HERE Images (#415) is far more interesting. So I think it would make sense to drop the log level for these events to "debug" (1), and make the CLI apps' default logging level "info" (2).

This change won't affect anything other than stream & packet events, since the CLI apps do not currently log anything at the "trace" or "debug" levels.

To see stream & packet events, simply use the `-l 1` argument to set the log level to "debug".