### PR TITLE
Report emergency_alert.num_locations=0 if location decoding fails

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -480,16 +480,17 @@ static void callback(const nrsc5_event_t *evt, void *opaque)
             switch (evt->emergency_alert.location_format)
             {
             case NRSC5_LOCATION_FORMAT_SAME:
-                strcat(alert_details, "SAME=[");
+                strcat(alert_details, "SAME=");
                 break;
             case NRSC5_LOCATION_FORMAT_FIPS:
-                strcat(alert_details, "FIPS=[");
+                strcat(alert_details, "FIPS=");
                 break;
             case NRSC5_LOCATION_FORMAT_ZIP:
-                strcat(alert_details, "ZIP=[");
+                strcat(alert_details, "ZIP=");
                 break;
             }
 
+            strcat(alert_details, "[");
             for (i = 0; i < evt->emergency_alert.num_locations; i++)
             {
                 if (i > 0)


### PR DESCRIPTION
Resolves #454.

As noted in #455, if `decode_control_data` fails to decode an emergency alert's location codes, it leaves `num_locations` set to a non-zero value while failing to provide a `locations` array. This situation can cause crashes in API clients.

To solve the problem, I modified `decode_control_data` to set `num_locations` to zero (and `locations` to NULL) if location decoding fails for any reason.

I also split location decoding into its own function, and modified the C API client to provide cleaner output in the case that the location format is an unknown value.