### PR TITLE
Fix off-by-one error in EAS length checks

### DIFF
--- a/src/pids.c
+++ b/src/pids.c
@@ -207,7 +207,7 @@ static void decode_control_data(const char *control_data, int len, int *category
 
     for (int i = 0; i < *num_locations; i++)
     {
-        if (off + 1 >= len*8)
+        if (off + 1 > len*8)
         {
             log_warn("Invalid location data");
             return;
@@ -216,7 +216,7 @@ static void decode_control_data(const char *control_data, int len, int *category
         if ((i == 0) || bits[off++])
         {
             // Full-length location
-            if (off + full_len >= len*8)
+            if (off + full_len > len*8)
             {
                 log_warn("Invalid location data");
                 return;
@@ -226,7 +226,7 @@ static void decode_control_data(const char *control_data, int len, int *category
         else
         {
             // Compressed location
-            if (off + compressed_len >= len*8)
+            if (off + compressed_len > len*8)
             {
                 log_warn("Invalid location data");
                 return;


### PR DESCRIPTION
Partially addresses #454.

The root cause of the crash @TheDaChicken encountered in #454 is that the bounds checks in the EAS location decoder are off by one. If the location data occupies all control data bits, then the final bounds check incorrectly fails, preventing the location data from being reported.

The crash revealed a second issue: if the control data were in fact invalid and a bounds check legitimately failed, then `decode_control_data` exits early and does not return a pointer to an array of locations. But it does return the decoded `num_locations` value, and so the API client fails when it attempts to read the non-existent array. I'll think about how best to solve this and open a follow-up PR.