### PR TITLE
Align FFTW input and output arrays

### DIFF
--- a/src/acquire.c
+++ b/src/acquire.c
@@ -311,6 +311,8 @@ void acquire_init(acquire_t *st, input_t *input)
     st->filter_am = firdecim_q15_create(filter_taps_am, sizeof(filter_taps_am) / sizeof(filter_taps_am[0]));
 
     pthread_mutex_lock(&fftw_mutex);
+    st->fftin = fftwf_alloc_complex(FFT_FM);
+    st->fftout = fftwf_alloc_complex(FFT_FM);
     st->fft_plan_fm = fftwf_plan_dft_1d(FFT_FM, st->fftin, st->fftout, FFTW_FORWARD, FFTW_ESTIMATE);
     st->fft_plan_am = fftwf_plan_dft_1d(FFT_AM, st->fftin, st->fftout, FFTW_FORWARD, FFTW_ESTIMATE);
     pthread_mutex_unlock(&fftw_mutex);
@@ -370,5 +372,7 @@ void acquire_free(acquire_t *st)
     pthread_mutex_lock(&fftw_mutex);
     fftwf_destroy_plan(st->fft_plan_fm);
     fftwf_destroy_plan(st->fft_plan_am);
+    fftwf_free(st->fftin);
+    fftwf_free(st->fftout);
     pthread_mutex_unlock(&fftw_mutex);
 }

--- a/src/acquire.h
+++ b/src/acquire.h
@@ -12,8 +12,8 @@ typedef struct
     cint16_t in_buffer[FFTCP_FM * (ACQUIRE_SYMBOLS + 1)];
     float complex buffer[FFTCP_FM * (ACQUIRE_SYMBOLS + 1)];
     float complex sums[FFTCP_FM];
-    float complex fftin[FFT_FM];
-    float complex fftout[FFT_FM];
+    float complex *fftin;
+    float complex *fftout;
     float *shape;
     float shape_fm[FFTCP_FM];
     float shape_am[FFTCP_AM];


### PR DESCRIPTION
While reviewing #481, I noticed small changes in nrsc5's output when changes were made to the `input_t` struct. The reason for this behaviour is that FFTW uses SIMD-optimized transforms when its input and output arrays are aligned:

https://www.fftw.org/fftw3_doc/SIMD-alignment-and-fftw_005fmalloc.html

The FFTW documentation recommends using its memory allocation functions to guarantee the correct alignment. With this change, I measured a performance improvement of approximately 6%.