### PR TITLE
Update minimum CMake version to 3.10

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,5 +1,5 @@
-cmake_minimum_required (VERSION 3.5)
-cmake_policy (VERSION 3.5...3.28)
+cmake_minimum_required (VERSION 3.10)
+cmake_policy (VERSION 3.10...3.28)
 include (CheckLibraryExists)
 include (CheckSymbolExists)
 include (ExternalProject)


### PR DESCRIPTION
Fixes #466.

CMake 3.10 was released in November 2017, so it should be safe to require it.