### PR TITLE
Check that string lengths match before memcmp

### DIFF
--- a/src/output.c
+++ b/src/output.c
@@ -726,7 +726,8 @@ static void process_port(output_t *st, uint16_t port_id, uint16_t seq, uint8_t *
 
             if (file->name)
             {
-                if ((memcmp(buf, file->name, hdrlen) != 0)
+                if ((hdrlen != strlen(file->name))
+                    || (memcmp(buf, file->name, hdrlen) != 0)
                     || (size != file->size)
                     || (mime != file->mime)
                     || (year != file->expiry_utc.tm_year)


### PR DESCRIPTION
While fuzz-testing AAS parsing, the following crash occurred:

```
==2397507==ERROR: AddressSanitizer: heap-buffer-overflow on address 0x5030000053c3 at pc 0x5f504627f036 bp 0x75810a122c60 sp 0x75810a122408
READ of size 119 at 0x5030000053c3 thread T1
    #0 0x5f504627f035 in MemcmpInterceptorCommon(void*, int (*)(void const*, void const*, unsigned long), void const*, void const*, unsigned long) (/home/argilo/git/nrsc5/build-asan/src/nrsc5+0x121035) (BuildId: 0c43535d347cef03852ba19135b41ef676f3b3ab)
    #1 0x5f504627f480 in bcmp (/home/argilo/git/nrsc5/build-asan/src/nrsc5+0x121480) (BuildId: 0c43535d347cef03852ba19135b41ef676f3b3ab)
    #2 0x5f504636231e in process_port /home/argilo/git/nrsc5/src/output.c:729:22
    #3 0x5f504635c08d in output_aas_push /home/argilo/git/nrsc5/src/output.c:839:9
    #4 0x5f50463a911d in parse_hdlc /home/argilo/git/nrsc5/src/frame.c:382:17
    #5 0x5f50463a30c4 in process_fixed_block /home/argilo/git/nrsc5/src/frame.c:450:5
    #6 0x5f50463a30c4 in process_fixed_data /home/argilo/git/nrsc5/src/frame.c:512:17
    #7 0x5f50463a30c4 in frame_process /home/argilo/git/nrsc5/src/frame.c:527:21
    #8 0x5f504639903f in decode_process_p1 /home/argilo/git/nrsc5/src/decode.c:294:5
    #9 0x5f50463799dc in sync_process_fm /home/argilo/git/nrsc5/src/sync.c:535:21
    #10 0x5f504639363b in acquire_process /home/argilo/git/nrsc5/src/acquire.c:256:9
    #11 0x5f504636ff47 in input_push /home/argilo/git/nrsc5/src/input.c:72:9
    #12 0x5f50463716da in input_push_cu8 /home/argilo/git/nrsc5/src/input.c:123:5
    #13 0x5f50463561c5 in worker_thread /home/argilo/git/nrsc5/src/nrsc5.c:190:21
    #14 0x5f50462fb0fc in asan_thread_start(void*) asan_interceptors.cpp.o
    #15 0x75810ec9caa3 in start_thread nptl/pthread_create.c:447:8
    #16 0x75810ed29c6b in clone3 misc/../sysdeps/unix/sysv/linux/x86_64/clone3.S:78
```

The root cause is that the `memcmp` that compares the LOT header's filename against the previous filename is done without first verifying whether the lengths of the two strings are equal. As a result, the `memcmp` can overrun `file->name`. Here I've added the missing length check.