### PR TITLE
Deprecate the port field in stream/packet/LOT events

### DIFF
--- a/include/nrsc5.h
+++ b/include/nrsc5.h
@@ -425,7 +425,7 @@ struct nrsc5_event_t
             nrsc5_id3_comment_t *comments;
         } id3;
         struct {
-            uint16_t port;
+            uint16_t port;  /**< DEPRECATED: Use `component->data.port` instead */
             uint16_t seq;
             unsigned int size;
             uint32_t mime;  /**< DEPRECATED: Use `component->data.mime` instead */
@@ -434,7 +434,7 @@ struct nrsc5_event_t
             nrsc5_sig_component_t *component;
         } stream;
         struct {
-            uint16_t port;
+            uint16_t port;  /**< DEPRECATED: Use `component->data.port` instead */
             uint16_t seq;
             unsigned int size;
             uint32_t mime;  /**< DEPRECATED: Use `component->data.mime` instead */
@@ -443,7 +443,7 @@ struct nrsc5_event_t
             nrsc5_sig_component_t *component;
         } packet;
         struct {
-            uint16_t port;
+            uint16_t port;  /**< DEPRECATED: Use `component->data.port` instead */
             unsigned int lot;
             unsigned int size;
             uint32_t mime;

--- a/src/main.c
+++ b/src/main.c
@@ -400,16 +400,16 @@ static void callback(const nrsc5_event_t *evt, void *opaque)
         }
         break;
     case NRSC5_EVENT_STREAM:
-        log_debug("Stream data: port=%04X seq=%04X mime=%08X size=%d", evt->stream.port, evt->stream.seq, evt->stream.component->data.mime, evt->stream.size);
+        log_debug("Stream data: port=%04X seq=%04X mime=%08X size=%d", evt->stream.component->data.port, evt->stream.seq, evt->stream.component->data.mime, evt->stream.size);
         break;
     case NRSC5_EVENT_PACKET:
-        log_debug("Packet data: port=%04X seq=%04X mime=%08X size=%d", evt->packet.port, evt->packet.seq, evt->packet.component->data.mime, evt->packet.size);
+        log_debug("Packet data: port=%04X seq=%04X mime=%08X size=%d", evt->packet.component->data.port, evt->packet.seq, evt->packet.component->data.mime, evt->packet.size);
         break;
     case NRSC5_EVENT_LOT:
         if (st->aas_files_path)
             dump_aas_file(st, evt);
         strftime(time_str, sizeof(time_str), "%Y-%m-%dT%H:%M:%SZ", evt->lot.expiry_utc);
-        log_info("LOT file: port=%04X lot=%d name=%s size=%d mime=%08X expiry=%s", evt->lot.port, evt->lot.lot, evt->lot.name, evt->lot.size, evt->lot.mime, time_str);
+        log_info("LOT file: port=%04X lot=%d name=%s size=%d mime=%08X expiry=%s", evt->lot.component->data.port, evt->lot.lot, evt->lot.name, evt->lot.size, evt->lot.mime, time_str);
         break;
     case NRSC5_EVENT_STATION_ID:
         log_info("Country: %s, FCC facility ID: %d", evt->station_id.country_code, evt->station_id.fcc_facility_id);

--- a/src/nrsc5.c
+++ b/src/nrsc5.c
@@ -732,13 +732,13 @@ void nrsc5_report_ber(nrsc5_t *st, float cber)
     nrsc5_report(st, &evt);
 }
 
