### PR TITLE
Exciter/Importer, Leap Offset & Local Time to API

### DIFF
--- a/include/nrsc5.h
+++ b/include/nrsc5.h
@@ -185,7 +185,9 @@ enum
     NRSC5_EVENT_HERE_IMAGE,
     NRSC5_EVENT_LOT_HEADER,
     NRSC5_EVENT_LOT_FRAGMENT,
-    NRSC5_EVENT_AGC
+    NRSC5_EVENT_AGC,
+    NRSC5_EVENT_EXCITER_INFO,
+    NRSC5_EVENT_IMPORTER_INFO,
 };
 
 enum
@@ -391,6 +393,8 @@ struct nrsc5_event_t
  * - `NRSC5_EVENT_EMERGENCY_ALERT` : emergency alert, see `emergency_alert` member
  * - `NRSC5_EVENT_HERE_IMAGE` : HERE Images traffic/weather map, see `here_image` member
  * - `NRSC5_EVENT_AGC` : automatic gain control status, see `agc` member
+ * - `NRSC5_EVENT_EXCITER_INFO` : exciter data, see `device_info` member
+ * - `NRSC5_EVENT_IMPORTER_INFO` : importer data, see `device_info` member
  */
     unsigned int event;
     union
@@ -573,6 +577,14 @@ struct nrsc5_event_t
             float peak_dbfs;     /**< peak signal amplitude in dB, relative to full scale */
             int is_final;        /**< 1 if this is the final (best) gain value, otherwise 0 */
         } agc;
+        struct {
+            char id[2];                  /**< 2-character identifier of the device, e.g. "GG" or "L7" */
+            int core_version[4];         /**< Core Version number. */
+            int manufacturer_version[4]; /**< Manufacturer-assigned Version number. */
+            int core_status;             /**< Core status. Values such like 0 (Commercial Release), 1 (Engineering Release), 2 (Patch). */
+            int manufacturer_status;     /**< Manufacturer status. Values such like 0 (Commercial Release), 1 (Engineering Release), 2 (Patch). */
+            int importer_connected;      /**< 1 if an importer is connected, otherwise 0 for EXCITER_INFO event. Set to -1 for IMPORTER_INFO event. */
+        } device_info;
     };
 };
 /**

--- a/include/nrsc5.h
+++ b/include/nrsc5.h
@@ -188,6 +188,8 @@ enum
     NRSC5_EVENT_AGC,
     NRSC5_EVENT_EXCITER_INFO,
     NRSC5_EVENT_IMPORTER_INFO,
+    NRSC5_EVENT_LEAP_OFFSET,
+    NRSC5_EVENT_LOCAL_TIME,
 };
 
 enum
@@ -395,6 +397,8 @@ struct nrsc5_event_t
  * - `NRSC5_EVENT_AGC` : automatic gain control status, see `agc` member
  * - `NRSC5_EVENT_EXCITER_INFO` : exciter data, see `device_info` member
  * - `NRSC5_EVENT_IMPORTER_INFO` : importer data, see `device_info` member
+ * - `NRSC5_EVENT_LEAP_OFFSET` : leap offset, see `leap_offset` member
+ * - `NRSC5_EVENT_LOCAL_TIME` : local time data, see `local_time` member
  */
     unsigned int event;
     union
@@ -585,6 +589,17 @@ struct nrsc5_event_t
             int manufacturer_status;     /**< Manufacturer status. Values such like 0 (Commercial Release), 1 (Engineering Release), 2 (Patch). */
             int importer_connected;      /**< 1 if an importer is connected, otherwise 0 for EXCITER_INFO event. Set to -1 for IMPORTER_INFO event. */
         } device_info;
+        struct {
+            int pending_leap_offset;          /**< Future GPS-UTC offset in seconds. Meant to be broadcasted months before the leap seconds and a few hours afterward. */
+            int current_leap_offset;          /**< Current GPS-UTC offset in seconds. */
+            int alfn_pending_leap_adjustment; /**< Represents GPS time of a pending leap second adjustment in ALFN.*/
+        } leap_offset;
+        struct {
+            int utc_offset;    /**< Local Time Zone UTC Offset in MINUTES. */
+            int dst_regional;  /**< 1 if DST is currently in effect regionally, otherwise 0. */
+            int dst_local;     /**< 1 if DST is currently in effect in the station's region, otherwise 0. */
+            int dst_scheduled; /**< DST Schedule. 0 means Daylight Savings is not practiced. 1 means U.S./Canada Schedule. 2 means EU Daylight savings schedule. */
+        } local_time;
     };
 };
 /**

--- a/include/nrsc5.h
+++ b/include/nrsc5.h
@@ -55,6 +55,8 @@
 #define NRSC5_SAMPLE_RATE_CS16_AM  46511.71875 /**< Sample rate at which nrsc5_pipe_samples_cs16() expects samples (AM only) */
 #define NRSC5_SAMPLE_RATE_AUDIO    44100       /**< Sample rate of outgoing audio */
 
+#define NRSC5_DEVICE_VERSION_LENGTH 4          /**< Length of Core Version & Manufacture Version in SIS Parameter messages. */
+
 #ifdef NRSC5_EXPORTS
 #ifdef __MINGW32__
 #define NRSC5_API __declspec(dllexport)
@@ -188,7 +190,7 @@ enum
     NRSC5_EVENT_AGC,
     NRSC5_EVENT_EXCITER_INFO,
     NRSC5_EVENT_IMPORTER_INFO,
-    NRSC5_EVENT_LEAP_OFFSET,
+    NRSC5_EVENT_LEAP_SECOND_OFFSET,
     NRSC5_EVENT_LOCAL_TIME,
 };
 
@@ -395,9 +397,9 @@ struct nrsc5_event_t
  * - `NRSC5_EVENT_EMERGENCY_ALERT` : emergency alert, see `emergency_alert` member
  * - `NRSC5_EVENT_HERE_IMAGE` : HERE Images traffic/weather map, see `here_image` member
  * - `NRSC5_EVENT_AGC` : automatic gain control status, see `agc` member
- * - `NRSC5_EVENT_EXCITER_INFO` : exciter data, see `device_info` member
- * - `NRSC5_EVENT_IMPORTER_INFO` : importer data, see `device_info` member
- * - `NRSC5_EVENT_LEAP_OFFSET` : leap offset, see `leap_offset` member
+ * - `NRSC5_EVENT_EXCITER_INFO` : exciter data, see `exciter_info` member
+ * - `NRSC5_EVENT_IMPORTER_INFO` : importer data, see `importer_info` member
+ * - `NRSC5_EVENT_LEAP_SECOND_OFFSET` : leap second offset, see `leap_second_offset` member
  * - `NRSC5_EVENT_LOCAL_TIME` : local time data, see `local_time` member
  */
     unsigned int event;
