### PR TITLE
Refactor audio output queue

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -18,7 +18,6 @@
 #include <math.h>
 #include <nrsc5.h>
 #include <pthread.h>
-#include <sys/time.h>
 #include <unistd.h>
 
 #include <assert.h>
@@ -42,8 +41,7 @@
 #include "bitwriter.h"
 #include "log.h"
 
-#define AUDIO_BUFFERS 128
-#define AUDIO_THRESHOLD 8
+#define AUDIO_BUFFERS 16
 #define AUDIO_DATA_LENGTH 8192
 #define FILE_BUFFER_LENGTH 32768
 #define STDIN_POLL_RATE_MS 100
@@ -80,7 +78,6 @@ typedef struct {
     pthread_cond_t cond;
 
     unsigned int program;
-    unsigned int audio_ready;
     unsigned int audio_packets_valid;
     unsigned int audio_packets;
     unsigned int audio_bytes;
@@ -127,44 +124,30 @@ static void reset_audio_buffers(state_t *st)
 static void push_audio_buffer(state_t *st, unsigned int program, const int16_t *data, size_t count)
 {
     audio_buffer_t *b;
-    struct timespec ts;
-    struct timeval now;
-
-    gettimeofday(&now, NULL);
-    ts.tv_sec = now.tv_sec;
-    ts.tv_nsec = (now.tv_usec + 100000) * 1000;
-    if (ts.tv_nsec >= 1000000000)
-    {
-        ts.tv_nsec -= 1000000000;
-        ts.tv_sec += 1;
-    }
 
     pthread_mutex_lock(&st->mutex);
     if (program != st->program)
         goto unlock;
 
-    while (st->free == NULL)
+    if (st->input_name)
     {
-        if (pthread_cond_timedwait(&st->cond, &st->mutex, &ts) == ETIMEDOUT)
+        while (st->free == NULL)
+            pthread_cond_wait(&st->cond, &st->mutex);
+    }
+    else
+    {
+        if (st->free == NULL)
         {
-            log_warn("Audio output timed out, dropping samples");
-            reset_audio_buffers(st);
+            log_warn("Audio output queue full, dropping samples");
+            goto unlock;
         }
     }
+
     b = st->free;
     st->free = b->next;
-    pthread_mutex_unlock(&st->mutex);
 
     assert(AUDIO_DATA_LENGTH == count * sizeof(data[0]));
     memcpy(b->data, data, count * sizeof(data[0]));
-
-    pthread_mutex_lock(&st->mutex);
-    if (program != st->program)
-    {
-        b->next = st->free;
-        st->free = b;
-        goto unlock;
-    }
 
     b->next = NULL;
     if (st->tail)
@@ -172,9 +155,6 @@ static void push_audio_buffer(state_t *st, unsigned int program, const int16_t *
     else
         st->head = b;
     st->tail = b;
-
-    if (st->audio_ready < AUDIO_THRESHOLD)
-        st->audio_ready++;
 
     pthread_cond_signal(&st->cond);
 
@@ -315,7 +295,6 @@ static void change_program(state_t *st, unsigned int program)
     pthread_mutex_lock(&st->mutex);
 
     // reset audio buffers
-    st->audio_ready = 0;
     if (st->tail)
     {
         st->tail->next = st->free;
@@ -411,7 +390,6 @@ static void callback(const nrsc5_event_t *evt, void *opaque)
             }
             log_info(am_flags);
         }
-        st->audio_ready = 0;
         break;
     case NRSC5_EVENT_LOST_SYNC:
         log_info("Lost synchronization");
@@ -672,7 +650,7 @@ static void *audio_main(void *arg)
         audio_buffer_t *b;
 
         pthread_mutex_lock(&st->mutex);
-        while (!st->done && (st->head == NULL || st->audio_ready < AUDIO_THRESHOLD))
+        while (!st->done && (st->head == NULL))
             pthread_cond_wait(&st->cond, &st->mutex);
 
         // exit once done and no more audio buffers

--- a/support/cli.py
+++ b/support/cli.py
@@ -265,7 +265,11 @@ class NRSC5CLI:
                     elif self.args.t == "raw":
                         self.raw_output.write(evt.data)
                 else:
-                    self.audio_queue.put(evt.data)
+                    blocking_audio_output = bool(self.args.r)
+                    try:
+                        self.audio_queue.put(evt.data, block=blocking_audio_output)
+                    except queue.Full:
+                        logging.warning("Audio output queue full, dropping samples")
         elif evt_type == nrsc5.EventType.ID3:
             if evt.program == self.args.program:
                 if evt.title:


### PR DESCRIPTION
Fixes #495.
Fixes #497.

Here I have fixed several issues related to audio output in the C and Python CLI applications:

1. In the Python CLI, when receiving from an SDR and playing back audio on a sound card, clock drift in the sound card could eventually lead to the audio output queue becoming full. At this point, the libnrsc5 callback function would be blocked, resulting in dropped I/Q samples and loss of synchronization. The C CLI avoids this problem by dropping audio samples when the queue becomes full, and I've implemented that approach in the Python CLI as well.
2. The C CLI had an excessively large audio output queue (128 packets, or ~6 seconds). I've reduced it to 16 packets, matching the Python CLI.
3. To compensate for the (former) lack of elastic buffering in libnrsc5, the C CLI waited until the audio queue reached 8 packets before beginning audio output. This approach is no longer necessary since elastic buffering was implemented in #399, so I have removed it.
4. In the C CLI, the `push_audio_buffer` function used a 100-ms timeout to avoid dropping audio output when reading from a file. This does not work correctly, as explained in #495. Instead of the timeout, I've changed the code so that it blocks indefinitely while waiting for space in the output queue (if reading from an I/Q file) or aborts immediately and drops the audio packet (if receiving from an SDR).
5. In the C CLI, the `push_audio_buffer` function briefly unlocked its mutex while performing a `memcpy`. After re-locking, it was necessary to re-check the value of `st->program` in case it had changed. Since the `memcpy` should be fast, I've changed the code to leave the mutex locked.