-void nrsc5_report_stream(nrsc5_t *st, uint16_t port, uint16_t seq, unsigned int size, const uint8_t *data,
+void nrsc5_report_stream(nrsc5_t *st, uint16_t seq, unsigned int size, const uint8_t *data,
                          nrsc5_sig_service_t *service, nrsc5_sig_component_t *component)
 {
     nrsc5_event_t evt;
 
     evt.event = NRSC5_EVENT_STREAM;
-    evt.stream.port = port;
+    evt.stream.port = component->data.port;
     evt.stream.seq = seq;
     evt.stream.size = size;
     evt.stream.mime = component->data.mime;
@@ -748,13 +748,13 @@ void nrsc5_report_stream(nrsc5_t *st, uint16_t port, uint16_t seq, unsigned int 
     nrsc5_report(st, &evt);
 }
 
-void nrsc5_report_packet(nrsc5_t *st, uint16_t port, uint16_t seq, unsigned int size, const uint8_t *data,
+void nrsc5_report_packet(nrsc5_t *st, uint16_t seq, unsigned int size, const uint8_t *data,
                          nrsc5_sig_service_t *service, nrsc5_sig_component_t *component)
 {
     nrsc5_event_t evt;
 
     evt.event = NRSC5_EVENT_PACKET;
-    evt.packet.port = port;
+    evt.packet.port = component->data.port;
     evt.packet.seq = seq;
     evt.packet.size = size;
     evt.packet.mime = component->data.mime;
@@ -764,14 +764,14 @@ void nrsc5_report_packet(nrsc5_t *st, uint16_t port, uint16_t seq, unsigned int 
     nrsc5_report(st, &evt);
 }
 
-void nrsc5_report_lot(nrsc5_t *st, uint16_t port, unsigned int lot, unsigned int size, uint32_t mime,
+void nrsc5_report_lot(nrsc5_t *st, unsigned int lot, unsigned int size, uint32_t mime,
                       const char *name, const uint8_t *data, struct tm *expiry_utc,
                       nrsc5_sig_service_t *service, nrsc5_sig_component_t *component)
 {
     nrsc5_event_t evt;
 
     evt.event = NRSC5_EVENT_LOT;
-    evt.lot.port = port;
+    evt.lot.port = component->data.port;
     evt.lot.lot = lot;
     evt.lot.size = size;
     evt.lot.mime = mime;

--- a/src/output.c
+++ b/src/output.c
@@ -652,14 +652,14 @@ static void process_port(output_t *st, uint16_t port_id, uint16_t seq, uint8_t *
     {
     case NRSC5_AAS_TYPE_STREAM:
     {
-        nrsc5_report_stream(st->radio, port_id, seq, len, buf, component->service_ext, component->component_ext);
+        nrsc5_report_stream(st->radio, seq, len, buf, component->service_ext, component->component_ext);
         if (component->data.mime == NRSC5_MIME_HERE_IMAGE)
             here_images_push(&st->here_images, seq, len, buf);
         break;
     }
     case NRSC5_AAS_TYPE_PACKET:
     {
-        nrsc5_report_packet(st->radio, port_id, seq, len, buf, component->service_ext, component->component_ext);
+        nrsc5_report_packet(st->radio, seq, len, buf, component->service_ext, component->component_ext);
         break;
     }
     case NRSC5_AAS_TYPE_LOT:
@@ -760,7 +760,7 @@ static void process_port(output_t *st, uint16_t port_id, uint16_t seq, uint8_t *
                 uint8_t *data = malloc(num_fragments * LOT_FRAGMENT_SIZE);
                 for (int i = 0; i < num_fragments; i++)
                     memcpy(data + i * LOT_FRAGMENT_SIZE, file->fragments[i], LOT_FRAGMENT_SIZE);
-                nrsc5_report_lot(st->radio, component->data.port, file->lot, file->size, file->mime,
+                nrsc5_report_lot(st->radio, file->lot, file->size, file->mime,
                                  file->name, data, &file->expiry_utc,
                                  component->service_ext, component->component_ext);
                 free(data);

--- a/src/private.h
+++ b/src/private.h
@@ -53,11 +53,11 @@ void nrsc5_report_mer(nrsc5_t *, float lower, float upper);
 void nrsc5_report_ber(nrsc5_t *, float cber);
 void nrsc5_report_hdc(nrsc5_t *, unsigned int program, const uint8_t *data, size_t count);
 void nrsc5_report_audio(nrsc5_t *, unsigned int program, const int16_t *data, size_t count);
-void nrsc5_report_stream(nrsc5_t *, uint16_t port, uint16_t seq, unsigned int size, const uint8_t *data,
+void nrsc5_report_stream(nrsc5_t *, uint16_t seq, unsigned int size, const uint8_t *data,
                          nrsc5_sig_service_t *service, nrsc5_sig_component_t *component);
-void nrsc5_report_packet(nrsc5_t *, uint16_t port, uint16_t seq, unsigned int size, const uint8_t *data,
+void nrsc5_report_packet(nrsc5_t *, uint16_t seq, unsigned int size, const uint8_t *data,
                          nrsc5_sig_service_t *service, nrsc5_sig_component_t *component);
-void nrsc5_report_lot(nrsc5_t *, uint16_t port, unsigned int lot, unsigned int size, uint32_t mime,
+void nrsc5_report_lot(nrsc5_t *, unsigned int lot, unsigned int size, uint32_t mime,
                       const char *name, const uint8_t *data, struct tm *expiry_utc,
                       nrsc5_sig_service_t *service, nrsc5_sig_component_t *component);
 void nrsc5_report_audio_service(nrsc5_t *, unsigned int program, unsigned int access, unsigned int type, 

--- a/support/cli.py
+++ b/support/cli.py
@@ -271,14 +271,14 @@ class NRSC5CLI:
                                      component.data.type.name, component.data.mime.name)
         elif evt_type == nrsc5.EventType.STREAM:
             logging.debug("Stream data: port=%04X seq=%04X mime=%s size=%s",
-                         evt.port, evt.seq, evt.component.data.mime.name, len(evt.data))
+                         evt.component.data.port, evt.seq, evt.component.data.mime.name, len(evt.data))
         elif evt_type == nrsc5.EventType.PACKET:
             logging.debug("Packet data: port=%04X seq=%04X mime=%s size=%s",
-                         evt.port, evt.seq, evt.component.data.mime.name, len(evt.data))
+                         evt.component.data.port, evt.seq, evt.component.data.mime.name, len(evt.data))
         elif evt_type == nrsc5.EventType.LOT:
             time_str = evt.expiry_utc.strftime("%Y-%m-%dT%H:%M:%SZ")
             logging.info("LOT file: port=%04X lot=%s name=%s size=%s mime=%s expiry=%s",
-                         evt.port, evt.lot, evt.name, len(evt.data), evt.mime.name, time_str)
+                         evt.component.data.port, evt.lot, evt.name, len(evt.data), evt.mime.name, time_str)
             if self.args.dump_aas_files:
                 path = os.path.join(self.args.dump_aas_files, evt.name)
                 with open(path, "wb") as file:

--- a/support/nrsc5.py
+++ b/support/nrsc5.py
@@ -707,18 +707,18 @@ class NRSC5:
             stream = c_evt.u.stream
             service = self.services[stream.service.contents.number]
             component = self.components[(stream.service.contents.number, stream.component.contents.id)]
-            evt = STREAM(stream.port, stream.seq, MIMEType(component.data.mime), stream.data[:stream.size], service, component)
+            evt = STREAM(component.data.port, stream.seq, MIMEType(component.data.mime), stream.data[:stream.size], service, component)
         elif evt_type == EventType.PACKET:
             packet = c_evt.u.packet
             service = self.services[packet.service.contents.number]
             component = self.components[(packet.service.contents.number, packet.component.contents.id)]
-            evt = PACKET(packet.port, packet.seq, MIMEType(component.data.mime), packet.data[:packet.size], service, component)
+            evt = PACKET(component.data.port, packet.seq, MIMEType(component.data.mime), packet.data[:packet.size], service, component)
         elif evt_type == EventType.LOT:
             lot = c_evt.u.lot
             service = self.services[lot.service.contents.number]
             component = self.components[(lot.service.contents.number, lot.component.contents.id)]
             expiry_time = self._timestruct_to_datetime(lot.expiry_utc)
-            evt = LOT(lot.port, lot.lot, MIMEType(lot.mime), self._decode(lot.name), lot.data[:lot.size], expiry_time, service, component)
+            evt = LOT(component.data.port, lot.lot, MIMEType(lot.mime), self._decode(lot.name), lot.data[:lot.size], expiry_time, service, component)
         elif evt_type == EventType.SIS:
             sis = c_evt.u.sis
 


### PR DESCRIPTION
After the addition of `service` and `component` fields in #414, the `port` field in stream, packet, and LOT events is now redundant. Thus, I think it would make sense to deprecate it and suggest `component->data.port` as a replacement.