@@ -582,23 +584,30 @@ struct nrsc5_event_t
             int is_final;        /**< 1 if this is the final (best) gain value, otherwise 0 */
         } agc;
         struct {
-            char id[2];                  /**< 2-character identifier of the device, e.g. "GG" or "L7" */
-            int core_version[4];         /**< Core Version number. */
-            int manufacturer_version[4]; /**< Manufacturer-assigned Version number. */
-            int core_status;             /**< Core status. Values such like 0 (Commercial Release), 1 (Engineering Release), 2 (Patch). */
-            int manufacturer_status;     /**< Manufacturer status. Values such like 0 (Commercial Release), 1 (Engineering Release), 2 (Patch). */
-            int importer_connected;      /**< 1 if an importer is connected, otherwise 0 for EXCITER_INFO event. Set to -1 for IMPORTER_INFO event. */
-        } device_info;
+            const char* manufacturer_id;                           /**< Manufacturer ID, e.g. "GG" or "L7" */
+            int core_version[NRSC5_DEVICE_VERSION_LENGTH];         /**< Core Version number. */
+            int core_status;                                       /**< Core Version status. 0 (Commercial Release), 1 (Engineering Release), 2 (Patch). */
+            int manufacturer_version[NRSC5_DEVICE_VERSION_LENGTH]; /**< Manufacturer-assigned Version number. */
+            int manufacturer_status;                               /**< Manufacturer Version status. 0 (Commercial Release), 1 (Engineering Release), 2 (Patch). */
+            int importer_connected;                                /**< 1 if an importer is connected, otherwise 0. */
+        } exciter_info;
         struct {
-            int pending_leap_offset;          /**< Future GPS-UTC offset in seconds. Meant to be broadcasted months before the leap seconds and a few hours afterward. */
-            int current_leap_offset;          /**< Current GPS-UTC offset in seconds. */
-            int alfn_pending_leap_adjustment; /**< Represents GPS time of a pending leap second adjustment in ALFN.*/
-        } leap_offset;
+            const char* manufacturer_id;                           /**< Manufacturer ID, e.g. "GG" or "L7" */
+            int core_version[NRSC5_DEVICE_VERSION_LENGTH];         /**< Core Version number. */
+            int core_status;                                       /**< Core Version status. 0 (Commercial Release), 1 (Engineering Release), 2 (Patch). */
+            int manufacturer_version[NRSC5_DEVICE_VERSION_LENGTH]; /**< Manufacturer-assigned Version number. */
+            int manufacturer_status;                               /**< Manufacturer Version status. 0 (Commercial Release), 1 (Engineering Release), 2 (Patch). */
+        } importer_info;
         struct {
-            int utc_offset;    /**< Local Time Zone UTC Offset in MINUTES. */
+            int pending_offset;           /**< Future GPS-UTC offset in seconds. Meant to be broadcasted months before the leap seconds and a few hours afterward. */
+            int current_offset;           /**< Current GPS-UTC offset in seconds. */
+            unsigned int pending_alfn;    /**< ALFN representing the GPS time of a pending leap second adjustment, or 0 if a leap second is not pending.*/
+        } leap_second_offset;
+        struct {
+            int utc_offset;    /**< Local Time Zone UTC Offset in minutes. */
             int dst_regional;  /**< 1 if DST is currently in effect regionally, otherwise 0. */
-            int dst_local;     /**< 1 if DST is currently in effect in the station's region, otherwise 0. */
-            int dst_scheduled; /**< DST Schedule. 0 means Daylight Savings is not practiced. 1 means U.S./Canada Schedule. 2 means EU Daylight savings schedule. */
+            int dst_local;     /**< 1 if DST is practiced locally, otherwise 0. */
+            int dst_schedule;  /**< DST Schedule. 0 means Daylight Saving Time is not practiced. 1 means U.S./Canada schedule. 2 means EU schedule. */
         } local_time;
     };
 };

--- a/src/main.c
+++ b/src/main.c
@@ -603,6 +603,20 @@ static void callback(const nrsc5_event_t *evt, void *opaque)
                   evt->device_info.manufacturer_version[0], evt->device_info.manufacturer_version[1], evt->device_info.manufacturer_version[2],
                   evt->device_info.manufacturer_version[3], evt->device_info.manufacturer_status);
         break;
+    case NRSC5_EVENT_LEAP_OFFSET:
+        log_debug("Leap second offset: pending=%d, current=%d, ALFN adjustment=%d",
+                 evt->leap_offset.pending_leap_offset,
+                 evt->leap_offset.current_leap_offset,
+                 evt->leap_offset.alfn_pending_leap_adjustment);
+        break;
+    case NRSC5_EVENT_LOCAL_TIME:
+        log_debug("Local time: UTC offset=%d minutes, DST scheduled=%d, DST regional? %s, DST local? %s",
+                 evt->local_time.utc_offset,
+                 evt->local_time.dst_scheduled,
+                 evt->local_time.dst_regional ? "yes" : "no",
+                 evt->local_time.dst_local ? "yes" : "no");
+        break;
+
     }
 }
 

--- a/src/main.c
+++ b/src/main.c
@@ -586,6 +586,23 @@ static void callback(const nrsc5_event_t *evt, void *opaque)
                  evt->here_image.name,
                  evt->here_image.size);
         break;
+    case NRSC5_EVENT_EXCITER_INFO:
+        log_debug("Exciter manuf. \"%c%c\", core version %d.%d.%d.%d, core status %d, manuf. version %d.%d.%d.%d, manuf. status %d, importer connected? %s",
+                  evt->device_info.id[0], evt->device_info.id[1],
+                  evt->device_info.core_version[0], evt->device_info.core_version[1], evt->device_info.core_version[2],
+                  evt->device_info.core_version[3], evt->device_info.core_status,
+                  evt->device_info.manufacturer_version[0], evt->device_info.manufacturer_version[1], evt->device_info.manufacturer_version[2],
+                  evt->device_info.manufacturer_version[3], evt->device_info.manufacturer_status,
+                  evt->device_info.importer_connected ? "yes" : "no");
+        break;
+    case NRSC5_EVENT_IMPORTER_INFO:
+        log_debug("Importer manuf. \"%c%c\", core version %d.%d.%d.%d, core status %d, manuf. version %d.%d.%d.%d, manuf. status %d",
+                  evt->device_info.id[0], evt->device_info.id[1],
+                  evt->device_info.core_version[0], evt->device_info.core_version[1], evt->device_info.core_version[2],
+                  evt->device_info.core_version[3], evt->device_info.core_status,
+                  evt->device_info.manufacturer_version[0], evt->device_info.manufacturer_version[1], evt->device_info.manufacturer_version[2],
+                  evt->device_info.manufacturer_version[3], evt->device_info.manufacturer_status);
+        break;
     }
 }
 

--- a/src/main.c
+++ b/src/main.c
@@ -587,32 +587,32 @@ static void callback(const nrsc5_event_t *evt, void *opaque)
                  evt->here_image.size);
         break;
     case NRSC5_EVENT_EXCITER_INFO:
-        log_debug("Exciter manuf. \"%c%c\", core version %d.%d.%d.%d, core status %d, manuf. version %d.%d.%d.%d, manuf. status %d, importer connected? %s",
-                  evt->device_info.id[0], evt->device_info.id[1],
-                  evt->device_info.core_version[0], evt->device_info.core_version[1], evt->device_info.core_version[2],
-                  evt->device_info.core_version[3], evt->device_info.core_status,
-                  evt->device_info.manufacturer_version[0], evt->device_info.manufacturer_version[1], evt->device_info.manufacturer_version[2],
-                  evt->device_info.manufacturer_version[3], evt->device_info.manufacturer_status,
-                  evt->device_info.importer_connected ? "yes" : "no");
+        log_debug("Exciter manuf. \"%s\", core version %d.%d.%d.%d, core status %d, manuf. version %d.%d.%d.%d, manuf. status %d, importer connected? %s",
+                  evt->exciter_info.manufacturer_id,
+                  evt->exciter_info.core_version[0], evt->exciter_info.core_version[1], evt->exciter_info.core_version[2],
+                  evt->exciter_info.core_version[3], evt->exciter_info.core_status,
+                  evt->exciter_info.manufacturer_version[0], evt->exciter_info.manufacturer_version[1], evt->exciter_info.manufacturer_version[2],
+                  evt->exciter_info.manufacturer_version[3], evt->exciter_info.manufacturer_status,
+                  evt->exciter_info.importer_connected ? "yes" : "no");
         break;
     case NRSC5_EVENT_IMPORTER_INFO:
