### PR TITLE
Add AM system control values to the API and CLI apps

### DIFF
--- a/include/nrsc5.h
+++ b/include/nrsc5.h
@@ -402,6 +402,10 @@ struct nrsc5_event_t
         struct {
             float freq_offset; /**< Frequency offset in Hz */
             int psmi;          /**< Primary Service Mode Indicator (1, 2, 3, 5, 6, or 11 for FM; 1 or 2 for AM) */
+            int pli;           /**< Power Level Indicator (AM only; set to -1 for FM) */
+            int hppi;          /**< High-Power PIDS Indicator (AM only; set to -1 for FM) */
+            int aabi;          /**< Analog Audio Bandwidth Indicator (AM only; set to -1 for FM) */
+            int rdbi;          /**< Reduced Digital Bandwidth Indicator (AM only; set to -1 for FM) */
         } sync;
         struct {
             float cber;

--- a/src/input.c
+++ b/src/input.c
@@ -181,7 +181,7 @@ void input_set_sync_state(input_t *st, unsigned int new_state)
         float freq_offset = (st->acq.prev_angle - 2 * M_PI * st->acq.cfo)
                           * (st->radio->mode == NRSC5_MODE_FM ? NRSC5_SAMPLE_RATE_CS16_FM : NRSC5_SAMPLE_RATE_CS16_AM)
                           / (2 * M_PI * st->acq.fft);
-        nrsc5_report_sync(st->radio, freq_offset, st->sync.psmi);
+        nrsc5_report_sync(st->radio, freq_offset, st->sync.psmi, st->sync.pli, st->sync.hppi, st->sync.aabi, st->sync.rdbi);
     }
 
     st->sync_state = new_state;

--- a/src/main.c
+++ b/src/main.c
@@ -391,7 +391,24 @@ static void callback(const nrsc5_event_t *evt, void *opaque)
         log_info("Frequency offset: %.0f Hz", evt->sync.freq_offset);
         log_info("Primary service mode: %d", evt->sync.psmi);
         if (evt->sync.pli != -1)
-            log_info("PLI=%d, HPPI=%d, AABI=%d, RDBI=%d", evt->sync.pli, evt->sync.hppi, evt->sync.aabi, evt->sync.rdbi);
+        {
+            char am_flags[128] = "";
+            strcat(am_flags, "Digital bandwidth: ");
+            strcat(am_flags, evt->sync.rdbi ? "reduced" : "full");
+            if (!evt->sync.rdbi)
+            {
+                if (evt->sync.psmi != 2)
+                {
+                    strcat(am_flags, ", analog bandwidth: ");
+                    strcat(am_flags, evt->sync.aabi ? "8 kHz" : "5 kHz");
+                    strcat(am_flags, ", secondary/tertiary power: ");
+                    strcat(am_flags, evt->sync.pli ? "high" : "low");
+                }
+                strcat(am_flags, ", PIDS power: ");
+                strcat(am_flags, evt->sync.hppi ? "high" : "low");
+            }
+            log_info(am_flags);
+        }
         st->audio_ready = 0;
         break;
     case NRSC5_EVENT_LOST_SYNC:

--- a/src/main.c
+++ b/src/main.c
@@ -390,6 +390,8 @@ static void callback(const nrsc5_event_t *evt, void *opaque)
         log_info("Synchronized");
         log_info("Frequency offset: %.0f Hz", evt->sync.freq_offset);
         log_info("Primary service mode: %d", evt->sync.psmi);
+        if (evt->sync.pli != -1)
+            log_info("PLI=%d, HPPI=%d, AABI=%d, RDBI=%d", evt->sync.pli, evt->sync.hppi, evt->sync.aabi, evt->sync.rdbi);
         st->audio_ready = 0;
         break;
     case NRSC5_EVENT_LOST_SYNC:

--- a/src/nrsc5.c
+++ b/src/nrsc5.c
@@ -684,13 +684,17 @@ void nrsc5_report_iq(nrsc5_t *st, const void *data, size_t count)
     nrsc5_report(st, &evt);
 }
 
-void nrsc5_report_sync(nrsc5_t *st, float freq_offset, int psmi)
+void nrsc5_report_sync(nrsc5_t *st, float freq_offset, int psmi, int pli, int hppi, int aabi, int rdbi)
 {
     nrsc5_event_t evt;
 
     evt.event = NRSC5_EVENT_SYNC;
     evt.sync.freq_offset = freq_offset;
     evt.sync.psmi = psmi;
+    evt.sync.pli = pli;
+    evt.sync.hppi = hppi;
+    evt.sync.aabi = aabi;
+    evt.sync.rdbi = rdbi;
     nrsc5_report(st, &evt);
 }
 

--- a/src/private.h
+++ b/src/private.h
@@ -48,7 +48,7 @@ void nrsc5_report(nrsc5_t *, const nrsc5_event_t *evt);
 void nrsc5_report_lost_device(nrsc5_t *st);
 void nrsc5_report_agc(nrsc5_t *st, float gain_db, float peak_dbfs, int is_final);
 void nrsc5_report_iq(nrsc5_t *, const void *data, size_t count);
-void nrsc5_report_sync(nrsc5_t *, float freq_offset, int psmi);
+void nrsc5_report_sync(nrsc5_t *, float freq_offset, int psmi, int pli, int hppi, int aabi, int rdbi);
 void nrsc5_report_lost_sync(nrsc5_t *);
 void nrsc5_report_mer(nrsc5_t *, float lower, float upper);
 void nrsc5_report_ber(nrsc5_t *, float cber);

