### PR TITLE
Only report ID3 when the content changes

### DIFF
--- a/src/output.c
+++ b/src/output.c
@@ -207,6 +207,9 @@ void output_reset(output_t *st)
 
     for (int i = 0; i < MAX_PROGRAMS; i++)
     {
+        free(st->last_psd[i]);
+        st->last_psd[i] = NULL;
+        st->last_psd_len[i] = 0;
         for (int j = 0; j < MAX_STREAMS; j++)
         {
             for (int k = 0; k < ELASTIC_BUFFER_LEN; k++)
@@ -286,6 +289,18 @@ static void output_id3(output_t *st, unsigned int program, uint8_t *buf, unsigne
 
     evt.event = NRSC5_EVENT_ID3;
     evt.id3.comments = NULL;
+
+    if ((len == st->last_psd_len[program]) && (memcmp(buf, st->last_psd[program], len) == 0))
+    {
+        return;
+    }
+    else
+    {
+        free(st->last_psd[program]);
+        st->last_psd_len[program] = len;
+        st->last_psd[program] = malloc(len);
+        memcpy(st->last_psd[program], buf, len);
+    }
 
     if (len < 10 || memcmp(buf, "ID3\x03\x00", 5) || buf[5]) return;
     id3_len = id3_length(buf + 6) + 10;

--- a/src/output.h
+++ b/src/output.h
@@ -120,6 +120,8 @@ typedef struct
 {
     nrsc5_t *radio;
     elastic_buffer_t elastic[MAX_PROGRAMS][MAX_STREAMS];
+    uint8_t *last_psd[MAX_PROGRAMS];
+    unsigned int last_psd_len[MAX_PROGRAMS];
 #ifdef HAVE_FAAD2
     NeAACDecHandle aacdec[MAX_PROGRAMS];
     int16_t silence[NRSC5_AUDIO_FRAME_SAMPLES * 2];


### PR DESCRIPTION
Fixes #429.

In general, libnrsc5 reports events only when the corresponding data values change. This avoids burdening applications with duplicate events, and cuts down on the amount of information that the command-line applications log.

But until now, ID3 events did not get this treatment. Every ID3 tag in the PSD stream was reported, even if it was the same as the last one. In some cases, multiple events were reported back-to-back because a single PDU can contain multiple ID3 tags.

Here I've changed libnrsc5 so that it only reports ID3 events when the PSD data changes. This roughly halves the amount of information logged by the command-line applications.