-        log_debug("Importer manuf. \"%c%c\", core version %d.%d.%d.%d, core status %d, manuf. version %d.%d.%d.%d, manuf. status %d",
-                  evt->device_info.id[0], evt->device_info.id[1],
-                  evt->device_info.core_version[0], evt->device_info.core_version[1], evt->device_info.core_version[2],
-                  evt->device_info.core_version[3], evt->device_info.core_status,
-                  evt->device_info.manufacturer_version[0], evt->device_info.manufacturer_version[1], evt->device_info.manufacturer_version[2],
-                  evt->device_info.manufacturer_version[3], evt->device_info.manufacturer_status);
+        log_debug("Importer manuf. \"%s\", core version %d.%d.%d.%d, core status %d, manuf. version %d.%d.%d.%d, manuf. status %d",
+                  evt->importer_info.manufacturer_id,
+                  evt->importer_info.core_version[0], evt->importer_info.core_version[1], evt->importer_info.core_version[2],
+                  evt->importer_info.core_version[3], evt->importer_info.core_status,
+                  evt->importer_info.manufacturer_version[0], evt->importer_info.manufacturer_version[1], evt->importer_info.manufacturer_version[2],
+                  evt->importer_info.manufacturer_version[3], evt->importer_info.manufacturer_status);
         break;
-    case NRSC5_EVENT_LEAP_OFFSET:
-        log_debug("Leap second offset: pending=%d, current=%d, ALFN adjustment=%d",
-                 evt->leap_offset.pending_leap_offset,
-                 evt->leap_offset.current_leap_offset,
-                 evt->leap_offset.alfn_pending_leap_adjustment);
+    case NRSC5_EVENT_LEAP_SECOND_OFFSET:
+        log_debug("Leap second offset: pending=%d, current=%d, ALFN of pending adjustment=%d",
+                 evt->leap_second_offset.pending_offset,
+                 evt->leap_second_offset.current_offset,
+                 evt->leap_second_offset.pending_alfn);
         break;
     case NRSC5_EVENT_LOCAL_TIME:
-        log_debug("Local time: UTC offset=%d minutes, DST scheduled=%d, DST regional? %s, DST local? %s",
+        log_debug("Local time: UTC offset=%d minutes, DST schedule=%d, DST in effect regionally? %s, DST practiced locally? %s",
                  evt->local_time.utc_offset,
-                 evt->local_time.dst_scheduled,
+                 evt->local_time.dst_schedule,
                  evt->local_time.dst_regional ? "yes" : "no",
                  evt->local_time.dst_local ? "yes" : "no");
         break;

--- a/src/nrsc5.c
+++ b/src/nrsc5.c
@@ -1089,6 +1089,29 @@ void nrsc5_report_emergency_alert(nrsc5_t *st, const char *message, const uint8_
     nrsc5_report(st, &evt);
 }
 
+void nrsc5_report_device_info(nrsc5_t *st, const int device, const char id[2],
+                              const int core_version[4], const int manufacturer_version[4],
+                              const int core_status, const int manufacturer_status,
+                              const int importer_connected)
+{
+    nrsc5_event_t evt;
+
+    if (device)
+        evt.event = NRSC5_EVENT_IMPORTER_INFO;
+    else
+        evt.event = NRSC5_EVENT_EXCITER_INFO;
+
+    memcpy(evt.device_info.id, id, sizeof(char) * 2);
+    memcpy(evt.device_info.core_version, core_version, sizeof(int) * 4);
+    memcpy(evt.device_info.manufacturer_version, manufacturer_version, sizeof(int) * 4);
+
+    evt.device_info.core_status = core_status;
+    evt.device_info.manufacturer_status = manufacturer_status;
+    evt.device_info.importer_connected = importer_connected;
+
+    nrsc5_report(st, &evt);
+}
+
 void nrsc5_report_here_image(nrsc5_t *st, int image_type, int seq, int n1, int n2, unsigned int timestamp,
                              float latitude1, float longitude1, float latitude2, float longitude2,
                              const char *name, unsigned int size, const uint8_t *data)

--- a/src/nrsc5.c
+++ b/src/nrsc5.c
@@ -1089,38 +1089,55 @@ void nrsc5_report_emergency_alert(nrsc5_t *st, const char *message, const uint8_
     nrsc5_report(st, &evt);
 }
 
-void nrsc5_report_device_info(nrsc5_t *st, const int device, const char id[2],
-                              const int core_version[4], const int manufacturer_version[4],
-                              const int core_status, const int manufacturer_status,
-                              const int importer_connected)
+void nrsc5_report_exciter_info(nrsc5_t *st, const char* manufacturer_id,
+                               const int core_version[NRSC5_DEVICE_VERSION_LENGTH],
+                               const int manufacturer_version[NRSC5_DEVICE_VERSION_LENGTH],
+                               const int core_status, const int manufacturer_status,
+                               const int importer_connected)
 {
     nrsc5_event_t evt;
 
-    if (device)
-        evt.event = NRSC5_EVENT_IMPORTER_INFO;
-    else
-        evt.event = NRSC5_EVENT_EXCITER_INFO;
+    evt.event = NRSC5_EVENT_EXCITER_INFO;
 
-    memcpy(evt.device_info.id, id, sizeof(char) * 2);
-    memcpy(evt.device_info.core_version, core_version, sizeof(int) * 4);
-    memcpy(evt.device_info.manufacturer_version, manufacturer_version, sizeof(int) * 4);
+    memcpy(evt.exciter_info.core_version, core_version, sizeof(int) * NRSC5_DEVICE_VERSION_LENGTH);
+    memcpy(evt.exciter_info.manufacturer_version, manufacturer_version, sizeof(int) * NRSC5_DEVICE_VERSION_LENGTH);
 
-    evt.device_info.core_status = core_status;
-    evt.device_info.manufacturer_status = manufacturer_status;
-    evt.device_info.importer_connected = importer_connected;
+    evt.exciter_info.manufacturer_id = manufacturer_id;
+    evt.exciter_info.core_status = core_status;
+    evt.exciter_info.manufacturer_status = manufacturer_status;
+    evt.exciter_info.importer_connected = importer_connected;
+
+    nrsc5_report(st, &evt);
+}
+
+void nrsc5_report_importer_info(nrsc5_t *st, const char* manufacturer_id,
+                                const int core_version[NRSC5_DEVICE_VERSION_LENGTH],
+                                const int manufacturer_version[NRSC5_DEVICE_VERSION_LENGTH],
+                                const int core_status, const int manufacturer_status)
+{
+    nrsc5_event_t evt;
+
+    evt.event = NRSC5_EVENT_IMPORTER_INFO;
+
+    memcpy(evt.importer_info.core_version, core_version, sizeof(int) * NRSC5_DEVICE_VERSION_LENGTH);
+    memcpy(evt.importer_info.manufacturer_version, manufacturer_version, sizeof(int) * NRSC5_DEVICE_VERSION_LENGTH);
+
+    evt.importer_info.manufacturer_id = manufacturer_id;
+    evt.importer_info.core_status = core_status;
+    evt.importer_info.manufacturer_status = manufacturer_status;
 
     nrsc5_report(st, &evt);
 }
 
 void nrsc5_report_leap(nrsc5_t *st, const int pending_leap_offset, const int current_leap_offset,
-                       const int alfn_leap_adjustment)
+                       const unsigned int alfn_leap_adjustment)
 {
     nrsc5_event_t evt;
 
-    evt.event = NRSC5_EVENT_LEAP_OFFSET;
-    evt.leap_offset.pending_leap_offset = pending_leap_offset;
-    evt.leap_offset.current_leap_offset = current_leap_offset;
-    evt.leap_offset.alfn_pending_leap_adjustment = alfn_leap_adjustment;
+    evt.event = NRSC5_EVENT_LEAP_SECOND_OFFSET;
+    evt.leap_second_offset.pending_offset = pending_leap_offset;
+    evt.leap_second_offset.current_offset = current_leap_offset;
+    evt.leap_second_offset.pending_alfn = alfn_leap_adjustment;
 
     nrsc5_report(st, &evt);
 }