--- a/src/sync.c
+++ b/src/sync.c
@@ -231,7 +231,13 @@ static int find_block_am(sync_t *st, unsigned int ref)
 
     bc = (data[17] << 2) | (data[18] << 1) | data[19];
     if (bc == 0)
+    {
         st->psmi = (data[26] << 4) | (data[27] << 3) | (data[28] << 2) | (data[29] << 1) | data[30];
+        st->pli = data[7];
+        st->hppi = data[11];
+        st->aabi = data[12];
+        st->rdbi = data[15];
+    }
     return bc;
 }
 
@@ -796,6 +802,10 @@ void sync_reset(sync_t *st)
 
     st->idx = 0;
     st->psmi = 1;
+    st->pli = -1;
+    st->hppi = -1;
+    st->aabi = -1;
+    st->rdbi = -1;
     st->cfo_wait = 0;
     st->offset_history = 0;
     st->mer_cnt = 0;

--- a/src/sync.h
+++ b/src/sync.h
@@ -11,6 +11,10 @@ typedef struct
     float phases[FFT_FM][BLKSZ];
     unsigned int idx;
     int psmi;
+    int pli;
+    int hppi;
+    int aabi;
+    int rdbi;
     int cfo_wait;
     unsigned int bc;
     unsigned int offset_history;

--- a/support/cli.py
+++ b/support/cli.py
@@ -214,6 +214,8 @@ class NRSC5CLI:
             logging.info("Synchronized")
             logging.info("Frequency offset: %.0f Hz", evt.freq_offset)
             logging.info("Primary service mode: %d", evt.psmi)
+            if evt.pli != -1:
+                logging.info("PLI=%d, HPPI=%d, AABI=%d, RDBI=%d", evt.pli, evt.hppi, evt.aabi, evt.rdbi)
         elif evt_type == nrsc5.EventType.LOST_SYNC:
             logging.info("Lost synchronization")
         elif evt_type == nrsc5.EventType.MER:

--- a/support/cli.py
+++ b/support/cli.py
@@ -197,6 +197,15 @@ class NRSC5CLI:
             0xfc
         ])
 
+    def format_am_flags(self, evt):
+        parts = [f'Digital bandwidth: {"reduced" if evt.rdbi else "full"}']
+        if not evt.rdbi:
+            if evt.psmi != 2:
+                parts.append(f'analog bandwidth: {"8 kHz" if evt.aabi else "5 kHz"}')
+                parts.append(f'secondary/tertiary power: {"high" if evt.pli else "low"}')
+            parts.append(f'PIDS power: {"high" if evt.hppi else "low"}')
+        return ", ".join(parts)
+
     def callback(self, evt_type, evt):
         if evt_type == nrsc5.EventType.LOST_DEVICE:
             logging.info("Lost device")
@@ -215,7 +224,7 @@ class NRSC5CLI:
             logging.info("Frequency offset: %.0f Hz", evt.freq_offset)
             logging.info("Primary service mode: %d", evt.psmi)
             if evt.pli != -1:
-                logging.info("PLI=%d, HPPI=%d, AABI=%d, RDBI=%d", evt.pli, evt.hppi, evt.aabi, evt.rdbi)
+                logging.info(self.format_am_flags(evt))
         elif evt_type == nrsc5.EventType.LOST_SYNC:
             logging.info("Lost synchronization")
         elif evt_type == nrsc5.EventType.MER:

--- a/support/nrsc5.py
+++ b/support/nrsc5.py
@@ -189,7 +189,7 @@ class PacketFlags(enum.IntFlag):
 
 
 IQ = collections.namedtuple("IQ", ["data"])
-Sync = collections.namedtuple("Sync", ["freq_offset", "psmi"])
+Sync = collections.namedtuple("Sync", ["freq_offset", "psmi", "pli", "hppi", "aabi", "rdbi"])
 MER = collections.namedtuple("MER", ["lower", "upper"])
 BER = collections.namedtuple("BER", ["cber"])
 HDC = collections.namedtuple("HDC", ["program", "data", "flags"])
@@ -237,6 +237,10 @@ class _Sync(ctypes.Structure):
     _fields_ = [
         ("freq_offset", ctypes.c_float),
         ("psmi", ctypes.c_int),
+        ("pli", ctypes.c_int),
+        ("hppi", ctypes.c_int),
+        ("aabi", ctypes.c_int),
+        ("rdbi", ctypes.c_int),
     ]
 
 
@@ -672,7 +676,7 @@ class NRSC5:
             evt = IQ(iq.data[:iq.count])
         elif evt_type == EventType.SYNC:
             sync = c_evt.u.sync
-            evt = Sync(sync.freq_offset, sync.psmi)
+            evt = Sync(sync.freq_offset, sync.psmi, sync.pli, sync.hppi, sync.aabi, sync.rdbi)
         elif evt_type == EventType.MER:
             mer = c_evt.u.mer
             evt = MER(mer.lower, mer.upper)


### PR DESCRIPTION
For AM stations, libnrsc5 currently reports the Service Mode Indicator (SMI) in SYNC events. Alongside this value, the reference subcarrier also conveys four others:

* Power Level Indicator (PLI)
* High-Power PIDS Indicator (HPPI)
* Analog Audio Bandwidth Indicator (AABI)
* Reduced Digital Bandwidth Indicator (RDBI)

Descriptions of these values can be found in NRSC-5-E, Layer 1 AM, section 11.2.2 - 11.2.5.

I think these values are interesting enough to expose in the API, so I've done so here.