### PR TITLE
Install DLL to /bin

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -116,6 +116,7 @@ endif ()
 
 install (
     TARGETS nrsc5 nrsc5_static
+    RUNTIME DESTINATION bin
     LIBRARY DESTINATION lib
     ARCHIVE DESTINATION lib
     PUBLIC_HEADER DESTINATION include


### PR DESCRIPTION
@TheDaChicken noticed that libnrsc5.dll is no longer installed to the correct directory. This is because `RUNTIME DESTINATION bin` was removed from the library targets in #442, but DLL targets are in fact RUNTIME targets (as explained in https://cmake.org/cmake/help/latest/command/install.html).

To solve the problem, I've added back the removed line.