### PR TITLE
Refactor LOT LRU counter

### DIFF
--- a/src/output.c
+++ b/src/output.c
@@ -145,6 +145,7 @@ static void aas_reset(output_t *st)
                     aas_free_lot(&component->data.lot_files[k]);
         }
     }
+    st->lot_lru_counter = 1;
 
     memset(st->services, 0, sizeof(st->services));
     nrsc5_clear_sig(st->radio);
@@ -632,7 +633,6 @@ static aas_file_t *find_free_lot(sig_component_t *component)
 
 static void process_port(output_t *st, uint16_t port_id, uint16_t seq, uint8_t *buf, unsigned int len)
 {
-    static unsigned int counter = 1;
     sig_component_t *component;
 
     if (st->services[0].type == SIG_SERVICE_NONE)
@@ -695,7 +695,7 @@ static void process_port(output_t *st, uint16_t port_id, uint16_t seq, uint8_t *
             file->lot = lot;
             file->fragments = calloc(MAX_LOT_FRAGMENTS, sizeof(uint8_t*));
         }
-        file->timestamp = counter++;
+        file->timestamp = st->lot_lru_counter++;
 
         int new_data = 0;
 
@@ -739,7 +739,7 @@ static void process_port(output_t *st, uint16_t port_id, uint16_t seq, uint8_t *
                     aas_free_lot(file);
                     file->lot = lot;
                     file->fragments = calloc(MAX_LOT_FRAGMENTS, sizeof(uint8_t*));
-                    file->timestamp = counter;
+                    file->timestamp = st->lot_lru_counter;
                     new_data = 1;
                 }
             }

--- a/src/output.h
+++ b/src/output.h
@@ -98,6 +98,7 @@ typedef struct
     int16_t silence[NRSC5_AUDIO_FRAME_SAMPLES * 2];
 #endif
     sig_service_t services[MAX_SIG_SERVICES];
+    unsigned int lot_lru_counter;
     here_images_t here_images;
 } output_t;
 


### PR DESCRIPTION
libnrsc5's LOT receiver can track up to 12 simultaneous file downloads per port. When a new LOT ID is seen, the least-recently-used LOT id is removed from the table of in-progress downloads to make space for a new one.

Currently, a static variable (`counter`) is incremented each time a LOT fragment arrives, and its value is stored in the corresponding LOT file struct. This value is used to determine which LOT ID is the least recently used. Unfortunately the static variable is shared across all `nrsc5_t` instances. Using a static variable without synchronization could lead to Undefined Behaviour in multi-threaded programs. To solve the problem, I propose to replace the static variable with a member variable in the `output_t` struct, which will be separate for each `nrsc5_t` instance.