@@ -1134,7 +1151,7 @@ void nrsc5_report_local_time(nrsc5_t *st, const int tzo, const int dst_regional,
     evt.local_time.utc_offset = tzo;
     evt.local_time.dst_regional = dst_regional;
     evt.local_time.dst_local = dst_local;
-    evt.local_time.dst_scheduled = dst_schedule;
+    evt.local_time.dst_schedule = dst_schedule;
 
     nrsc5_report(st, &evt);
 }

--- a/src/nrsc5.c
+++ b/src/nrsc5.c
@@ -1112,6 +1112,33 @@ void nrsc5_report_device_info(nrsc5_t *st, const int device, const char id[2],
     nrsc5_report(st, &evt);
 }
 
+void nrsc5_report_leap(nrsc5_t *st, const int pending_leap_offset, const int current_leap_offset,
+                       const int alfn_leap_adjustment)
+{
+    nrsc5_event_t evt;
+
+    evt.event = NRSC5_EVENT_LEAP_OFFSET;
+    evt.leap_offset.pending_leap_offset = pending_leap_offset;
+    evt.leap_offset.current_leap_offset = current_leap_offset;
+    evt.leap_offset.alfn_pending_leap_adjustment = alfn_leap_adjustment;
+
+    nrsc5_report(st, &evt);
+}
+
+void nrsc5_report_local_time(nrsc5_t *st, const int tzo, const int dst_regional,
+                             const int dst_local, const int dst_schedule)
+{
+    nrsc5_event_t evt;
+
+    evt.event = NRSC5_EVENT_LOCAL_TIME;
+    evt.local_time.utc_offset = tzo;
+    evt.local_time.dst_regional = dst_regional;
+    evt.local_time.dst_local = dst_local;
+    evt.local_time.dst_scheduled = dst_schedule;
+
+    nrsc5_report(st, &evt);
+}
+
 void nrsc5_report_here_image(nrsc5_t *st, int image_type, int seq, int n1, int n2, unsigned int timestamp,
                              float latitude1, float longitude1, float latitude2, float longitude2,
                              const char *name, unsigned int size, const uint8_t *data)

--- a/src/pids.c
+++ b/src/pids.c
@@ -408,7 +408,7 @@ static void decode_sis(pids_t *st, uint8_t *bits)
         int category, prog_num;
         asd_t audio_service;
         dsd_t data_service;
-        int index, parameter, tzo, dst_scheduled, dst_local, dst_regional;
+        int index, parameter, tzo, dst_schedule, dst_local, dst_regional;
 
         if (off > 60) break;
         msg_id = decode_int(bits, &off, 4);
@@ -668,23 +668,23 @@ static void decode_sis(pids_t *st, uint8_t *bits)
                 case 2:
                     if (st->parameters[0] >= 0 && st->parameters[1] >= 0 && st->parameters[2] >= 0)
                     {
-                        const int pending_leap_offset = st->parameters[0] >> 8;
-                        const int current_leap_offset = st->parameters[0] & 0xff;
-                        const int alfn_pending_leap_adjustment = (unsigned int)st->parameters[2] << 16 | st->parameters[1];
+                        const int pending_offset = st->parameters[0] >> 8;
+                        const int current_offset = st->parameters[0] & 0xff;
+                        const unsigned int pending_alfn = (unsigned int)st->parameters[2] << 16 | st->parameters[1];
 
-                        nrsc5_report_leap(st->input->radio, pending_leap_offset, current_leap_offset, alfn_pending_leap_adjustment);
+                        nrsc5_report_leap(st->input->radio, pending_offset, current_offset, pending_alfn);
                     }
                     break;
                 case 3:
                     dst_regional = st->parameters[3] & 0x1;
                     dst_local = (st->parameters[3] >> 1) & 0x1;
-                    dst_scheduled = (st->parameters[3] >> 2) & 0x7;
+                    dst_schedule = (st->parameters[3] >> 2) & 0x7;
                     tzo = (st->parameters[3] >> 5) & 0x7ff;
 
                     if (tzo >= 1024)
                         tzo -= 2048;
 
-                    nrsc5_report_local_time(st->input->radio, tzo, dst_regional, dst_local, dst_scheduled);
+                    nrsc5_report_local_time(st->input->radio, tzo, dst_regional, dst_local, dst_schedule);
                     break;
                 case 4:
                 case 5:
