### PR TITLE
Don't report duplicate HERE images

### DIFF
--- a/src/here_images.h
+++ b/src/here_images.h
@@ -4,6 +4,7 @@
 #include <nrsc5.h>
 
 #define MAX_PAYLOAD_BYTES (65536 + 2)
+#define HERE_TRAFFIC_TILES 9
 
 typedef struct
 {
@@ -13,6 +14,7 @@ typedef struct
     int expected_seq;
     int payload_len;
     uint64_t sync_state;
+    unsigned int last_timestamp[1 + HERE_TRAFFIC_TILES];
 } here_images_t;
 
 void here_images_push(here_images_t *st, uint16_t seq, unsigned int len, uint8_t *buf);


### PR DESCRIPTION
This is a follow-up to #415.

HERE images are sometimes sent multiple times. In other parts of the API we avoid reporting duplicate data, and I think we should do so here as well. This could help to avoid race conditions where HERE data is read while being overwritten by a duplicate copy.

FYI @markjfine 