### PR TITLE
Refactor SIS

### DIFF
--- a/src/pids.c
+++ b/src/pids.c
@@ -35,6 +35,14 @@
 #define SIS_MSG_ID_EMERGENCY_ALERTS_MESSAGE 9
 #define SIS_MSG_ID_ADV_SERVICE_INFORMATION 10
 
+#define SIS_SERVICE_CATEGORY_AUDIO 0
+#define SIS_SERVICE_CATEGORY_DATA 1
+
+#define SIS_EMERGENCY_ALERTS_SAME 0
+#define SIS_EMERGENCY_ALERTS_FIPS 1
+#define SIS_EMERGENCY_ALERTS_ZIP  2
+
+
 static char *chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZ ?-*$ ";
 static int payload_sizes[] = {
     32, 22, 58, 32, 27, 58, 27, 22,
@@ -179,28 +187,26 @@ static char decode_char7(const uint8_t *bits, int *off)
     return (char) decode_int(bits, off, 7);
 }
 
-static int* decode_locations(const uint8_t *bits, const int len, const int location_format, const int num_locations)
+static int decode_locations(const uint8_t *bits, const int len, int locations[MAX_ALERT_LOCATIONS], const int location_format, const int num_locations)
 {
     int off = 0;
-    int locations[MAX_ALERT_LOCATIONS];
     int previous_location = 0;
     int full_len, compressed_len;
-    int *locations_out;
 
     switch (location_format)
     {
-    case 0: // SAME
+    case SIS_EMERGENCY_ALERTS_SAME:
         full_len = 20;
         compressed_len = 14;
         break;
-    case 1: // FIPS
-    case 2: // ZIP
+    case SIS_EMERGENCY_ALERTS_FIPS:
+    case SIS_EMERGENCY_ALERTS_ZIP:
         full_len = 17;
         compressed_len = 10;
         break;
     default:
         log_warn("Invalid location format: %d", location_format);
-        return NULL;
+        return -1;
     }
 
     for (int i = 0; i < num_locations; i++)
@@ -208,7 +214,7 @@ static int* decode_locations(const uint8_t *bits, const int len, const int locat
         if (off + 1 > len)
         {
             log_warn("Invalid location data");
-            return NULL;
+            return -1;
         }
 
         if ((i == 0) || bits[off++])
@@ -217,9 +223,9 @@ static int* decode_locations(const uint8_t *bits, const int len, const int locat
             if (off + full_len > len)
             {
                 log_warn("Invalid location data");
-                return NULL;
+                return -1;
             }
-            locations[i] = decode_int_reverse(bits, &off, full_len);
+            locations[i] = (int)decode_int_reverse(bits, &off, full_len);
         }
         else
         {
@@ -227,7 +233,7 @@ static int* decode_locations(const uint8_t *bits, const int len, const int locat
             if (off + compressed_len > len)
             {
                 log_warn("Invalid location data");
-                return NULL;
+                return -1;
             }
             int new_digits = (int)decode_int_reverse(bits, &off, compressed_len);
             int old_digits = (previous_location % 100000) - (previous_location % 1000);
@@ -237,17 +243,10 @@ static int* decode_locations(const uint8_t *bits, const int len, const int locat
         previous_location = locations[i];
     }
 
-    locations_out = malloc(sizeof(int) * num_locations);
-    if (locations_out == NULL)
-    {
-        log_warn("Failed to allocate memory for emergency alert locations");
-        return NULL;
-    }
-    memcpy(locations_out, locations, sizeof(int) * num_locations);
-    return locations_out;
+    return 0;
 }
 
-static void decode_control_data(const char *control_data, const int len, int *category1, int *category2, int *location_format, int *num_locations, int **locations_out)
+static void decode_control_data(const char *control_data, const int len, int *category1, int *category2, int locations[MAX_ALERT_LOCATIONS], int *location_format, int *num_locations)
 {
     uint8_t bits[MAX_ALERT_CNT_LEN * 8];
     int off = 0;
@@ -266,8 +265,7 @@ static void decode_control_data(const char *control_data, const int len, int *ca
     *num_locations = (int)decode_int_reverse(bits, &off, 5);
     off += 1; // unknown
 
-    *locations_out = decode_locations(bits + off, len*8 - off, *location_format, *num_locations);
-    if (*locations_out == NULL)
+    if (decode_locations(bits + off, len*8 - off, locations, *location_format, *num_locations) < 0)
         *num_locations = 0;
 }
 
@@ -300,7 +298,7 @@ static void report(pids_t *st)
     int category2 = -1;
     int location_format = -1;
     int num_locations = -1;
-    int *locations = NULL;
+    int locations[MAX_ALERT_LOCATIONS];
 
     if (st->country_code[0] != 0)
         country_code = st->country_code;
@@ -323,7 +321,7 @@ static void report(pids_t *st)
     if (st->alert_displayed)
     {
         alert = utf8_encode(st->alert_encoding, st->alert + st->alert_cnt_len, st->alert_len - st->alert_cnt_len);
-        decode_control_data(st->alert, st->alert_cnt_len, &category1, &category2, &location_format, &num_locations, &locations);
+        decode_control_data(st->alert, st->alert_cnt_len, &category1, &category2, locations, &location_format, &num_locations);
     }
 
     if (!isnan(st->latitude) && !isnan(st->longitude))
@@ -368,7 +366,6 @@ static void report(pids_t *st)
     free(slogan);
     free(message);
     free(alert);
-    free(locations);
 
     while (audio_services)
     {
@@ -599,7 +596,7 @@ static int sis_decode_service_information(pids_t *st, const uint8_t* bits)
 
     switch (category)
     {
-    case 0:
+    case SIS_SERVICE_CATEGORY_AUDIO:
         audio_service.access = (int)decode_int(bits, &off, 1);
         prog_num = (int)decode_int(bits, &off, 6);
         audio_service.type = (int)decode_int(bits, &off, 8);
@@ -621,7 +618,7 @@ static int sis_decode_service_information(pids_t *st, const uint8_t* bits)
             updated = 1;
         }
         break;
-    case 1:
+    case SIS_SERVICE_CATEGORY_DATA:
         data_service.access = (int)decode_int(bits, &off, 1);
         data_service.type = (int)decode_int(bits, &off, 9);
         off += 3; // reserved
@@ -750,6 +747,7 @@ static void sis_decode_parameter(pids_t *st, const uint8_t* bits)
             log_debug("Importer configuration number: %d", parameter);
             break;
         default:
+            log_warn("Unknown SIS parameter index: %d", index);
             break;
         }
     }
@@ -916,12 +914,11 @@ static int sis_decode_emergency_alerts(pids_t *st, const uint8_t *bits)
                 int category2 = -1;
                 int location_format = -1;
                 int num_locations = -1;
-                int *locations = NULL;
+                int locations[MAX_ALERT_LOCATIONS];
                 char *message = utf8_encode(st->alert_encoding, st->alert + st->alert_cnt_len, st->alert_len - st->alert_cnt_len);
-                decode_control_data(st->alert, st->alert_cnt_len, &category1, &category2, &location_format, &num_locations, &locations);
+                decode_control_data(st->alert, st->alert_cnt_len, &category1, &category2, locations, &location_format, &num_locations);
                 nrsc5_report_emergency_alert(st->input->radio, message, (uint8_t *)st->alert, st->alert_cnt_len, category1, category2, location_format, num_locations, locations);
                 free(message);
-                free(locations);
 
                 updated = 1;
             }
@@ -1016,6 +1013,7 @@ static void sis_decode(pids_t *st, const uint8_t *bits)
             off += 58;
             break;
         default:
+            log_warn("Unknown SIS MSG ID: %d", msg_id);
             break;
         }
     }
