### PR TITLE
Report AGC status in an API event

### DIFF
--- a/include/nrsc5.h
+++ b/include/nrsc5.h
@@ -183,7 +183,8 @@ enum
     NRSC5_EVENT_EMERGENCY_ALERT,
     NRSC5_EVENT_HERE_IMAGE,
     NRSC5_EVENT_LOT_HEADER,
-    NRSC5_EVENT_LOT_FRAGMENT
+    NRSC5_EVENT_LOT_FRAGMENT,
+    NRSC5_EVENT_AGC
 };
 
 enum
@@ -382,6 +383,7 @@ struct nrsc5_event_t
  * - `NRSC5_EVENT_DATA_SERVICE_DESCRIPTOR` : SIS data service descriptor, see `dsd` member
  * - `NRSC5_EVENT_EMERGENCY_ALERT` : emergency alert, see `emergency_alert` member
  * - `NRSC5_EVENT_HERE_IMAGE` : HERE Images traffic/weather map, see `here_image` member
+ * - `NRSC5_EVENT_AGC` : automatic gain control status, see `agc` member
  */
     unsigned int event;
     union
@@ -554,6 +556,11 @@ struct nrsc5_event_t
             unsigned int size;   /**< size of image file, in bytes */
             const uint8_t *data; /**< contents of image file */
         } here_image;
+        struct {
+            float gain_db;       /**< SDR gain value in dB */
+            float peak_dbfs;     /**< peak signal amplitude in dB, relative to full scale */
+            int is_final;        /**< 1 if this is the final (best) gain value, otherwise 0 */
+        } agc;
     };
 };
 /**

--- a/src/main.c
+++ b/src/main.c
@@ -320,6 +320,12 @@ static void callback(const nrsc5_event_t *evt, void *opaque)
     case NRSC5_EVENT_LOST_DEVICE:
         done_signal(st);
         break;
+    case NRSC5_EVENT_AGC:
+        if (evt->agc.is_final)
+            log_info("Best gain: %.1f dB, Peak amplitude: %.1f dBFS", evt->agc.gain_db, evt->agc.peak_dbfs);
+        else
+            log_debug("Gain: %.1f dB, Peak amplitude: %.1f dBFS", evt->agc.gain_db, evt->agc.peak_dbfs);
+        break;
     case NRSC5_EVENT_BER:
         dump_ber(evt->ber.cber);
         break;

--- a/src/nrsc5.c
+++ b/src/nrsc5.c
@@ -82,7 +82,7 @@ static int do_auto_gain(nrsc5_t *st)
         }
 
         float amplitude_db = 20 * log10f((max_sample - min_sample + 1) / 256.0f);
-        log_debug("Gain: %.1f dB, Peak amplitude: %.1f dBFS", gain / 10.0f, amplitude_db);
+        nrsc5_report_agc(st, gain / 10.0f, amplitude_db, 0);
 
         if (amplitude_db < -6.0f)
         {
@@ -102,7 +102,7 @@ static int do_auto_gain(nrsc5_t *st)
         }
     }
 
-    log_debug("Best gain: %.1f dB, Peak amplitude: %.1f dBFS", best_gain / 10.0f, best_amplitude_db);
+    nrsc5_report_agc(st, best_gain / 10.0f, best_amplitude_db, 1);
     st->gain = best_gain;
     set_tuner_gain(st, best_gain);
     ret = 0;
@@ -660,6 +660,17 @@ void nrsc5_report_lost_device(nrsc5_t *st)
     nrsc5_event_t evt;
 
     evt.event = NRSC5_EVENT_LOST_DEVICE;
+    nrsc5_report(st, &evt);
+}
+
+void nrsc5_report_agc(nrsc5_t *st, float gain_db, float peak_dbfs, int is_final)
+{
+    nrsc5_event_t evt;
+
+    evt.event = NRSC5_EVENT_AGC;
+    evt.agc.gain_db = gain_db;
+    evt.agc.peak_dbfs = peak_dbfs;
+    evt.agc.is_final = is_final;
     nrsc5_report(st, &evt);
 }
 

--- a/src/private.h
+++ b/src/private.h
@@ -46,6 +46,7 @@ struct nrsc5_t
 
 void nrsc5_report(nrsc5_t *, const nrsc5_event_t *evt);
 void nrsc5_report_lost_device(nrsc5_t *st);
+void nrsc5_report_agc(nrsc5_t *st, float gain_db, float peak_dbfs, int is_final);
 void nrsc5_report_iq(nrsc5_t *, const void *data, size_t count);
 void nrsc5_report_sync(nrsc5_t *, float freq_offset, int psmi);
 void nrsc5_report_lost_sync(nrsc5_t *);

--- a/support/cli.py
+++ b/support/cli.py
@@ -200,6 +200,11 @@ class NRSC5CLI:
             logging.info("Lost device")
             with self.device_condition:
                 self.device_condition.notify()
+        elif evt_type == nrsc5.EventType.AGC:
+            if evt.is_final:
+                logging.info("Best gain: %.1f dB, Peak amplitude: %.1f dBFS", evt.gain_db, evt.peak_dbfs)
+            else:
+                logging.debug("Gain: %.1f dB, Peak amplitude: %.1f dBFS", evt.gain_db, evt.peak_dbfs)
         elif evt_type == nrsc5.EventType.IQ:
             if self.args.w:
                 self.iq_output.write(evt.data)


### PR DESCRIPTION
Partially addresses #372.

Information about RTL-SDR automatic gain selection is only reported via library debug messages. Client applications are interested in this information, so it would make sense to expose it through an API event instead.

I've updated the C and Python CLI applications to display the best gain value at the "info" level, and the intermediate gain values at the "debug" level. (Use the `-l 1` argument to see them.)

```
19:43:56 Gain: 25.4 dB, Peak amplitude: -12.7 dBFS
19:43:56 Gain: 38.6 dB, Peak amplitude: 0.0 dBFS
19:43:56 Gain: 32.8 dB, Peak amplitude: -6.0 dBFS
19:43:56 Gain: 28.0 dB, Peak amplitude: -9.6 dBFS
19:43:56 Gain: 29.7 dB, Peak amplitude: -8.5 dBFS
19:43:56 Best gain: 29.7 dB, Peak amplitude: -8.5 dBFS
```