### PR TITLE
In MA1 mode, delay the P3 logical channel to match P1

### DIFF
--- a/src/decode.c
+++ b/src/decode.c
@@ -43,7 +43,7 @@ static int bit_map(unsigned char matrix[PARTITION_WIDTH_AM * BLKSZ * 8], int b, 
 static void interleaver_ma1(decode_t *st)
 {
     int b, k, p;
-    for (int n = 0; n < 18000; n++)
+    for (int n = 0; n < BL_LENGTH; n++)
     {
         b = n/2250;
         k = (n + n/750 + 1) % 750;
@@ -53,7 +53,7 @@ static void interleaver_ma1(decode_t *st)
         b = (3*n + 3) % 8;
         k = (n + n/3000 + 3) % 750;
         p = 3 + (n % 3);
-        st->ml[DIVERSITY_DELAY_AM + n] = bit_map(st->buffer_pl, b, k, p);
+        st->ml[ML_LENGTH * DIVERSITY_DELAY_AM + n] = bit_map(st->buffer_pl, b, k, p);
 
         b = n/2250;
         k = (n + n/750) % 750;
@@ -63,29 +63,29 @@ static void interleaver_ma1(decode_t *st)
         b = (3*n) % 8;
         k = (n + n/3000 + 2) % 750;
         p = 3 + (n % 3);
-        st->mu[DIVERSITY_DELAY_AM + n] = bit_map(st->buffer_pu, b, k, p);
+        st->mu[MU_LENGTH * DIVERSITY_DELAY_AM + n] = bit_map(st->buffer_pu, b, k, p);
     }
 
     if (st->input->sync.psmi != SERVICE_MODE_MA3)
     {
-        for (int n = 0; n < 12000; n++)
+        for (int n = 0; n < EL_LENGTH; n++)
         {
             b = (3*n + n/3000) % 8;
             k = (n + (n/6000)) % 750;
             p = n % 2;
-            st->el[n] = bit_map(st->buffer_t, b, k, p);
+            st->el[EL_LENGTH * DIVERSITY_DELAY_AM + n] = bit_map(st->buffer_t, b, k, p);
         }
-        for (int n = 0; n < 24000; n++)
+        for (int n = 0; n < EU_LENGTH; n++)
         {
             b = (3*n + n/3000 + 2*(n/12000)) % 8;
             k = (n + (n/6000)) % 750;
             p = n % 4;
-            st->eu[n] = bit_map(st->buffer_s, b, k, p);
+            st->eu[EU_LENGTH * DIVERSITY_DELAY_AM + n] = bit_map(st->buffer_s, b, k, p);
         }
     }
     else
     {
-        for (int n = 0; n < 18000; n++)
+        for (int n = 0; n < EBL_LENGTH; n++)
         {
             b = (3*n + 3) % 8;
             k = (n + n/3000 + 3) % 750;
@@ -95,7 +95,7 @@ static void interleaver_ma1(decode_t *st)
             b = (3*n + 3) % 8;
             k = (n + n/3000 + 3) % 750;
             p = 3 + (n % 3);
-            st->eml[DIVERSITY_DELAY_AM + n] = bit_map(st->buffer_t, b, k, p);
+            st->eml[EML_LENGTH * DIVERSITY_DELAY_AM + n] = bit_map(st->buffer_t, b, k, p);
 
             b = (3*n) % 8;
             k = (n + n/3000 + 2) % 750;
@@ -105,7 +105,7 @@ static void interleaver_ma1(decode_t *st)
             b = (3*n) % 8;
             k = (n + n/3000 + 2) % 750;
             p = 3 + (n % 3);
-            st->emu[DIVERSITY_DELAY_AM + n] = bit_map(st->buffer_s, b, k, p);
+            st->emu[EMU_LENGTH * DIVERSITY_DELAY_AM + n] = bit_map(st->buffer_s, b, k, p);
         }
     }
 
@@ -141,12 +141,17 @@ static void interleaver_ma1(decode_t *st)
         }
     }
 