@@ -1033,10 +1031,9 @@ static void sis_decode(pids_t *st, const uint8_t *bits)
 
 void pids_frame_push(pids_t *st, const uint8_t *bits)
 {
-    int i;
     uint8_t pids[PIDS_FRAME_LEN];
 
-    for (i = 0; i < PIDS_FRAME_LEN; i++)
+    for (int i = 0; i < PIDS_FRAME_LEN; i++)
     {
         pids[i] = bits[((i>>3)<<3) + 7 - (i & 7)];
     }
@@ -1048,7 +1045,7 @@ void pids_frame_push(pids_t *st, const uint8_t *bits)
         if (type == PIDS_TYPE_SIS)
             sis_decode(st, pids + 1);
         else if (type == PIDS_TYPE_LLDS)
-            log_debug("Ignoring LLDS frame.");
+            log_debug("Ignoring LLDS frame");
     }
 }
 

--- a/src/pids.c
+++ b/src/pids.c
@@ -21,6 +21,19 @@
 #include "unicode.h"
 
 #define ALERT_TIMEOUT_LIMIT 16
+#define PIDS_TYPE_SIS 0
+#define PIDS_TYPE_LLDS 1
+
+#define SIS_MSG_ID_STATION_ID 0
+#define SIS_MSG_ID_STATION_NAME_SHORT 1
+#define SIS_MSG_ID_STATION_NAME_LONG  2
+#define SIS_MSG_ID_STATION_LOCATION  4
+#define SIS_MSG_ID_STATION_MESSAGE   5
+#define SIS_MSG_ID_SERVICE_INFORMATION 6
+#define SIS_MSG_ID_PARAMETER_MESSAGE 7
+#define SIS_MSG_ID_UNIVERSAL_SHORT_STATION_NAME 8
+#define SIS_MSG_ID_EMERGENCY_ALERTS_MESSAGE 9
+#define SIS_MSG_ID_ADV_SERVICE_INFORMATION 10
 
 static char *chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZ ?-*$ ";
 static int payload_sizes[] = {
@@ -131,7 +144,7 @@ static int control_data_crc(const char *control_data, int len)
     return reg & 0x0fff;
 }
 
-static unsigned int decode_int(uint8_t *bits, int *off, unsigned int length)
+static unsigned int decode_int(const uint8_t *bits, int *off, unsigned int length)
 {
     unsigned int i, result = 0;
     for (i = 0; i < length; i++)
@@ -142,7 +155,7 @@ static unsigned int decode_int(uint8_t *bits, int *off, unsigned int length)
     return result;
 }
 