@@ -692,14 +692,15 @@ static void decode_sis(pids_t *st, uint8_t *bits)
                 case 7:
                     if (st->parameters[4] >= 0 && st->parameters[5] >= 0 && st->parameters[6] >= 0 && st->parameters[7] >= 0)
                     {
-                        const char id[2] = {
-                            (char)((st->parameters[4] >> 8) & 0x7f), (char)(st->parameters[4] & 0x7f)
+                        const char manufacturer_id[3] = {
+                            (char)((st->parameters[4] >> 8) & 0x7f), (char)(st->parameters[4] & 0x7f),
+                            '\0'
                         };
-                        const int core_version[4] = {
+                        const int core_version[NRSC5_DEVICE_VERSION_LENGTH] = {
                             (st->parameters[5] >> 11) & 0x1f, (st->parameters[5] >> 6) & 0x1f, (st->parameters[5] >> 1) & 0x1f,
                             (st->parameters[7] >> 11) & 0x1f
                         };
-                        const int manufacturer[4] = {
+                        const int manufacturer[NRSC5_DEVICE_VERSION_LENGTH] = {
                             (st->parameters[6] >> 11) & 0x1f, (st->parameters[6] >> 6) & 0x1f, (st->parameters[6] >> 1) & 0x1f,
                             (st->parameters[7] >> 6) & 0x1f,
                         };
@@ -708,7 +709,7 @@ static void decode_sis(pids_t *st, uint8_t *bits)
                         const int manufacturer_status = st->parameters[7] & 0x7;
                         const int importer_connected = (st->parameters[4] >> 7) & 0x1;
 
-                        nrsc5_report_device_info(st->input->radio, 0, id, core_version, manufacturer,
+                        nrsc5_report_exciter_info(st->input->radio, manufacturer_id, core_version, manufacturer,
                             core_status, manufacturer_status, importer_connected);
                     }
                     break;
@@ -718,22 +719,23 @@ static void decode_sis(pids_t *st, uint8_t *bits)
                 case 11:
                     if (st->parameters[8] >= 0 && st->parameters[9] >= 0 && st->parameters[10] >= 0 && st->parameters[11] >= 0)
                     {
-                        const char id[2] = {
-                            (char)((st->parameters[8] >> 8) & 0x7f), (char)(st->parameters[8] & 0x7f)
+                        const char manufacturer_id[3] = {
+                            (char)((st->parameters[8] >> 8) & 0x7f), (char)(st->parameters[8] & 0x7f),
+                            '\0'
                         };
-                        const int core_version[4] = {
+                        const int core_version[NRSC5_DEVICE_VERSION_LENGTH] = {
                             (st->parameters[9] >> 11) & 0x1f, (st->parameters[9] >> 6) & 0x1f, (st->parameters[9] >> 1) & 0x1f,
                             (st->parameters[11] >> 11) & 0x1f,
                         };
-                        const int manufacturer[4] = {
+                        const int manufacturer[NRSC5_DEVICE_VERSION_LENGTH] = {
                             (st->parameters[10] >> 11) & 0x1f, (st->parameters[10] >> 6) & 0x1f, (st->parameters[10] >> 1) & 0x1f,
                             (st->parameters[11] >> 6) & 0x1f
                         };
                         const int core_status = (st->parameters[11] >> 3) & 0x7;
                         const int manufacturer_status = st->parameters[11] & 0x7;
 
-                        nrsc5_report_device_info(st->input->radio, 1, id, core_version, manufacturer,
-                            core_status, manufacturer_status, -1);
+                        nrsc5_report_importer_info(st->input->radio, manufacturer_id, core_version, manufacturer,
+                            core_status, manufacturer_status);
                     }
                     break;
                 case 12:

--- a/src/pids.c
+++ b/src/pids.c
@@ -408,7 +408,7 @@ static void decode_sis(pids_t *st, uint8_t *bits)
         int category, prog_num;
         asd_t audio_service;
         dsd_t data_service;
-        int index, parameter, tzo;
+        int index, parameter, tzo, dst_scheduled, dst_local, dst_regional;
 
         if (off > 60) break;
         msg_id = decode_int(bits, &off, 4);
@@ -664,19 +664,27 @@ static void decode_sis(pids_t *st, uint8_t *bits)
                 switch (index)
                 {
                 case 0:
-                    log_debug("Pending leap second offset: %d, current leap second offset: %d",
-                        parameter >> 8, parameter & 0xff);
-                    break;
                 case 1:
                 case 2:
-                    if (st->parameters[1] >= 0 && st->parameters[2] >= 0)
-                        log_debug("ALFN of pending leap second adjustment: %d", (unsigned int)st->parameters[2] << 16 | st->parameters[1]);
+                    if (st->parameters[0] >= 0 && st->parameters[1] >= 0 && st->parameters[2] >= 0)
+                    {
+                        const int pending_leap_offset = st->parameters[0] >> 8;
+                        const int current_leap_offset = st->parameters[0] & 0xff;
+                        const int alfn_pending_leap_adjustment = (unsigned int)st->parameters[2] << 16 | st->parameters[1];
+
+                        nrsc5_report_leap(st->input->radio, pending_leap_offset, current_leap_offset, alfn_pending_leap_adjustment);
+                    }
                     break;
                 case 3:
-                    tzo = (parameter >> 5) & 0x7ff;
-                    if (tzo >= 1024) tzo -= 2048;
-                    log_debug("Local time zone offset: %d minutes, DST sched. %d, local DST? %s, regional DST? %s",
-                        tzo, (parameter >> 2) & 0x7, parameter & 0x2 ? "yes" : "no", parameter & 0x1 ? "yes" : "no");
+                    dst_regional = st->parameters[3] & 0x1;
+                    dst_local = (st->parameters[3] >> 1) & 0x1;
+                    dst_scheduled = (st->parameters[3] >> 2) & 0x7;
+                    tzo = (st->parameters[3] >> 5) & 0x7ff;
+
+                    if (tzo >= 1024)
+                        tzo -= 2048;
+
+                    nrsc5_report_local_time(st->input->radio, tzo, dst_regional, dst_local, dst_scheduled);
                     break;
                 case 4:
                 case 5:
@@ -698,7 +706,7 @@ static void decode_sis(pids_t *st, uint8_t *bits)
 
                         const int core_status = (st->parameters[7] >> 3) & 0x7;
                         const int manufacturer_status = st->parameters[7] & 0x7;
-                        const int importer_connected = (st->parameters[4] >> 7) & 1;
+                        const int importer_connected = (st->parameters[4] >> 7) & 0x1;
 
                         nrsc5_report_device_info(st->input->radio, 0, id, core_version, manufacturer,
                             core_status, manufacturer_status, importer_connected);

--- a/src/pids.c
+++ b/src/pids.c
@@ -684,13 +684,24 @@ static void decode_sis(pids_t *st, uint8_t *bits)
                 case 7:
                     if (st->parameters[4] >= 0 && st->parameters[5] >= 0 && st->parameters[6] >= 0 && st->parameters[7] >= 0)
                     {
-                        log_debug("Exciter manuf. \"%c%c\", core version %d.%d.%d.%d-%d, manuf. version %d.%d.%d.%d-%d",
-                            (st->parameters[4] >> 8) & 0x7f, st->parameters[4] & 0x7f,
+                        const char id[2] = {
+                            (char)((st->parameters[4] >> 8) & 0x7f), (char)(st->parameters[4] & 0x7f)
+                        };
+                        const int core_version[4] = {
                             (st->parameters[5] >> 11) & 0x1f, (st->parameters[5] >> 6) & 0x1f, (st->parameters[5] >> 1) & 0x1f,
-                            (st->parameters[7] >> 11) & 0x1f, (st->parameters[7] >> 3) & 0x7,
+                            (st->parameters[7] >> 11) & 0x1f
+                        };
+                        const int manufacturer[4] = {
                             (st->parameters[6] >> 11) & 0x1f, (st->parameters[6] >> 6) & 0x1f, (st->parameters[6] >> 1) & 0x1f,
-                            (st->parameters[7] >> 6) & 0x1f, st->parameters[7] & 0x7
-                        );
+                            (st->parameters[7] >> 6) & 0x1f,
+                        };
+
+                        const int core_status = (st->parameters[7] >> 3) & 0x7;
+                        const int manufacturer_status = st->parameters[7] & 0x7;
+                        const int importer_connected = (st->parameters[4] >> 7) & 1;
+
+                        nrsc5_report_device_info(st->input->radio, 0, id, core_version, manufacturer,
+                            core_status, manufacturer_status, importer_connected);
                     }
                     break;
                 case 8:
@@ -699,13 +710,22 @@ static void decode_sis(pids_t *st, uint8_t *bits)
                 case 11:
                     if (st->parameters[8] >= 0 && st->parameters[9] >= 0 && st->parameters[10] >= 0 && st->parameters[11] >= 0)
                     {
-                        log_debug("Importer manuf. \"%c%c\", core version %d.%d.%d.%d-%d, manuf. version %d.%d.%d.%d-%d",
-                            (st->parameters[8] >> 8) & 0x7f, st->parameters[8] & 0x7f,
+                        const char id[2] = {
+                            (char)((st->parameters[8] >> 8) & 0x7f), (char)(st->parameters[8] & 0x7f)
+                        };
+                        const int core_version[4] = {
                             (st->parameters[9] >> 11) & 0x1f, (st->parameters[9] >> 6) & 0x1f, (st->parameters[9] >> 1) & 0x1f,
-                            (st->parameters[11] >> 11) & 0x1f, (st->parameters[11] >> 3) & 0x7,
+                            (st->parameters[11] >> 11) & 0x1f,
+                        };
+                        const int manufacturer[4] = {
                             (st->parameters[10] >> 11) & 0x1f, (st->parameters[10] >> 6) & 0x1f, (st->parameters[10] >> 1) & 0x1f,
-                            (st->parameters[11] >> 6) & 0x1f, st->parameters[11] & 0x7
-                        );
+                            (st->parameters[11] >> 6) & 0x1f
+                        };
+                        const int core_status = (st->parameters[11] >> 3) & 0x7;
+                        const int manufacturer_status = st->parameters[11] & 0x7;
+
+                        nrsc5_report_device_info(st->input->radio, 1, id, core_version, manufacturer,
+                            core_status, manufacturer_status, -1);
                     }
                     break;
                 case 12:

--- a/src/private.h
+++ b/src/private.h
@@ -87,10 +87,11 @@ void nrsc5_report_emergency_alert(nrsc5_t *st, const char *message, const uint8_
 void nrsc5_report_here_image(nrsc5_t *st, int image_type, int seq, int n1, int n2, unsigned int timestamp,
                              float latitude1, float longitude1, float latitude2, float longitude2,
                              const char *name, unsigned int size, const uint8_t *data);
-void nrsc5_report_device_info(nrsc5_t *st, int device, const char id[2], const int core_version[4],
-                              const int manufacturer_version[4], int core_status, int manufacturer_status,
-                              int importer_connected);
+void nrsc5_report_exciter_info(nrsc5_t *st, const char* manufacturer_id, const int core_version[4], const int manufacturer_version[4],
+                               int core_status, int manufacturer_status, int importer_connected);
+void nrsc5_report_importer_info(nrsc5_t *st, const char* manufacturer_id, const int core_version[4], const int manufacturer_version[4],
+                                int core_status, int manufacturer_status);
 void nrsc5_report_leap(nrsc5_t *st, int pending_leap_offset, int current_leap_offset,
-                       int alfn_leap_adjustment);
+                       unsigned int alfn_leap_adjustment);
 void nrsc5_report_local_time(nrsc5_t *st, int utc_offset, int dst_regional, int dst_local,
                              int dst_schedule);

--- a/src/private.h
+++ b/src/private.h
@@ -90,3 +90,7 @@ void nrsc5_report_here_image(nrsc5_t *st, int image_type, int seq, int n1, int n
 void nrsc5_report_device_info(nrsc5_t *st, int device, const char id[2], const int core_version[4],
                               const int manufacturer_version[4], int core_status, int manufacturer_status,
                               int importer_connected);
+void nrsc5_report_leap(nrsc5_t *st, int pending_leap_offset, int current_leap_offset,
+                       int alfn_leap_adjustment);
+void nrsc5_report_local_time(nrsc5_t *st, int utc_offset, int dst_regional, int dst_local,
+                             int dst_schedule);

--- a/src/private.h
+++ b/src/private.h
@@ -87,3 +87,6 @@ void nrsc5_report_emergency_alert(nrsc5_t *st, const char *message, const uint8_
 void nrsc5_report_here_image(nrsc5_t *st, int image_type, int seq, int n1, int n2, unsigned int timestamp,
                              float latitude1, float longitude1, float latitude2, float longitude2,
                              const char *name, unsigned int size, const uint8_t *data);
+void nrsc5_report_device_info(nrsc5_t *st, int device, const char id[2], const int core_version[4],
+                              const int manufacturer_version[4], int core_status, int manufacturer_status,
+                              int importer_connected);

--- a/support/cli.py
+++ b/support/cli.py
@@ -373,27 +373,27 @@ class NRSC5CLI:
                          evt.image_type.name, evt.seq, evt.n1, evt.n2, time_str, evt.latitude1, evt.longitude1,
                          evt.latitude2, evt.longitude2, evt.name, len(evt.data))
         elif evt_type == nrsc5.EventType.EXCITER_INFO:
-            logging.debug("Exciter manuf. \"%c%c\", core version %d.%d.%d.%d, core status %d, manuf. version %d.%d.%d.%d, manuf. status %d, importer connected? %s",
-                          evt.id[0], evt.id[1], evt.core_version[0], evt.core_version[1], evt.core_version[2],
+            logging.debug("Exciter manuf. \"%s\", core version %d.%d.%d.%d, core status %d, manuf. version %d.%d.%d.%d, manuf. status %d, importer connected? %s",
+                          evt.manufacturer_id, evt.core_version[0], evt.core_version[1], evt.core_version[2],
                           evt.core_version[3], evt.core_status,
                           evt.manufacturer_version[0], evt.manufacturer_version[1], evt.manufacturer_version[2],
                           evt.manufacturer_version[3], evt.manufacturer_status,
-                          evt.importer_connected)
+                          "yes" if evt.importer_connected else "no")
         elif evt_type == nrsc5.EventType.IMPORTER_INFO:
-            logging.debug("Importer manuf. \"%c%c\", core version %d.%d.%d.%d, core status %d, manuf. version %d.%d.%d.%d, manuf. status %d",
-                          evt.id[0], evt.id[1], evt.core_version[0], evt.core_version[1], evt.core_version[2],
+            logging.debug("Importer manuf. \"%s\", core version %d.%d.%d.%d, core status %d, manuf. version %d.%d.%d.%d, manuf. status %d",
+                          evt.manufacturer_id, evt.core_version[0], evt.core_version[1], evt.core_version[2],
                           evt.core_version[3], evt.core_status,
                           evt.manufacturer_version[0], evt.manufacturer_version[1], evt.manufacturer_version[2],
                           evt.manufacturer_version[3], evt.manufacturer_status)
-        elif evt_type == nrsc5.EventType.LEAP_OFFSET:
-            logging.debug("Leap second offset: pending=%d, current=%d, ALFN adjustment=%d",
-                          evt.pending_leap_offset, evt.current_leap_offset,
-                          evt.alfn_pending_leap_adjustment)
+        elif evt_type == nrsc5.EventType.LEAP_SECOND_OFFSET:
+            logging.debug("Leap second offset: pending=%d, current=%d, ALFN of pending adjustment=%d",
+                          evt.pending_offset, evt.current_offset,
+                          evt.pending_alfn)
         elif evt_type == nrsc5.EventType.LOCAL_TIME:
-            logging.debug("Local time: UTC offset=%d minutes, DST scheduled=%d, DST regional? %s, DST local? %s",
+            logging.debug("Local time: UTC offset=%d minutes, DST schedule=%d, DST in effect regionally? %s, DST practiced locally? %s",
                           evt.utc_offset,
-                          evt.dst_scheduled,
-                          evt.dst_regional if 'yes' else "no", evt.dst_local if 'yes' else 'no')
+                          evt.dst_schedule,
+                          "yes" if evt.dst_regional else "no", "yes" if evt.dst_local else "no")
 
 
 if __name__ == "__main__":

--- a/support/cli.py
+++ b/support/cli.py
@@ -385,6 +385,15 @@ class NRSC5CLI:
                           evt.core_version[3], evt.core_status,
                           evt.manufacturer_version[0], evt.manufacturer_version[1], evt.manufacturer_version[2],
                           evt.manufacturer_version[3], evt.manufacturer_status)
+        elif evt_type == nrsc5.EventType.LEAP_OFFSET:
+            logging.debug("Leap second offset: pending=%d, current=%d, ALFN adjustment=%d",
+                          evt.pending_leap_offset, evt.current_leap_offset,
+                          evt.alfn_pending_leap_adjustment)
+        elif evt_type == nrsc5.EventType.LOCAL_TIME:
+            logging.debug("Local time: UTC offset=%d minutes, DST scheduled=%d, DST regional? %s, DST local? %s",
+                          evt.utc_offset,
+                          evt.dst_scheduled,
+                          evt.dst_regional if 'yes' else "no", evt.dst_local if 'yes' else 'no')
 
 
 if __name__ == "__main__":

--- a/support/cli.py
+++ b/support/cli.py
@@ -372,6 +372,19 @@ class NRSC5CLI:
             logging.info("HERE Image: type=%s, seq=%d, n1=%d, n2=%d, time=%s, lat1=%.5f, lon1=%.5f, lat2=%.5f, lon2=%.5f, name=%s, size=%d",
                          evt.image_type.name, evt.seq, evt.n1, evt.n2, time_str, evt.latitude1, evt.longitude1,
                          evt.latitude2, evt.longitude2, evt.name, len(evt.data))
+        elif evt_type == nrsc5.EventType.EXCITER_INFO:
+            logging.debug("Exciter manuf. \"%c%c\", core version %d.%d.%d.%d, core status %d, manuf. version %d.%d.%d.%d, manuf. status %d, importer connected? %s",
+                          evt.id[0], evt.id[1], evt.core_version[0], evt.core_version[1], evt.core_version[2],
+                          evt.core_version[3], evt.core_status,
+                          evt.manufacturer_version[0], evt.manufacturer_version[1], evt.manufacturer_version[2],
+                          evt.manufacturer_version[3], evt.manufacturer_status,
+                          evt.importer_connected)
+        elif evt_type == nrsc5.EventType.IMPORTER_INFO:
+            logging.debug("Importer manuf. \"%c%c\", core version %d.%d.%d.%d, core status %d, manuf. version %d.%d.%d.%d, manuf. status %d",
+                          evt.id[0], evt.id[1], evt.core_version[0], evt.core_version[1], evt.core_version[2],
+                          evt.core_version[3], evt.core_status,
+                          evt.manufacturer_version[0], evt.manufacturer_version[1], evt.manufacturer_version[2],
+                          evt.manufacturer_version[3], evt.manufacturer_status)
 
 
 if __name__ == "__main__":

--- a/support/nrsc5.py
+++ b/support/nrsc5.py
@@ -43,6 +43,8 @@ class EventType(enum.Enum):
     AGC = 26
     EXCITER_INFO = 27
     IMPORTER_INFO = 28
+    LEAP_OFFSET = 29
+    LOCAL_TIME = 30
 
 
 AUDIO_FRAME_SAMPLES = 2048
@@ -227,6 +229,8 @@ HEREImage = collections.namedtuple("HEREImage", ["image_type", "seq", "n1", "n2"
                                                  "latitude2", "longitude2", "name", "data"])
 AGC = collections.namedtuple("AGC", ["gain_db", "peak_dbfs", "is_final"])
 DeviceInfo = collections.namedtuple("DeviceInfo", ["id", "core_version", "manufacturer_version", "core_status", "manufacturer_status", "importer_connected"])
+LeapOffset = collections.namedtuple("LeapOffset", ["pending_leap_offset", "current_leap_offset", "alfn_pending_leap_adjustment"])
+LocalTime = collections.namedtuple("LocalTime", ["utc_offset", "dst_regional", "dst_local", "dst_scheduled"])
 
 class _IQ(ctypes.Structure):
     _fields_ = [
@@ -596,6 +600,20 @@ class _DeviceInfo(ctypes.Structure):
         ("importer_connected", ctypes.c_int),
     ]
 
+class _LeapOffset(ctypes.Structure):
+    _fields_ = [
+        ("pending_leap_offset", ctypes.c_int),
+        ("current_leap_offset", ctypes.c_int),
+        ("alfn_pending_leap_adjustment", ctypes.c_int)
+    ]
+
+class _LocalTime(ctypes.Structure):
+    _fields_ = [
+        ("utc_offset", ctypes.c_int),
+        ("dst_regional", ctypes.c_int),
+        ("dst_local", ctypes.c_int),
+        ("dst_scheduled", ctypes.c_int)
+    ]
 
 class _EventUnion(ctypes.Union):
     _fields_ = [
@@ -623,7 +641,9 @@ class _EventUnion(ctypes.Union):
         ("audio_service", _AudioService),
         ("here_image", _HEREImage),
         ("agc", _AGC),
-        ("device_info", _DeviceInfo)
+        ("device_info", _DeviceInfo),
+        ("leap_offset", _LeapOffset),
+        ("local_time", _LocalTime)
     ]
 
 
@@ -884,6 +904,12 @@ class NRSC5:
             device_info = c_evt.u.device_info
             evt = DeviceInfo(device_info.id, device_info.core_version, device_info.manufacturer_version,
                              device_info.core_status, device_info.manufacturer_status, device_info.importer_connected)
+        elif evt_type == EventType.LEAP_OFFSET:
+            leap_offset = c_evt.u.leap_offset
+            evt = LeapOffset(leap_offset.pending_leap_offset, leap_offset.current_leap_offset, leap_offset.alfn_pending_leap_adjustment)
+        elif evt_type == EventType.LOCAL_TIME:
+            local_time = c_evt.u.local_time
+            evt = LocalTime(local_time.utc_offset, bool(local_time.dst_regional), bool(local_time.dst_local), local_time.dst_scheduled)
 
         self.callback(evt_type, evt, *self.callback_args)
 

--- a/support/nrsc5.py
+++ b/support/nrsc5.py
@@ -41,6 +41,8 @@ class EventType(enum.Enum):
     LOT_HEADER = 24
     LOT_FRAGMENT = 25
     AGC = 26
+    EXCITER_INFO = 27
+    IMPORTER_INFO = 28
 
 
 AUDIO_FRAME_SAMPLES = 2048
@@ -224,7 +226,7 @@ AudioService = collections.namedtuple("AudioService", ["program", "access", "typ
 HEREImage = collections.namedtuple("HEREImage", ["image_type", "seq", "n1", "n2", "time_utc", "latitude1", "longitude1",
                                                  "latitude2", "longitude2", "name", "data"])
 AGC = collections.namedtuple("AGC", ["gain_db", "peak_dbfs", "is_final"])
-
+DeviceInfo = collections.namedtuple("DeviceInfo", ["id", "core_version", "manufacturer_version", "core_status", "manufacturer_status", "importer_connected"])
 
 class _IQ(ctypes.Structure):
     _fields_ = [
@@ -584,6 +586,16 @@ class _AGC(ctypes.Structure):
         ("is_final", ctypes.c_int),
     ]
 
+class _DeviceInfo(ctypes.Structure):
+    _fields_ = [
+        ("id", ctypes.c_char * 2),
+        ("core_version", ctypes.c_int * 4),
+        ("manufacturer_version", ctypes.c_int * 4),
+        ("core_status", ctypes.c_int),
+        ("manufacturer_status", ctypes.c_int),
+        ("importer_connected", ctypes.c_int),
+    ]
+
 
 class _EventUnion(ctypes.Union):
     _fields_ = [
@@ -611,6 +623,7 @@ class _EventUnion(ctypes.Union):
         ("audio_service", _AudioService),
         ("here_image", _HEREImage),
         ("agc", _AGC),
+        ("device_info", _DeviceInfo)
     ]
 
 
@@ -867,6 +880,10 @@ class NRSC5:
         elif evt_type == EventType.AGC:
             agc = c_evt.u.agc
             evt = AGC(agc.gain_db, agc.peak_dbfs, bool(agc.is_final))
+        elif evt_type == EventType.EXCITER_INFO or evt_type == EventType.IMPORTER_INFO:
+            device_info = c_evt.u.device_info
+            evt = DeviceInfo(device_info.id, device_info.core_version, device_info.manufacturer_version,
+                             device_info.core_status, device_info.manufacturer_status, device_info.importer_connected)
 
         self.callback(evt_type, evt, *self.callback_args)
 

--- a/support/nrsc5.py
+++ b/support/nrsc5.py
@@ -43,7 +43,7 @@ class EventType(enum.Enum):
     AGC = 26
     EXCITER_INFO = 27
     IMPORTER_INFO = 28
-    LEAP_OFFSET = 29
+    LEAP_SECOND_OFFSET = 29
     LOCAL_TIME = 30
 
 
@@ -54,6 +54,7 @@ SAMPLE_RATE_CS16_FM = 744187.5
 SAMPLE_RATE_CS16_AM = 46511.71875
 SAMPLE_RATE_AUDIO = 44100
 
+DEVICE_VERSION_LENGTH = 4
 
 class ServiceType(enum.Enum):
     AUDIO = 0
@@ -228,9 +229,10 @@ AudioService = collections.namedtuple("AudioService", ["program", "access", "typ
 HEREImage = collections.namedtuple("HEREImage", ["image_type", "seq", "n1", "n2", "time_utc", "latitude1", "longitude1",
                                                  "latitude2", "longitude2", "name", "data"])
 AGC = collections.namedtuple("AGC", ["gain_db", "peak_dbfs", "is_final"])
-DeviceInfo = collections.namedtuple("DeviceInfo", ["id", "core_version", "manufacturer_version", "core_status", "manufacturer_status", "importer_connected"])
-LeapOffset = collections.namedtuple("LeapOffset", ["pending_leap_offset", "current_leap_offset", "alfn_pending_leap_adjustment"])
-LocalTime = collections.namedtuple("LocalTime", ["utc_offset", "dst_regional", "dst_local", "dst_scheduled"])
+ExciterInfo = collections.namedtuple("ExciterInfo", ["manufacturer_id", "core_version", "core_status", "manufacturer_version", "manufacturer_status", "importer_connected"])
+ImporterInfo = collections.namedtuple("ImporterInfo", ["manufacturer_id", "core_version", "core_status", "manufacturer_version", "manufacturer_status"])
+LeapSecondOffset = collections.namedtuple("LeapOffset", ["pending_offset", "current_offset", "pending_alfn"])
+LocalTime = collections.namedtuple("LocalTime", ["utc_offset", "dst_regional", "dst_local", "dst_schedule"])
 
 class _IQ(ctypes.Structure):
     _fields_ = [
@@ -590,21 +592,30 @@ class _AGC(ctypes.Structure):
         ("is_final", ctypes.c_int),
     ]
 
-class _DeviceInfo(ctypes.Structure):
+class _ExciterInfo(ctypes.Structure):
     _fields_ = [
-        ("id", ctypes.c_char * 2),
-        ("core_version", ctypes.c_int * 4),
-        ("manufacturer_version", ctypes.c_int * 4),
+        ("manufacturer_id", ctypes.c_char_p),
+        ("core_version", ctypes.c_int * DEVICE_VERSION_LENGTH),
         ("core_status", ctypes.c_int),
+        ("manufacturer_version", ctypes.c_int * DEVICE_VERSION_LENGTH),
         ("manufacturer_status", ctypes.c_int),
         ("importer_connected", ctypes.c_int),
     ]
 
+class _ImporterInfo(ctypes.Structure):
+    _fields_ = [
+        ("manufacturer_id", ctypes.c_char_p),
+        ("core_version", ctypes.c_int * DEVICE_VERSION_LENGTH),
+        ("core_status", ctypes.c_int),
+        ("manufacturer_version", ctypes.c_int * DEVICE_VERSION_LENGTH),
+        ("manufacturer_status", ctypes.c_int),
+    ]
+
 class _LeapOffset(ctypes.Structure):
     _fields_ = [
-        ("pending_leap_offset", ctypes.c_int),
-        ("current_leap_offset", ctypes.c_int),
-        ("alfn_pending_leap_adjustment", ctypes.c_int)
+        ("pending_offset", ctypes.c_int),
+        ("current_offset", ctypes.c_int),
+        ("pending_alfn", ctypes.c_uint)
     ]
 
 class _LocalTime(ctypes.Structure):
@@ -612,7 +623,7 @@ class _LocalTime(ctypes.Structure):
         ("utc_offset", ctypes.c_int),
         ("dst_regional", ctypes.c_int),
         ("dst_local", ctypes.c_int),
-        ("dst_scheduled", ctypes.c_int)
+        ("dst_schedule", ctypes.c_int)
     ]
 
 class _EventUnion(ctypes.Union):
@@ -641,8 +652,9 @@ class _EventUnion(ctypes.Union):
         ("audio_service", _AudioService),
         ("here_image", _HEREImage),
         ("agc", _AGC),
-        ("device_info", _DeviceInfo),
-        ("leap_offset", _LeapOffset),
+        ("exciter_info", _ExciterInfo),
+        ("importer_info", _ImporterInfo),
+        ("leap_second_offset", _LeapOffset),
         ("local_time", _LocalTime)
     ]
 
@@ -900,16 +912,19 @@ class NRSC5:
         elif evt_type == EventType.AGC:
             agc = c_evt.u.agc
             evt = AGC(agc.gain_db, agc.peak_dbfs, bool(agc.is_final))
-        elif evt_type == EventType.EXCITER_INFO or evt_type == EventType.IMPORTER_INFO:
-            device_info = c_evt.u.device_info
-            evt = DeviceInfo(device_info.id, device_info.core_version, device_info.manufacturer_version,
-                             device_info.core_status, device_info.manufacturer_status, device_info.importer_connected)
-        elif evt_type == EventType.LEAP_OFFSET:
-            leap_offset = c_evt.u.leap_offset
-            evt = LeapOffset(leap_offset.pending_leap_offset, leap_offset.current_leap_offset, leap_offset.alfn_pending_leap_adjustment)
+        elif evt_type == EventType.EXCITER_INFO:
+            exciter_info = c_evt.u.exciter_info
+            evt = ExciterInfo(self._decode(exciter_info.manufacturer_id), exciter_info.core_version, exciter_info.core_status, exciter_info.manufacturer_version, exciter_info.manufacturer_status,
+                             bool(exciter_info.importer_connected))
+        elif evt_type == EventType.IMPORTER_INFO:
+            importer_info = c_evt.u.importer_info
+            evt = ImporterInfo(self._decode(importer_info.manufacturer_id), importer_info.core_version, importer_info.core_status, importer_info.manufacturer_version, importer_info.manufacturer_status)
+        elif evt_type == EventType.LEAP_SECOND_OFFSET:
+            leap_second_offset = c_evt.u.leap_second_offset
+            evt = LeapSecondOffset(leap_second_offset.pending_offset, leap_second_offset.current_offset, leap_second_offset.pending_alfn)
         elif evt_type == EventType.LOCAL_TIME:
             local_time = c_evt.u.local_time
-            evt = LocalTime(local_time.utc_offset, bool(local_time.dst_regional), bool(local_time.dst_local), local_time.dst_scheduled)
+            evt = LocalTime(local_time.utc_offset, bool(local_time.dst_regional), bool(local_time.dst_local), local_time.dst_schedule)
 
         self.callback(evt_type, evt, *self.callback_args)
 


### PR DESCRIPTION
This PR is to move another five debug messages in library to the API.  #372 

This includes four new events:

- Importer Info
- Exciter Info
- Leap offset
- Local Time

One silly new parameter that has not been logged is importer_connected. This also combines all leap offsets into one debug print.  