### PR TITLE
Find the path of faad2_hdc

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -220,14 +220,24 @@ endif ()
 if (USE_FAAD2)
     # use patched faad if installed
     if (INSTALLED_FAAD_IS_PATCHED)
-        pkg_search_module(FAAD2 faad2)
+        message(STATUS "Try using patched system-provided FAAD2 library")
+        pkg_search_module(PC_FAAD2 QUIET faad2)
+
+        find_path(FAAD2_INCLUDE_DIRS neaacdec.h
+                HINTS ${PC_FAAD2_INCLUDEDIR} ${PC_FAAD2_INCLUDE_DIRS})
+
+        # use the libfaad_hdc.a, not libfaad as specified in pkg-config file
+        find_library(FAAD2_LIBRARIES NAMES faad_hdc
+                HINTS ${PC_FAAD2_LIBDIR} ${PC_FAAD2_LIBRARY_DIRS} )
+
+        if (FAAD2_INCLUDE_DIRS AND FAAD2_LIBRARY)
+            set(FAAD2_FOUND ON)
+        else ()
+            message (WARNING "FAAD2 patched not found. Building from source.")
+        endif()
     endif()
 
-    if (INSTALLED_FAAD_IS_PATCHED AND FAAD2_FOUND)
-        message(STATUS "Using patched system-provided FAAD2 library")
-        set(FAAD2_LIBRARIES faad_hdc) # use the libfaad_hdc.a, not libfaad as specified in pkg-config file
-        add_definitions(-DHAVE_FAAD2)
-    else()
+    if (NOT FAAD2_FOUND)
         set (FAAD2_PREFIX "${CMAKE_BINARY_DIR}/faad2-prefix")
         ExternalProject_Add (
             faad2_external
@@ -254,8 +264,12 @@ if (USE_FAAD2)
 
         set (FAAD2_INCLUDE_DIRS "${FAAD2_PREFIX}/include")
         set (FAAD2_LIBRARIES faad2)
-        add_definitions (-DHAVE_FAAD2)
         set (FAAD2_BUILTIN faad2)
+        set (FAAD2_FOUND ON)
+    endif()
+
+    if (FAAD2_FOUND)
+        add_definitions (-DHAVE_FAAD2)
     endif()
 else ()
     # we only use libao with faad2


### PR DESCRIPTION
Whenever I wanted to make changes to HDC patch, I had to save it as a patch and let cmake recompile it.

`INSTALLED_FAAD_IS_PATCHED` option has made it easier. Currently, it assumes that the linker will find faad_hdc. I cannot provide a location if the linker cannot find it. 

You would normally provide a cmake find module file. Currently nrsc5's cmake relies on only pkgconfig. I think switching to cmake find module files would be a separate PR I think. 