-static unsigned int decode_int_reverse(uint8_t *bits, int *off, unsigned int length)
+static unsigned int decode_int_reverse(const uint8_t *bits, int *off, unsigned int length)
 {
     unsigned int i, result = 0;
     for (i = 0; i < length; i++)
@@ -150,23 +163,23 @@ static unsigned int decode_int_reverse(uint8_t *bits, int *off, unsigned int len
     return result;
 }
 
-static int decode_signed_int(uint8_t *bits, int *off, unsigned int length)
+static int decode_signed_int(const uint8_t *bits, int *off, const unsigned int length)
 {
     int result = (int) decode_int(bits, off, length);
     return (result & (1 << (length - 1))) ? result - (1 << length) : result;
 }
 
-static char decode_char5(uint8_t *bits, int *off)
+static char decode_char5(const uint8_t *bits, int *off)
 {
     return chars[decode_int(bits, off, 5)];
 }
 
-static char decode_char7(uint8_t *bits, int *off)
+static char decode_char7(const uint8_t *bits, int *off)
 {
     return (char) decode_int(bits, off, 7);
 }
 
-static int* decode_locations(uint8_t *bits, int len, int location_format, int num_locations)
+static int* decode_locations(const uint8_t *bits, const int len, const int location_format, const int num_locations)
 {
     int off = 0;
     int locations[MAX_ALERT_LOCATIONS];
@@ -216,7 +229,7 @@ static int* decode_locations(uint8_t *bits, int len, int location_format, int nu
                 log_warn("Invalid location data");
                 return NULL;
             }
-            int new_digits = decode_int_reverse(bits, &off, compressed_len);
+            int new_digits = (int)decode_int_reverse(bits, &off, compressed_len);
             int old_digits = (previous_location % 100000) - (previous_location % 1000);
             locations[i] = ((new_digits / 1000) * 100000) + (new_digits % 1000) + old_digits;
         }
@@ -234,24 +247,23 @@ static int* decode_locations(uint8_t *bits, int len, int location_format, int nu
     return locations_out;
 }
 
-static void decode_control_data(const char *control_data, int len, int *category1, int *category2, int *location_format, int *num_locations, int **locations_out)
+static void decode_control_data(const char *control_data, const int len, int *category1, int *category2, int *location_format, int *num_locations, int **locations_out)
 {
-    int i, j;
     uint8_t bits[MAX_ALERT_CNT_LEN * 8];
     int off = 0;
 
-    for (i = 0; i < len; i++)
-        for (j = 0; j < 8; j++)
+    for (int i = 0; i < len; i++)
+        for (int j = 0; j < 8; j++)
             bits[i*8 + j] = ((unsigned char)control_data[i] >> j) & 1;
 
     off += 8; // unknown
     off += 12; // CNT CRC
     off += 8; // unknown
-    *category1 = decode_int_reverse(bits, &off, 5);
-    *category2 = decode_int_reverse(bits, &off, 5);
+    *category1 = (int)decode_int_reverse(bits, &off, 5);
+    *category2 = (int)decode_int_reverse(bits, &off, 5);
     off += 9; // unknown
-    *location_format = decode_int_reverse(bits, &off, 3);
-    *num_locations = decode_int_reverse(bits, &off, 5);
+    *location_format = (int)decode_int_reverse(bits, &off, 3);
+    *num_locations = (int)decode_int_reverse(bits, &off, 5);
     off += 1; // unknown
 
     *locations_out = decode_locations(bits + off, len*8 - off, *location_format, *num_locations);
@@ -259,7 +271,7 @@ static void decode_control_data(const char *control_data, int len, int *category
         *num_locations = 0;
 }
 
-static char *utf8_encode(encoding_t encoding, char *buf, int len)
+static char *utf8_encode(const encoding_t encoding, const char *buf, const int len)
 {
     if (encoding == ENCODING_ISO_8859_1)
         return iso_8859_1_to_utf_8((uint8_t *) buf, len);
@@ -382,37 +394,563 @@ static void reset_alert(pids_t *st)
     st->alert_timeout = 0;
 }
 
-static void decode_sis(pids_t *st, uint8_t *bits)
+static int sis_decode_station_id(pids_t *st, const uint8_t* bits)
 {
-    int payloads, off, i;
+    int updated = 0;
+    char country_code[3] = {0};
+    int fcc_facility_id;
+    int j, off = 0;
+
+    for (j = 0; j < 2; j++)
+    {
+        country_code[j] = decode_char5(bits, &off);
+    }
+    off += 3; // reserved
+    fcc_facility_id = (int)decode_int(bits, &off, 19);
+
+    if ((strcmp(country_code, st->country_code) != 0) || (fcc_facility_id != st->fcc_facility_id))
+    {
+        strcpy(st->country_code, country_code);
+        st->fcc_facility_id = fcc_facility_id;
+        nrsc5_report_station_id(st->input->radio, st->country_code, st->fcc_facility_id);
+        updated = 1;
+    }
+
+    return updated;
+}
+
+static int sis_decode_station_name_short(pids_t *st, const uint8_t* bits)
+{
+    char short_name[8] = {0};
+    int off = 0, updated = 0, j;
+
+    for (j = 0; j < 4; j++)
+    {
+        short_name[j] = decode_char5(bits, &off);
+    }
+    if (bits[off] == 0 && bits[off+1] == 1)
+        strcat(short_name, "-FM");
+    off += 2;
+
+    if (strcmp(short_name, st->short_name) != 0)
+    {
+        strcpy(st->short_name, short_name);
+        nrsc5_report_station_name(st->input->radio, st->short_name);
+        updated = 1;
+    }
+
+    return updated;
+}
+
+static int sis_decode_station_long_name(pids_t *st, const uint8_t* bits)
+{
+    unsigned int j;
+    int updated = 0, off = 0;
+    int tmp = 55;
+
+    const unsigned last_frame = decode_int(bits, &off, 3);
+    const unsigned current_frame = decode_int(bits, &off, 3);
+    const int seq = (int)decode_int(bits, &tmp, 3);
+
+    if ((current_frame == 0) && (seq != st->long_name_seq))
+    {
+        memset(st->long_name, 0, sizeof(st->long_name));
+        memset(st->long_name_have_frame, 0, sizeof(st->long_name_have_frame));
+        st->long_name_seq = seq;
+        st->long_name_displayed = 0;
+    }
+
+    for (j = 0; j < 7; j++)
+        st->long_name[current_frame * 7 + j] = decode_char7(bits, &off);
+    st->long_name_have_frame[current_frame] = 1;
+
+    if ((st->long_name_seq >= 0) && !st->long_name_displayed)
+    {
+        int complete = 1;
+        for (j = 0; j < last_frame + 1; j++)
+            complete &= st->long_name_have_frame[j];
+
+        if (complete)
+        {
+            st->long_name_displayed = 1;
+
+            if (!st->slogan_displayed)
+            {
+                char *slogan = utf8_encode(ENCODING_ISO_8859_1, st->long_name, strlen(st->long_name));
+                nrsc5_report_station_slogan(st->input->radio, slogan);
+                free(slogan);
+            }
+
+            updated = 1;
+        }
+    }
+    return updated;
+}
+
+static int sis_decode_station_location(pids_t *st, const uint8_t* bits)
+{
+    int updated = 0, off = 0;
+
+    if (bits[off++])
+    {
+        const float latitude = (float)decode_signed_int(bits, &off, 22) / 8192.0f;
+        const unsigned int altitude_high = decode_int(bits, &off, 4) << 8;
+        if ((latitude != st->latitude) || (altitude_high != (st->altitude & 0xf00)))
+        {
+            st->latitude = latitude;
+            st->altitude = (st->altitude & 0x0f0) | altitude_high;
+            if (!isnan(st->longitude))
+            {
+                nrsc5_report_station_location(st->input->radio, st->latitude, st->longitude, st->altitude);
+                updated = 1;
+            }
+        }
+    }
+    else
+    {
+        const float longitude = (float)decode_signed_int(bits, &off, 22) / 8192.0f;
+        const unsigned altitude_low = decode_int(bits, &off, 4) << 4;
+        if ((longitude != st->longitude) || (altitude_low != (st->altitude & 0x0f0)))
+        {
+            st->longitude = longitude;
+            st->altitude = (st->altitude & 0xf00) | altitude_low;
+            if (!isnan(st->latitude))
+            {
+                nrsc5_report_station_location(st->input->radio, st->latitude, st->longitude, st->altitude);
+                updated = 1;
+            }
+        }
+    }
+
+    return updated;
+}
+
+static int sis_decode_station_message(pids_t *st, const uint8_t* bits)
+{
+    int off = 0, updated = 0, j;
+    const int current_frame = (int)decode_int(bits, &off, 5);
+    const int seq = (int)decode_int(bits, &off, 2);
+
+    if (current_frame == 0)
+    {
+        if (seq != st->message_seq)
+        {
+            memset(st->message, 0, sizeof(st->message));
+            memset(st->message_have_frame, 0, sizeof(st->message_have_frame));
+            st->message_seq = seq;
+            st->message_displayed = 0;
+        }
+        st->message_priority = bits[off++];
+        st->message_encoding = decode_int(bits, &off, 3);
+        st->message_len = (int)decode_int(bits, &off, 8);
+        st->message_checksum = decode_int(bits, &off, 7);
+        for (j = 0; j < 4; j++)
+            st->message[j] = (char)decode_int(bits, &off, 8);
+    }
+    else
+    {
+        off += 3; // reserved
+        for (j = 0; j < 6; j++)
+            st->message[current_frame * 6 - 2 + j] = (char)decode_int(bits, &off, 8);
+    }
+    st->message_have_frame[current_frame] = 1;
+
+    if ((st->message_seq >= 0) && !st->message_displayed)
+    {
+        int complete = 1;
+        for (j = 0; j < (st->message_len + 7) / 6; j++)
+            complete &= st->message_have_frame[j];
+
+        if (complete)
+        {
+            unsigned int checksum = 0;
+            for (j = 0; j < st->message_len; j++)
+                checksum += (unsigned char) st->message[j];
+            checksum = (((checksum >> 8) & 0x7f) + (checksum & 0xff)) & 0x7f;
+
+            if (checksum == st->message_checksum)
+            {
+                st->message_displayed = 1;
+
+                char *message = utf8_encode(st->message_encoding, st->message, st->message_len);
+                nrsc5_report_station_message(st->input->radio, message);
+                free(message);
+
+                updated = 1;
+            }
+            else
+            {
+                log_warn("Invalid message checksum: %d != %d", st->message_checksum, checksum);
+            }
+        }
+    }
+
+    return updated;
+}
+
+static int sis_decode_service_information(pids_t *st, const uint8_t* bits)
+{
+    int updated = 0, off = 0, j;
+    int prog_num;
+    asd_t audio_service;
+    dsd_t data_service;
+
+    const unsigned int category = decode_int(bits, &off, 2);
+
+    switch (category)
+    {
+    case 0:
+        audio_service.access = (int)decode_int(bits, &off, 1);
+        prog_num = (int)decode_int(bits, &off, 6);
+        audio_service.type = (int)decode_int(bits, &off, 8);
+        off += 5; // reserved
+        audio_service.sound_exp = (int)decode_int(bits, &off, 5);
+
+        if (prog_num >= MAX_AUDIO_SERVICES)
+        {
+            log_warn("Invalid program number: %d", prog_num);
+            break;
+        }
+
+        if (st->audio_services[prog_num].access != audio_service.access
+            || st->audio_services[prog_num].type != audio_service.type
+            || st->audio_services[prog_num].sound_exp != audio_service.sound_exp)
+        {
+            st->audio_services[prog_num] = audio_service;
+            nrsc5_report_asd(st->input->radio, prog_num, audio_service.access, audio_service.type, audio_service.sound_exp);
+            updated = 1;
+        }
+        break;
+    case 1:
+        data_service.access = (int)decode_int(bits, &off, 1);
+        data_service.type = (int)decode_int(bits, &off, 9);
+        off += 3; // reserved
+        data_service.mime_type = (int)decode_int(bits, &off, 12);
+
+        for (j = 0; j < MAX_DATA_SERVICES; j++)
+        {
+            if (st->data_services[j].access == data_service.access
+                && st->data_services[j].type == data_service.type
+                && st->data_services[j].mime_type == data_service.mime_type)
+            {
+                break;
+            }
+            else if (st->data_services[j].type == -1)
+            {
+                st->data_services[j] = data_service;
+                nrsc5_report_dsd(st->input->radio, data_service.access, data_service.type, data_service.mime_type);
+                updated = 1;
+                break;
+            }
+        }
+        break;
+    default:
+        log_warn("Unknown service category identifier: %d", category);
+    }
+
+    return updated;
+}
+
+static void sis_decode_parameter(pids_t *st, const uint8_t* bits)
+{
+    int off = 0;
+
+    const unsigned int index = decode_int(bits, &off, 6);
+    const int parameter = (int)decode_int(bits, &off, 16);
+
+    if (index >= NUM_PARAMETERS)
+    {
+        log_warn("Invalid parameter index: %d", index);
+        return;
+    }
+
+    if (st->parameters[index] != parameter)
+    {
+        st->parameters[index] = parameter;
+        switch (index)
+        {
+        case 0:
+        case 1:
+        case 2:
+            if (st->parameters[0] >= 0 && st->parameters[1] >= 0 && st->parameters[2] >= 0)
+            {
+                const int pending_offset = st->parameters[0] >> 8;
+                const int current_offset = st->parameters[0] & 0xff;
+                const unsigned int pending_alfn = (unsigned int)st->parameters[2] << 16 | st->parameters[1];
+
+                nrsc5_report_leap_second_offset(st->input->radio, pending_offset, current_offset, pending_alfn);
+            }
+            break;
+        case 3:
+            {
+                const int dst_regional = st->parameters[3] & 0x1;
+                const int dst_local = (st->parameters[3] >> 1) & 0x1;
+                const int dst_schedule = (st->parameters[3] >> 2) & 0x7;
+                int tzo = (st->parameters[3] >> 5) & 0x7ff;
+
+                if (tzo >= 1024)
+                    tzo -= 2048;
+
+                nrsc5_report_local_time(st->input->radio, tzo, dst_regional, dst_local, dst_schedule);
+            }
+            break;
+        case 4:
+        case 5:
+        case 6:
+        case 7:
+            if (st->parameters[4] >= 0 && st->parameters[5] >= 0 && st->parameters[6] >= 0 && st->parameters[7] >= 0)
+            {
+                const char manufacturer_id[3] = {
+                    (char)((st->parameters[4] >> 8) & 0x7f), (char)(st->parameters[4] & 0x7f),
+                    '\0'
+                };
+                const int core_version[NRSC5_DEVICE_VERSION_LENGTH] = {
+                    (st->parameters[5] >> 11) & 0x1f, (st->parameters[5] >> 6) & 0x1f, (st->parameters[5] >> 1) & 0x1f,
+                    (st->parameters[7] >> 11) & 0x1f
+                };
+                const int manufacturer_version[NRSC5_DEVICE_VERSION_LENGTH] = {
+                    (st->parameters[6] >> 11) & 0x1f, (st->parameters[6] >> 6) & 0x1f, (st->parameters[6] >> 1) & 0x1f,
+                    (st->parameters[7] >> 6) & 0x1f,
+                };
+
+                const int core_status = (st->parameters[7] >> 3) & 0x7;
+                const int manufacturer_status = st->parameters[7] & 0x7;
+                const int importer_connected = (st->parameters[4] >> 7) & 0x1;
+
+                nrsc5_report_exciter_info(st->input->radio, manufacturer_id, core_version, manufacturer_version,
+                    core_status, manufacturer_status, importer_connected);
+            }
+            break;
+        case 8:
+        case 9:
+        case 10:
+        case 11:
+            if (st->parameters[8] >= 0 && st->parameters[9] >= 0 && st->parameters[10] >= 0 && st->parameters[11] >= 0)
+            {
+                const char manufacturer_id[3] = {
+                    (char)((st->parameters[8] >> 8) & 0x7f), (char)(st->parameters[8] & 0x7f),
+                    '\0'
+                };
+                const int core_version[NRSC5_DEVICE_VERSION_LENGTH] = {
+                    (st->parameters[9] >> 11) & 0x1f, (st->parameters[9] >> 6) & 0x1f, (st->parameters[9] >> 1) & 0x1f,
+                    (st->parameters[11] >> 11) & 0x1f,
+                };
+                const int manufacturer_version[NRSC5_DEVICE_VERSION_LENGTH] = {
+                    (st->parameters[10] >> 11) & 0x1f, (st->parameters[10] >> 6) & 0x1f, (st->parameters[10] >> 1) & 0x1f,
+                    (st->parameters[11] >> 6) & 0x1f
+                };
+                const int core_status = (st->parameters[11] >> 3) & 0x7;
+                const int manufacturer_status = st->parameters[11] & 0x7;
+
+                nrsc5_report_importer_info(st->input->radio, manufacturer_id, core_version, manufacturer_version,
+                    core_status, manufacturer_status);
+            }
+            break;
+        case 12:
+            log_debug("Importer configuration number: %d", parameter);
+            break;
+        default:
+            break;
+        }
+    }
+}
+
+static int sis_decode_universal_short_station_name(pids_t *st, const uint8_t *bits)
+{
+    int j, off = 0;
     int updated = 0;
 
-    if (bits[0] != 0) return;
-    payloads = bits[1] + 1;
-    off = 2;
+    const unsigned int current_frame = decode_int(bits, &off, 4);
+    if (bits[off++] == 0)
+    {
+        if (current_frame >= MAX_UNIVERSAL_SHORT_NAME_FRAMES)
+        {
+            log_error("unexpected frame number in Universal Short Station Name: %d", current_frame);
+            off += 53;
+            return 0;
+        }
+
+        if (current_frame == 0)
+        {
+            st->universal_short_name_encoding = decode_int(bits, &off, 3);
+            st->universal_short_name_append = bits[off++];
+            st->universal_short_name_len = bits[off++] + 1;
+            for (j = 0; j < 6; j++)
+                st->universal_short_name[j] = (char)decode_int(bits, &off, 8);
+        }
+        else
+        {
+            off += 5; // reserved
+            for (j = 0; j < 6; j++)
+                st->universal_short_name[current_frame * 6 + j] = (char)decode_int(bits, &off, 8);
+        }
+        st->universal_short_name_have_frame[current_frame] = 1;
+
+        if (st->universal_short_name_len >= 0 && !st->universal_short_name_displayed)
+        {
+            int complete = 1;
+            for (j = 0; j < st->universal_short_name_len; j++)
+                complete &= st->universal_short_name_have_frame[j];
+
+            if (complete)
+            {
+                strcpy(st->universal_short_name_final, st->universal_short_name);
+                if (st->universal_short_name_append)
+                    strcat(st->universal_short_name_final, "-FM");
+                st->universal_short_name_displayed = 1;
+
+                char *name = utf8_encode(st->universal_short_name_encoding,
+                                         st->universal_short_name_final,
+                                         strlen(st->universal_short_name_final));
+                nrsc5_report_station_name(st->input->radio, name);
+                free(name);
+
+                updated = 1;
+            }
+        }
+    }
+    else
+    {
+        if (current_frame == 0)
+        {
+            st->slogan_encoding = decode_int(bits, &off, 3);
+            off += 3; // reserved
+            st->slogan_len = (int)decode_int(bits, &off, 7);
+            for (j = 0; j < 5; j++)
+                st->slogan[j] = (char)decode_int(bits, &off, 8);
+        }
+        else
+        {
+            off += 5; // reserved
+            for (j = 0; j < 6; j++)
+                st->slogan[current_frame * 6 - 1 + j] = (char)decode_int(bits, &off, 8);
+        }
+        st->slogan_have_frame[current_frame] = 1;
+
+        if (st->slogan_len >= 0 && !st->slogan_displayed)
+        {
+            int complete = 1;
+            for (j = 0; j < (st->slogan_len + 6) / 6; j++)
+                complete &= st->slogan_have_frame[j];
+
+            if (complete)
+            {
+                st->slogan_displayed = 1;
+
+                if (!st->long_name_displayed)
+                {
+                    char *slogan = utf8_encode(st->slogan_encoding, st->slogan, st->slogan_len);
+                    nrsc5_report_station_slogan(st->input->radio, slogan);
+                    free(slogan);
+                }
+
+                updated = 1;
+            }
+        }
+    }
+
+    return updated;
+}
+
+static int sis_decode_emergency_alerts(pids_t *st, const uint8_t *bits)
+{
+    int off = 0, updated = 0, j;
+
+    const unsigned int current_frame = decode_int(bits, &off, 6);
+    const int seq = (int)decode_int(bits, &off, 2);
+    off += 2; // reserved
+
+    st->alert_timeout = 0;
+
+    if (current_frame == 0)
+    {
+        if (seq != st->alert_seq)
+        {
+            memset(st->alert, 0, sizeof(st->alert));
+            memset(st->alert_have_frame, 0, sizeof(st->alert_have_frame));
+            st->alert_seq = seq;
+            st->alert_displayed = 0;
+        }
+        st->alert_encoding = decode_int(bits, &off, 3);
+        st->alert_len = (int)decode_int(bits, &off, 9);
+        st->alert_crc = (int)decode_int(bits, &off, 7);
+        st->alert_cnt_len = 1 + (2 * (int)decode_int(bits, &off, 5));
+        for (j = 0; j < 3; j++)
+            st->alert[j] = (char)decode_int(bits, &off, 8);
+    }
+    else
+    {
+        for (j = 0; j < 6; j++)
+            st->alert[current_frame * 6 - 3 + j] = (char)decode_int(bits, &off, 8);
+    }
+    st->alert_have_frame[current_frame] = 1;
+
+    if (st->alert_len >= 0 && !st->alert_displayed)
+    {
+        int complete = 1;
+        for (j = 0; j < (st->alert_len + 8) / 6; j++)
+            complete &= st->alert_have_frame[j];
+
+        if (complete)
+        {
+            const int expected_alert_crc = crc7(st->alert, st->alert_len);
+            if (st->alert_crc != expected_alert_crc)
+            {
+                log_warn("Invalid alert CRC: 0x%02x != 0x%02x", st->alert_crc, expected_alert_crc);
+                return 0;
+            }
+
+            if ((st->alert_cnt_len < 7) || (st->alert_len < st->alert_cnt_len))
+            {
+                log_warn("Invalid alert CNT length");
+                return 0;
+            }
+
+            const int actual_cnt_crc = (((unsigned char)st->alert[2] & 0x0f) << 8) | (unsigned char)st->alert[1];
+            const int expected_cnt_crc = control_data_crc(st->alert, st->alert_cnt_len);
+            if (actual_cnt_crc == expected_cnt_crc)
+            {
+                st->alert_displayed = 1;
+
+                int category1 = -1;
+                int category2 = -1;
+                int location_format = -1;
+                int num_locations = -1;
+                int *locations = NULL;
+                char *message = utf8_encode(st->alert_encoding, st->alert + st->alert_cnt_len, st->alert_len - st->alert_cnt_len);
+                decode_control_data(st->alert, st->alert_cnt_len, &category1, &category2, &location_format, &num_locations, &locations);
+                nrsc5_report_emergency_alert(st->input->radio, message, (uint8_t *)st->alert, st->alert_cnt_len, category1, category2, location_format, num_locations, locations);
+                free(message);
+                free(locations);
+
+                updated = 1;
+            }
+            else
+            {
+                log_warn("Invalid CNT CRC: 0x%03x != 0x%03x", actual_cnt_crc, expected_cnt_crc);
+            }
+        }
+    }
+
+    return updated;
+}
+
+static void sis_decode(pids_t *st, const uint8_t *bits)
+{
+    int off = 0;
+    int updated = 0;
+
+    const int payloads = bits[0] + 1;
+    off += 1;
 
     if (st->alert_displayed)
         st->alert_timeout++;
 
-    for (i = 0; i < payloads; i++)
+    for (int i = 0; i < payloads; i++)
     {
-        int msg_id, payload_size, j;
-        char country_code[3] = {0};
-        int fcc_facility_id;
-        char short_name[8] = {0};
-        int seq;
-        int current_frame;
-        int last_frame;
-        float latitude, longitude;
-        int altitude_high, altitude_low;
-        int category, prog_num;
-        asd_t audio_service;
-        dsd_t data_service;
-        int index, parameter;
-
-        if (off > 60) break;
-        msg_id = decode_int(bits, &off, 4);
-        payload_size = payload_sizes[msg_id];
+        if (off > 59) break;
+        const unsigned int msg_id = decode_int(bits, &off, 4);
+        const int payload_size = payload_sizes[msg_id];
 
         if (payload_size == -1)
         {
@@ -420,7 +958,7 @@ static void decode_sis(pids_t *st, uint8_t *bits)
             break;
         }
 
-        if (off > 64 - payload_size)
+        if (off > 63 - payload_size)
         {
             log_error("not enough room for SIS payload, msg_id: %d", msg_id);
             break;
@@ -428,491 +966,56 @@ static void decode_sis(pids_t *st, uint8_t *bits)
 
         switch (msg_id)
         {
-        case 0:
-            for (j = 0; j < 2; j++)
-            {
-                country_code[j] = decode_char5(bits, &off);
-            }
-            off += 3; // reserved
-            fcc_facility_id = decode_int(bits, &off, 19);
-
-            if ((strcmp(country_code, st->country_code) != 0) || (fcc_facility_id != st->fcc_facility_id))
-            {
-                strcpy(st->country_code, country_code);
-                st->fcc_facility_id = fcc_facility_id;
-                nrsc5_report_station_id(st->input->radio, st->country_code, st->fcc_facility_id);
+        case SIS_MSG_ID_STATION_ID:
+            if (sis_decode_station_id(st, bits + off))
                 updated = 1;
-            }
-            break;
-        case 1:
-            for (j = 0; j < 4; j++)
-            {
-                short_name[j] = decode_char5(bits, &off);
-            }
-            if (bits[off] == 0 && bits[off+1] == 1)
-                strcat(short_name, "-FM");
-            off += 2;
-
-            if (strcmp(short_name, st->short_name) != 0)
-            {
-                strcpy(st->short_name, short_name);
-                nrsc5_report_station_name(st->input->radio, st->short_name);
-                updated = 1;
-            }
-            break;
-        case 2:
-            off += 55;
-            seq = decode_int(bits, &off, 3);
-            off -= 58;
-
-            last_frame = decode_int(bits, &off, 3);
-            current_frame = decode_int(bits, &off, 3);
-
-            if ((current_frame == 0) && (seq != st->long_name_seq))
-            {
-                memset(st->long_name, 0, sizeof(st->long_name));
-                memset(st->long_name_have_frame, 0, sizeof(st->long_name_have_frame));
-                st->long_name_seq = seq;
-                st->long_name_displayed = 0;
-            }
-
-            for (j = 0; j < 7; j++)
-                st->long_name[current_frame * 7 + j] = decode_char7(bits, &off);
-            st->long_name_have_frame[current_frame] = 1;
-
-            if ((st->long_name_seq >= 0) && !st->long_name_displayed)
-            {
-                int complete = 1;
-                for (j = 0; j < last_frame + 1; j++)
-                    complete &= st->long_name_have_frame[j];
-
-                if (complete)
-                {
-                    st->long_name_displayed = 1;
-
-                    if (!st->slogan_displayed)
-                    {
-                        char *slogan = utf8_encode(ENCODING_ISO_8859_1, st->long_name, strlen(st->long_name));
-                        nrsc5_report_station_slogan(st->input->radio, slogan);
-                        free(slogan);
-                    }
-
-                    updated = 1;
-                }
-            }
-
-            off += 3;
-            break;
-        case 3:
             off += 32;
             break;
-        case 4:
-            if (bits[off++])
-            {
-                latitude = decode_signed_int(bits, &off, 22) / 8192.0;
-                altitude_high = decode_int(bits, &off, 4) << 8;
-                if ((latitude != st->latitude) || (altitude_high != (st->altitude & 0xf00)))
-                {
-                    st->latitude = latitude;
-                    st->altitude = (st->altitude & 0x0f0) | altitude_high;
-                    if (!isnan(st->longitude))
-                    {
-                        nrsc5_report_station_location(st->input->radio, st->latitude, st->longitude, st->altitude);
-                        updated = 1;
-                    }
-                }
-            }
-            else
-            {
-                longitude = decode_signed_int(bits, &off, 22) / 8192.0;
-                altitude_low = decode_int(bits, &off, 4) << 4;
-                if ((longitude != st->longitude) || (altitude_low != (st->altitude & 0x0f0)))
-                {
-                    st->longitude = longitude;
-                    st->altitude = (st->altitude & 0xf00) | altitude_low;
-                    if (!isnan(st->latitude))
-                    {
-                        nrsc5_report_station_location(st->input->radio, st->latitude, st->longitude, st->altitude);
-                        updated = 1;
-                    }
-                }
-            }
+        case SIS_MSG_ID_STATION_NAME_SHORT:
+            if (sis_decode_station_name_short(st, bits + off))
+                updated = 1;
+            off += 22;
             break;
-        case 5:
-            current_frame = decode_int(bits, &off, 5);
-            seq = decode_int(bits, &off, 2);
-
-            if (current_frame == 0)
-            {
-                if (seq != st->message_seq)
-                {
-                    memset(st->message, 0, sizeof(st->message));
-                    memset(st->message_have_frame, 0, sizeof(st->message_have_frame));
-                    st->message_seq = seq;
-                    st->message_displayed = 0;
-                }
-                st->message_priority = bits[off++];
-                st->message_encoding = decode_int(bits, &off, 3);
-                st->message_len = decode_int(bits, &off, 8);
-                st->message_checksum = decode_int(bits, &off, 7);
-                for (j = 0; j < 4; j++)
-                    st->message[j] = decode_int(bits, &off, 8);
-            }
-            else
-            {
-                off += 3; // reserved
-                for (j = 0; j < 6; j++)
-                    st->message[current_frame * 6 - 2 + j] = decode_int(bits, &off, 8);
-            }
-            st->message_have_frame[current_frame] = 1;
-
-            if ((st->message_seq >= 0) && !st->message_displayed)
-            {
-                int complete = 1;
-                for (j = 0; j < (st->message_len + 7) / 6; j++)
-                    complete &= st->message_have_frame[j];
-
-                if (complete)
-                {
-                    unsigned int checksum = 0;
-                    for (j = 0; j < st->message_len; j++)
-                        checksum += (unsigned char) st->message[j];
-                    checksum = (((checksum >> 8) & 0x7f) + (checksum & 0xff)) & 0x7f;
-
-                    if (checksum == st->message_checksum)
-                    {
-                        st->message_displayed = 1;
-
-                        char *message = utf8_encode(st->message_encoding, st->message, st->message_len);
-                        nrsc5_report_station_message(st->input->radio, message);
-                        free(message);
-
-                        updated = 1;
-                    }
-                    else
-                    {
-                        log_warn("Invalid message checksum: %d != %d", st->message_checksum, checksum);
-                    }
-                }
-            }
+        case SIS_MSG_ID_STATION_NAME_LONG:
+            if (sis_decode_station_long_name(st, bits + off))
+                updated = 1;
+            off += 58;
             break;
-        case 6:
-        case 10:
-            category = decode_int(bits, &off, 2);
-            switch (category)
-            {
-            case 0:
-                audio_service.access = decode_int(bits, &off, 1);
-                prog_num = decode_int(bits, &off, 6);
-                audio_service.type = decode_int(bits, &off, 8);
-                off += 5; // reserved
-                audio_service.sound_exp = decode_int(bits, &off, 5);
-
-                if (prog_num >= MAX_AUDIO_SERVICES)
-                {
-                    log_warn("Invalid program number: %d", prog_num);
-                    break;
-                }
-
-                if (st->audio_services[prog_num].access != audio_service.access
-                    || st->audio_services[prog_num].type != audio_service.type
-                    || st->audio_services[prog_num].sound_exp != audio_service.sound_exp)
-                {
-                    st->audio_services[prog_num] = audio_service;
-                    nrsc5_report_asd(st->input->radio, prog_num, audio_service.access, audio_service.type, audio_service.sound_exp);
-                    updated = 1;
-                }
-                break;
-            case 1:
-                data_service.access = decode_int(bits, &off, 1);
-                data_service.type = decode_int(bits, &off, 9);
-                off += 3; // reserved
-                data_service.mime_type = decode_int(bits, &off, 12);
-
-                for (j = 0; j < MAX_DATA_SERVICES; j++)
-                {
-                    if (st->data_services[j].access == data_service.access
-                        && st->data_services[j].type == data_service.type
-                        && st->data_services[j].mime_type == data_service.mime_type)
-                    {
-                        break;
-                    }
-                    else if (st->data_services[j].type == -1)
-                    {
-                        st->data_services[j] = data_service;
-                        nrsc5_report_dsd(st->input->radio, data_service.access, data_service.type, data_service.mime_type);
-                        updated = 1;
-                        break;
-                    }
-                }
-                break;
-            default:
-                log_warn("Unknown service category identifier: %d", category);
-            }
+        case 3:
+            // reserved
+            off += 32;
             break;
-        case 7:
-            index = decode_int(bits, &off, 6);
-            parameter = decode_int(bits, &off, 16);
-            if (index >= NUM_PARAMETERS)
-            {
-                log_warn("Invalid parameter index: %d", index);
-                break;
-            }
-            if (st->parameters[index] != parameter)
-            {
-                st->parameters[index] = parameter;
-                switch (index)
-                {
-                case 0:
-                case 1:
-                case 2:
-                    if (st->parameters[0] >= 0 && st->parameters[1] >= 0 && st->parameters[2] >= 0)
-                    {
-                        const int pending_offset = st->parameters[0] >> 8;
-                        const int current_offset = st->parameters[0] & 0xff;
-                        const unsigned int pending_alfn = (unsigned int)st->parameters[2] << 16 | st->parameters[1];
-
-                        nrsc5_report_leap_second_offset(st->input->radio, pending_offset, current_offset, pending_alfn);
-                    }
-                    break;
-                case 3:
-                    {
-                        const int dst_regional = st->parameters[3] & 0x1;
-                        const int dst_local = (st->parameters[3] >> 1) & 0x1;
-                        const int dst_schedule = (st->parameters[3] >> 2) & 0x7;
-                        int tzo = (st->parameters[3] >> 5) & 0x7ff;
-
-                        if (tzo >= 1024)
-                            tzo -= 2048;
-
-                        nrsc5_report_local_time(st->input->radio, tzo, dst_regional, dst_local, dst_schedule);
-                    }
-                    break;
-                case 4:
-                case 5:
-                case 6:
-                case 7:
-                    if (st->parameters[4] >= 0 && st->parameters[5] >= 0 && st->parameters[6] >= 0 && st->parameters[7] >= 0)
-                    {
-                        const char manufacturer_id[3] = {
-                            (char)((st->parameters[4] >> 8) & 0x7f), (char)(st->parameters[4] & 0x7f),
-                            '\0'
-                        };
-                        const int core_version[NRSC5_DEVICE_VERSION_LENGTH] = {
-                            (st->parameters[5] >> 11) & 0x1f, (st->parameters[5] >> 6) & 0x1f, (st->parameters[5] >> 1) & 0x1f,
-                            (st->parameters[7] >> 11) & 0x1f
-                        };
-                        const int manufacturer_version[NRSC5_DEVICE_VERSION_LENGTH] = {
-                            (st->parameters[6] >> 11) & 0x1f, (st->parameters[6] >> 6) & 0x1f, (st->parameters[6] >> 1) & 0x1f,
-                            (st->parameters[7] >> 6) & 0x1f,
-                        };
-
-                        const int core_status = (st->parameters[7] >> 3) & 0x7;
-                        const int manufacturer_status = st->parameters[7] & 0x7;
-                        const int importer_connected = (st->parameters[4] >> 7) & 0x1;
-
-                        nrsc5_report_exciter_info(st->input->radio, manufacturer_id, core_version, manufacturer_version,
-                            core_status, manufacturer_status, importer_connected);
-                    }
-                    break;
-                case 8:
-                case 9:
-                case 10:
-                case 11:
-                    if (st->parameters[8] >= 0 && st->parameters[9] >= 0 && st->parameters[10] >= 0 && st->parameters[11] >= 0)
-                    {
-                        const char manufacturer_id[3] = {
-                            (char)((st->parameters[8] >> 8) & 0x7f), (char)(st->parameters[8] & 0x7f),
-                            '\0'
-                        };
-                        const int core_version[NRSC5_DEVICE_VERSION_LENGTH] = {
-                            (st->parameters[9] >> 11) & 0x1f, (st->parameters[9] >> 6) & 0x1f, (st->parameters[9] >> 1) & 0x1f,
-                            (st->parameters[11] >> 11) & 0x1f,
-                        };
-                        const int manufacturer_version[NRSC5_DEVICE_VERSION_LENGTH] = {
-                            (st->parameters[10] >> 11) & 0x1f, (st->parameters[10] >> 6) & 0x1f, (st->parameters[10] >> 1) & 0x1f,
-                            (st->parameters[11] >> 6) & 0x1f
-                        };
-                        const int core_status = (st->parameters[11] >> 3) & 0x7;
-                        const int manufacturer_status = st->parameters[11] & 0x7;
-
-                        nrsc5_report_importer_info(st->input->radio, manufacturer_id, core_version, manufacturer_version,
-                            core_status, manufacturer_status);
-                    }
-                    break;
-                case 12:
-                    log_debug("Importer configuration number: %d", parameter);
-                    break;
-                }
-            }
+        case SIS_MSG_ID_STATION_LOCATION:
+            if (sis_decode_station_location(st, bits + off))
+                updated = 1;
+            off += 27;
             break;
-        case 8:
-            current_frame = decode_int(bits, &off, 4);
-            if (bits[off++] == 0)
-            {
-                if (current_frame >= MAX_UNIVERSAL_SHORT_NAME_FRAMES)
-                {
-                    log_error("unexpected frame number in Universal Short Station Name: %d", current_frame);
-                    off += 53;
-                    break;
-                }
-
-                if (current_frame == 0)
-                {
-                    st->universal_short_name_encoding = decode_int(bits, &off, 3);
-                    st->universal_short_name_append = bits[off++];
-                    st->universal_short_name_len = bits[off++] + 1;
-                    for (j = 0; j < 6; j++)
-                        st->universal_short_name[j] = decode_int(bits, &off, 8);
-                }
-                else
-                {
-                    off += 5; // reserved
-                    for (j = 0; j < 6; j++)
-                        st->universal_short_name[current_frame * 6 + j] = decode_int(bits, &off, 8);
-                }
-                st->universal_short_name_have_frame[current_frame] = 1;
-
-                if (st->universal_short_name_len >= 0 && !st->universal_short_name_displayed)
-                {
-                    int complete = 1;
-                    for (j = 0; j < st->universal_short_name_len; j++)
-                        complete &= st->universal_short_name_have_frame[j];
-
-                    if (complete)
-                    {
-                        strcpy(st->universal_short_name_final, st->universal_short_name);
-                        if (st->universal_short_name_append)
-                            strcat(st->universal_short_name_final, "-FM");
-                        st->universal_short_name_displayed = 1;
-
-                        char *name = utf8_encode(st->universal_short_name_encoding,
-                                                 st->universal_short_name_final,
-                                                 strlen(st->universal_short_name_final));
-                        nrsc5_report_station_name(st->input->radio, name);
-                        free(name);
-
-                        updated = 1;
-                    }
-                }
-            }
-            else
-            {
-                if (current_frame == 0)
-                {
-                    st->slogan_encoding = decode_int(bits, &off, 3);
-                    off += 3; // reserved
-                    st->slogan_len = decode_int(bits, &off, 7);
-                    for (j = 0; j < 5; j++)
-                        st->slogan[j] = decode_int(bits, &off, 8);
-                }
-                else
-                {
-                    off += 5; // reserved
-                    for (j = 0; j < 6; j++)
-                        st->slogan[current_frame * 6 - 1 + j] = decode_int(bits, &off, 8);
-                }
-                st->slogan_have_frame[current_frame] = 1;
-
-                if (st->slogan_len >= 0 && !st->slogan_displayed)
-                {
-                    int complete = 1;
-                    for (j = 0; j < (st->slogan_len + 6) / 6; j++)
-                        complete &= st->slogan_have_frame[j];
-
-                    if (complete)
-                    {
-                        st->slogan_displayed = 1;
-
-                        if (!st->long_name_displayed)
-                        {
-                            char *slogan = utf8_encode(st->slogan_encoding, st->slogan, st->slogan_len);
-                            nrsc5_report_station_slogan(st->input->radio, slogan);
-                            free(slogan);
-                        }
-
-                        updated = 1;
-                    }
-                }
-            }
+        case SIS_MSG_ID_STATION_MESSAGE:
+            if (sis_decode_station_message(st, bits + off))
+                updated = 1;
+            off += 58;
             break;
-        case 9:
-            st->alert_timeout = 0;
-            current_frame = decode_int(bits, &off, 6);
-            seq = decode_int(bits, &off, 2);
-            off += 2; // reserved
-
-            if (current_frame == 0)
-            {
-                if (seq != st->alert_seq)
-                {
-                    memset(st->alert, 0, sizeof(st->alert));
-                    memset(st->alert_have_frame, 0, sizeof(st->alert_have_frame));
-                    st->alert_seq = seq;
-                    st->alert_displayed = 0;
-                }
-                st->alert_encoding = decode_int(bits, &off, 3);
-                st->alert_len = decode_int(bits, &off, 9);
-                st->alert_crc = decode_int(bits, &off, 7);
-                st->alert_cnt_len = 1 + (2 * decode_int(bits, &off, 5));
-                for (j = 0; j < 3; j++)
-                    st->alert[j] = decode_int(bits, &off, 8);
-            }
-            else
-            {
-                for (j = 0; j < 6; j++)
-                    st->alert[current_frame * 6 - 3 + j] = decode_int(bits, &off, 8);
-            }
-            st->alert_have_frame[current_frame] = 1;
-
-            if (st->alert_len >= 0 && !st->alert_displayed)
-            {
-                int complete = 1;
-                for (j = 0; j < (st->alert_len + 8) / 6; j++)
-                    complete &= st->alert_have_frame[j];
-
-                if (complete)
-                {
-                    int expected_alert_crc = crc7(st->alert, st->alert_len);
-                    if (st->alert_crc == expected_alert_crc)
-                    {
-                        if ((st->alert_cnt_len >= 7) && (st->alert_cnt_len <= st->alert_len))
-                        {
-                            int actual_cnt_crc = (((unsigned char)st->alert[2] & 0x0f) << 8) | (unsigned char)st->alert[1];
-                            int expected_cnt_crc = control_data_crc(st->alert, st->alert_cnt_len);
-                            if (actual_cnt_crc == expected_cnt_crc)
-                            {
-                                st->alert_displayed = 1;
-
-                                int category1 = -1;
-                                int category2 = -1;
-                                int location_format = -1;
-                                int num_locations = -1;
-                                int *locations = NULL;
-                                char *message = utf8_encode(st->alert_encoding, st->alert + st->alert_cnt_len, st->alert_len - st->alert_cnt_len);
-                                decode_control_data(st->alert, st->alert_cnt_len, &category1, &category2, &location_format, &num_locations, &locations);
-                                nrsc5_report_emergency_alert(st->input->radio, message, (uint8_t *)st->alert, st->alert_cnt_len, category1, category2, location_format, num_locations, locations);
-                                free(message);
-                                free(locations);
-                        
-                                updated = 1;
-                            }
-                            else
-                            {
-                                log_warn("Invalid CNT CRC: 0x%03x != 0x%03x", actual_cnt_crc, expected_cnt_crc);
-                            }
-                        }
-                        else
-                        {
-                            log_warn("Invalid alert CNT length");
-                        }
-                    }
-                    else
-                    {
-                        log_warn("Invalid alert CRC: 0x%02x != 0x%02x", st->alert_crc, expected_alert_crc);
-                    }
-                }
-            }
+        case SIS_MSG_ID_SERVICE_INFORMATION:
+        case SIS_MSG_ID_ADV_SERVICE_INFORMATION:
+            if (sis_decode_service_information(st, bits + off))
+                updated = 1;
+            off += 27;
+            break;
+        case SIS_MSG_ID_PARAMETER_MESSAGE:
+            sis_decode_parameter(st, bits + off);
+            off += 22;
+            break;
+        case SIS_MSG_ID_UNIVERSAL_SHORT_STATION_NAME:
+            if (sis_decode_universal_short_station_name(st, bits + off))
+                updated = 1;
+            off += 58;
+            break;
+        case SIS_MSG_ID_EMERGENCY_ALERTS_MESSAGE:
+            if (sis_decode_emergency_alerts(st, bits + off))
+                updated = 1;
+            off += 58;
+            break;
+        default:
             break;
         }
     }
@@ -924,21 +1027,29 @@ static void decode_sis(pids_t *st, uint8_t *bits)
         updated = 1;
     }
 
-    if (updated == 1)
+    if (updated)
         report(st);
 }
 
-void pids_frame_push(pids_t *st, uint8_t *bits)
+void pids_frame_push(pids_t *st, const uint8_t *bits)
 {
     int i;
-    uint8_t reversed[PIDS_FRAME_LEN];
+    uint8_t pids[PIDS_FRAME_LEN];
 
     for (i = 0; i < PIDS_FRAME_LEN; i++)
     {
-        reversed[i] = bits[((i>>3)<<3) + 7 - (i & 7)];
+        pids[i] = bits[((i>>3)<<3) + 7 - (i & 7)];
     }
-    if (check_crc12(reversed))
-        decode_sis(st, reversed);
+
+    if (check_crc12(pids))
+    {
+        const int type = pids[0];
+
+        if (type == PIDS_TYPE_SIS)
+            sis_decode(st, pids + 1);
+        else if (type == PIDS_TYPE_LLDS)
+            log_debug("Ignoring LLDS frame.");
+    }
 }
 
 void pids_init(pids_t *st, input_t *input)

--- a/src/pids.c
+++ b/src/pids.c
@@ -38,9 +38,9 @@
 #define SIS_SERVICE_CATEGORY_AUDIO 0
 #define SIS_SERVICE_CATEGORY_DATA 1
 
-#define SIS_EMERGENCY_ALERTS_SAME 0
-#define SIS_EMERGENCY_ALERTS_FIPS 1
-#define SIS_EMERGENCY_ALERTS_ZIP  2
+#define SIS_EA_LOCATION_FORMAT_SAME 0
+#define SIS_EA_LOCATION_FORMAT_FIPS 1
+#define SIS_EA_LOCATION_FORMAT_ZIP  2
 
 
 static char *chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZ ?-*$ ";
@@ -195,12 +195,12 @@ static int decode_locations(const uint8_t *bits, const int len, int locations[MA
 
     switch (location_format)
     {
-    case SIS_EMERGENCY_ALERTS_SAME:
+    case SIS_EA_LOCATION_FORMAT_SAME:
         full_len = 20;
         compressed_len = 14;
         break;
-    case SIS_EMERGENCY_ALERTS_FIPS:
-    case SIS_EMERGENCY_ALERTS_ZIP:
+    case SIS_EA_LOCATION_FORMAT_FIPS:
+    case SIS_EA_LOCATION_FORMAT_ZIP:
         full_len = 17;
         compressed_len = 10;
         break;

--- a/src/pids.h
+++ b/src/pids.h
@@ -95,5 +95,5 @@ typedef struct
     int alert_timeout;
 } pids_t;
 
-void pids_frame_push(pids_t *st, uint8_t *bits);
+void pids_frame_push(pids_t *st, const uint8_t *bits);
 void pids_init(pids_t *st, struct input_t *input);


### PR DESCRIPTION
The `decode_sis` function has gotten really big. This function may get bigger as time goes on. This is to split up sis into a function for each sis message that independently does its own work.

Plus, NRSC5-E defines a new PIDS type called LLDS. This PR also adds a library debug message for LLDS to identify if a station is broadcasting this type. 

I have done my own testing to confirm that there is no segment faults on my recordings. 