-    memmove(st->ml, st->ml + 18000, DIVERSITY_DELAY_AM);
-    memmove(st->mu, st->mu + 18000, DIVERSITY_DELAY_AM);
-    if (st->input->sync.psmi == SERVICE_MODE_MA3)
+    memmove(st->ml, st->ml + ML_LENGTH, ML_LENGTH * DIVERSITY_DELAY_AM);
+    memmove(st->mu, st->mu + MU_LENGTH, MU_LENGTH * DIVERSITY_DELAY_AM);
+    if (st->input->sync.psmi != SERVICE_MODE_MA3)
     {
-        memmove(st->eml, st->eml + 18000, DIVERSITY_DELAY_AM);
-        memmove(st->emu, st->emu + 18000, DIVERSITY_DELAY_AM);
+        memmove(st->el, st->el + EL_LENGTH, EL_LENGTH * DIVERSITY_DELAY_AM);
+        memmove(st->eu, st->eu + EU_LENGTH, EU_LENGTH * DIVERSITY_DELAY_AM);
+    }
+    else
+    {
+        memmove(st->eml, st->eml + EML_LENGTH, EML_LENGTH * DIVERSITY_DELAY_AM);
+        memmove(st->emu, st->emu + EMU_LENGTH, EMU_LENGTH * DIVERSITY_DELAY_AM);
     }
 
     int offset = 0;

--- a/src/decode.h
+++ b/src/decode.h
@@ -4,7 +4,17 @@
 #include "defines.h"
 #include "pids.h"
 
-#define DIVERSITY_DELAY_AM (18000 * 3)
+#define DIVERSITY_DELAY_AM 3
+#define BL_LENGTH 18000
+#define BU_LENGTH 18000
+#define ML_LENGTH 18000
+#define MU_LENGTH 18000
+#define EL_LENGTH 12000
+#define EU_LENGTH 24000
+#define EBL_LENGTH 18000
+#define EBU_LENGTH 18000
+#define EML_LENGTH 18000
+#define EMU_LENGTH 18000
 
 typedef struct
 {
@@ -34,16 +44,16 @@ typedef struct
     unsigned int am_errors;
     unsigned int am_diversity_wait;
 
-    uint8_t bl[18000];
-    uint8_t bu[18000];
-    uint8_t ml[18000 + DIVERSITY_DELAY_AM];
-    uint8_t mu[18000 + DIVERSITY_DELAY_AM];
-    uint8_t el[12000];
-    uint8_t eu[24000];
-    uint8_t ebl[18000];
-    uint8_t ebu[18000];
-    uint8_t eml[18000 + DIVERSITY_DELAY_AM];
-    uint8_t emu[18000 + DIVERSITY_DELAY_AM];
+    uint8_t bl[BL_LENGTH];
+    uint8_t bu[BU_LENGTH];
+    uint8_t ml[ML_LENGTH * (1 + DIVERSITY_DELAY_AM)];
+    uint8_t mu[MU_LENGTH * (1 + DIVERSITY_DELAY_AM)];
+    uint8_t el[EL_LENGTH * (1 + DIVERSITY_DELAY_AM)];
+    uint8_t eu[EU_LENGTH * (1 + DIVERSITY_DELAY_AM)];
+    uint8_t ebl[EBL_LENGTH];
+    uint8_t ebu[EBU_LENGTH];
+    uint8_t eml[EML_LENGTH * (1 + DIVERSITY_DELAY_AM)];
+    uint8_t emu[EMU_LENGTH * (1 + DIVERSITY_DELAY_AM)];
 
     int8_t viterbi_p1[P1_FRAME_LEN_FM * 3];
     uint8_t scrambler_p1[P1_FRAME_LEN_FM];


### PR DESCRIPTION
In service mode MA1, a diversity delay of 3 frames is applied to the P1 logical channel (specifically targeting the BL and BU subframes on the transmit side). As a result, the P1 logical channel has an additional 3 frames of latency and the receiver must delay the ML and MU subframes before deinterleaving so that all subframes have a combined (TX + RX) delay of exactly 3 frames.

The P3 logical channel does not have a diversity delay. To keep the received data aligned with the P1 logical channel (so that the core & enhanced streams can be coherently combined), it is necessary to apply an additional 3-frame delay in the receiver. I've accomplished that here by applying a 3-frame delay to the EL and EU subframes that carry the P3 logical channel.

No change is required for service mode MA3, because its P3 logical channel already has a 3-frame delay applied to the EML and EMU subframes, complementing the transmitter's 3-frame delays to the EBL and EBU subframes.