### PR TITLE
Refactor Decoder

### DIFF
--- a/src/conv.h
+++ b/src/conv.h
@@ -32,7 +32,6 @@ int nrsc5_conv_decode_p1(const int8_t *in, uint8_t *out);
 int nrsc5_conv_decode_pids(const int8_t *in, uint8_t *out);
 int nrsc5_conv_decode_p3_p4(const int8_t *in, uint8_t *out, int len);
 int nrsc5_conv_decode_e1(const int8_t *in, uint8_t *out, int len);
-int nrsc5_conv_decode_e2(const int8_t *in, uint8_t *out, int len);
-int nrsc5_conv_decode_e3(const int8_t *in, uint8_t *out, int len);
+int nrsc5_conv_decode_e2_e3(const int8_t *in, uint8_t *out, int len);
 
 #endif /* _CONV_H_ */

--- a/src/conv_dec.c
+++ b/src/conv_dec.c
@@ -472,12 +472,7 @@ int nrsc5_conv_decode_e1(const int8_t *in, uint8_t *out, int len)
   return nrsc5_conv_decode(in, out, 9, len, 0561, 0657, 0711);
 }
 
-int nrsc5_conv_decode_e2(const int8_t *in, uint8_t *out, int len)
+int nrsc5_conv_decode_e2_e3(const int8_t *in, uint8_t *out, int len)
 {
   return nrsc5_conv_decode(in, out, 9, len, 0561, 0753, 0711);
-}
-
-int nrsc5_conv_decode_e3(const int8_t *in, uint8_t *out, int len)
-{
-	return nrsc5_conv_decode(in, out, 9, len, 0561, 0753, 0711);
 }

--- a/src/decode.c
+++ b/src/decode.c
@@ -525,7 +525,7 @@ void decode_process_p1_p3_am(decode_t *st, const unsigned int bc)
                 if (st->input->sync.psmi != SERVICE_MODE_MA3)
                 {
                     total_frame_length += P3_FRAME_LEN_ENCODED_MA1;
-                    nrsc5_conv_decode_e1(st->viterbi_p3_am, st->scrambler_p3_am, P3_FRAME_LEN_MA1);
+                    nrsc5_conv_decode_e2_e3(st->viterbi_p3_am, st->scrambler_p3_am, P3_FRAME_LEN_MA1);
                     st->am_errors += bit_errors_e2(st->viterbi_p3_am, st->scrambler_p3_am, P3_FRAME_LEN_MA1);
                     descramble(st->scrambler_p3_am, P3_FRAME_LEN_MA1);
                     frame_push(&st->input->frame, st->scrambler_p3_am, P3_FRAME_LEN_MA1, P3_LOGICAL_CHANNEL);

--- a/src/decode.c
+++ b/src/decode.c
@@ -22,21 +22,50 @@
 #include "private.h"
 
 /* 1012s.pdf figure 10-4 */
-static int bl_delay[] = { 2, 1, 5 };
-static int ml_delay[] = { 11, 6, 7 };
-static int bu_delay[] = { 10, 8, 9 };
-static int mu_delay[] = { 4, 3, 0 };
-static int el_delay[] = { 0, 1 };
-static int eu_delay[] = { 2, 3, 5, 4 };
+static const int bl_delay[] = { 2, 1, 5 };
+static const int ml_delay[] = { 11, 6, 7 };
+static const int bu_delay[] = { 10, 8, 9 };
+static const int mu_delay[] = { 4, 3, 0 };
+static const int el_delay[] = { 0, 1 };
+static const int eu_delay[] = { 2, 3, 5, 4 };
+
+static const int8_t V_PM[] = {
+    10, 2, 18, 6, 14, 8, 16, 0, 12, 4,
+    11, 3, 19, 7, 15, 9, 17, 1, 13, 5
+};
+
+static const struct lte_conv_code conv_code_p = {
+    .n = 3,
+    .k = 7,
+    .len = P1_FRAME_LEN_FM,
+    .gen = { 0133, 0171, 0165 },
+    .term = CONV_TERM_TAIL_BITING,
+};
+
+static const struct lte_conv_code conv_code_e1 = {
+    .n = 3,
+    .k = 9,
+    .len = P3_FRAME_LEN_MA3,
+    .gen = { 0561, 0657, 0711 },
+    .term = CONV_TERM_TAIL_BITING,
+};
+
+static const struct lte_conv_code conv_code_e2_e3 = {
+    .n = 3,
+    .k = 9,
+    .len = P3_FRAME_LEN_MA1,
+    .gen = { 0561, 0753, 0711 },
+    .term = CONV_TERM_TAIL_BITING,
+};
 
 /* 1012s.pdf figure 10-5 */
-static int pids_il_delay[] = { 0, 1, 12, 13, 6, 5, 18, 17, 11, 7, 23, 19 };
-static int pids_iu_delay[] = { 2, 4, 14, 16, 3, 8, 15, 20, 9, 10, 21, 22 };
+static const int pids_il_delay[] = { 0, 1, 12, 13, 6, 5, 18, 17, 11, 7, 23, 19 };
+static const int pids_iu_delay[] = { 2, 4, 14, 16, 3, 8, 15, 20, 9, 10, 21, 22 };
 
-static int bit_map(unsigned char matrix[PARTITION_WIDTH_AM * BLKSZ * 8], int b, int k, int p)
+static int bit_map(const unsigned char matrix[PARTITION_WIDTH_AM * BLKSZ * 8], const int b, const int k, const int p)
 {
-    int col = (9*k) % 25;
-    int row = (11*col + 16*(k/25) + 11*(k/50)) % 32;
+    const int col = (9*k) % 25;
+    const int row = (11*col + 16*(k/25) + 11*(k/50)) % 32;
     return (matrix[PARTITION_WIDTH_AM * (b*BLKSZ + row) + col] >> p) & 1;
 }
 
@@ -200,9 +229,9 @@ static void interleaver_ma1(decode_t *st)
 }
 
 // calculate number of bit errors by re-encoding and comparing to the input
-static int bit_errors(int8_t *coded, uint8_t *decoded, unsigned int k, unsigned int frame_len,
-                      unsigned int g1, unsigned int g2, unsigned int g3,
-                      uint8_t *puncture, int puncture_len)
+static int bit_errors(int8_t *coded, uint8_t *decoded, const unsigned int k, unsigned int frame_len,
+                      const unsigned int gens[3],
+                      const uint8_t *puncture, const int puncture_len)
 {
     uint16_t r = 0;
     unsigned int i, j, errors = 0;
@@ -216,39 +245,33 @@ static int bit_errors(int8_t *coded, uint8_t *decoded, unsigned int k, unsigned 
         // shift in new bit
         r = (r >> 1) | (decoded[i] << (k-1));
 
-        if (puncture[j % puncture_len] && ((coded[j] > 0) != __builtin_parity(r & g1)))
+        if (puncture[j % puncture_len] && ((coded[j] > 0) != __builtin_parity(r & gens[0])))
             errors++;
-        if (puncture[(j+1) % puncture_len] && ((coded[j+1] > 0) != __builtin_parity(r & g2)))
+        if (puncture[(j+1) % puncture_len] && ((coded[j+1] > 0) != __builtin_parity(r & gens[1])))
             errors++;
-        if (puncture[(j+2) % puncture_len] && ((coded[j+2] > 0) != __builtin_parity(r & g3)))
+        if (puncture[(j+2) % puncture_len] && ((coded[j+2] > 0) != __builtin_parity(r & gens[2])))
             errors++;
     }
 
     return errors;
 }
 
-static int bit_errors_p1_fm(int8_t *coded, uint8_t *decoded)
+static int bit_errors_p_fm(int8_t *coded, uint8_t *decoded, const int len)
 {
-    uint8_t puncture[] = {1, 1, 1, 1, 1, 0};
-    return bit_errors(coded, decoded, 7, P1_FRAME_LEN_FM, 0133, 0171, 0165, puncture, 6);
+    const uint8_t puncture[] = {1, 1, 1, 1, 1, 0};
+    return bit_errors(coded, decoded, conv_code_p.k, len, conv_code_p.gen, puncture, 6);
 }
 
-static int bit_errors_p1_am(int8_t *coded, uint8_t *decoded)
+static int bit_errors_e1(int8_t *coded, uint8_t *decoded, const int len)
 {
-    uint8_t puncture[] = {1, 0, 1, 1, 0, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1};
-    return bit_errors(coded, decoded, 9, P1_FRAME_LEN_AM, 0561, 0657, 0711, puncture, 15);
+    const uint8_t puncture[] = {1, 0, 1, 1, 0, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1};
+    return bit_errors(coded, decoded, conv_code_e1.k, len, conv_code_e1.gen, puncture, 15);
 }
 
-static int bit_errors_p3_ma1(int8_t *coded, uint8_t *decoded)
+static int bit_errors_e2(int8_t *coded, uint8_t *decoded, const int len)
 {
-    uint8_t puncture[] = {1, 0, 1, 1, 0, 0};
-    return bit_errors(coded, decoded, 9, P3_FRAME_LEN_MA1, 0561, 0753, 0711, puncture, 6);
-}
-
-static int bit_errors_p3_ma3(int8_t *coded, uint8_t *decoded)
-{
-    uint8_t puncture[] = {1, 0, 1, 1, 0, 1, 1, 0, 1, 1, 1, 1, 1, 1, 1};
-    return bit_errors(coded, decoded, 9, P3_FRAME_LEN_MA3, 0561, 0657, 0711, puncture, 15);
+    const uint8_t puncture[] = {1, 0, 1, 1, 0, 0};
+    return bit_errors(coded, decoded, conv_code_e2_e3.k, len, conv_code_e2_e3.gen, puncture, 6);
 }
 
 static void descramble(uint8_t *buf, unsigned int length)
@@ -268,74 +291,73 @@ static void descramble(uint8_t *buf, unsigned int length)
     }
 }
 
-void decode_process_p1(decode_t *st)
+static void interleaver_i(const int8_t* in,
+                          int8_t* viterbi,
+                          int J,
+                          int B,
+                          int C,
+                          int M,
+                          const int8_t* V,
+                          const unsigned int N)
 {
-    const int J = 20, B = 16, C = 36;
-    const int8_t v[] = {
-        10, 2, 18, 6, 14, 8, 16, 0, 12, 4,
-        11, 3, 19, 7, 15, 9, 17, 1, 13, 5
-    };
     unsigned int i, out = 0;
-    for (i = 0; i < P1_FRAME_LEN_ENCODED_FM; i++)
+    for (i = 0; i < N; i++)
     {
-        int partition = v[i % J];
-        int block = ((i / J) + (partition * 7)) % B;
-        int k = i / (J * B);
-        int row = (k * 11) % 32;
-        int column = (k * 11 + k / (32*9)) % C;
-        st->viterbi_p1[out++] = st->buffer_pm[(block * 32 + row) * 720 + partition * C + column];
+        const int partition = V[((i + 2 * (M / 4)) / M) % J];
+        const int block = ((i / J) + (partition * 7)) % B;
+        const int k = i / (J * B);
+        const int row = (k * 11) % 32;
+        const int column = (k * 11 + k / (32 * 9)) % C;
+        viterbi[out++] = in[(block * 32 + row) * 720 + partition * C + column];
         if ((out % 6) == 5) // depuncture, [1, 1, 1, 1, 1, 0]
-            st->viterbi_p1[out++] = 0;
+            viterbi[out++] = 0;
     }
-
-    nrsc5_conv_decode_p1(st->viterbi_p1, st->scrambler_p1);
-    nrsc5_report_ber(st->input->radio, (float) bit_errors_p1_fm(st->viterbi_p1, st->scrambler_p1) / P1_FRAME_LEN_ENCODED_FM);
-    descramble(st->scrambler_p1, P1_FRAME_LEN_FM);
-    frame_push(&st->input->frame, st->scrambler_p1, P1_FRAME_LEN_FM, P1_LOGICAL_CHANNEL);
 }
 
-void decode_process_pids(decode_t *st)
+static void interleaver_ii(const int8_t* in, int8_t* viterbi, const int bc,
+                           const int J, const int B, const int C, const int8_t* V,
+                           const int b, const int I0, const int N)
 {
-    const int J = 20, B = 16, C = 36;
-    const int8_t v[] = {
-        10, 2, 18, 6, 14, 8, 16, 0, 12, 4,
-        11, 3, 19, 7, 15, 9, 17, 1, 13, 5
-    };
-    unsigned int i, out = 0;
-    for (i = 0; i < PIDS_FRAME_LEN_ENCODED_FM; i++)
-    {
-        int partition = v[i % J];
-        int block = decode_get_block(st) - 1;
-        int k = ((i / J) % (PIDS_FRAME_LEN_ENCODED_FM / J)) + (P1_FRAME_LEN_ENCODED_FM / (J * B));
-        int row = (k * 11) % 32;
-        int column = (k * 11 + k / (32*9)) % C;
-        st->viterbi_pids[out++] = st->buffer_pm[(block * 32 + row) * 720 + partition * C + column];
-        if ((out % 6) == 5) // depuncture, [1, 1, 1, 1, 1, 0]
-            st->viterbi_pids[out++] = 0;
-    }
+    int out = 0;
 
-    nrsc5_conv_decode_pids(st->viterbi_pids, st->scrambler_pids);
-    descramble(st->scrambler_pids, PIDS_FRAME_LEN);
-    pids_frame_push(&st->pids, st->scrambler_pids);
+    for (int i = bc * b; i < (bc+1) * b; i++)
+    {
+        const int partition = V[i % J];
+        const int block = i / b;
+        const int k = ((i / J) % (N / J)) + (I0 / (J * B));
+        const int row = (k * 11) % 32;
+        const int column = (k * 11 + k / (32*9)) % C;
+        viterbi[out++] = in[(block * 32 + row) * 720 + partition * C + column];
+        if ((out % 6) == 5) // depuncture, [1, 1, 1, 1, 1, 0]
+            viterbi[out++] = 0;
+    };
 }
 
-void decode_process_p3_p4(decode_t *st, interleaver_iv_t *interleaver, int8_t *viterbi, uint8_t *scrambler, unsigned int frame_len, logical_channel_t lc)
+void interleaver_iv(interleaver_iv_t* interleaver, int8_t* viterbi)
 {
-    const unsigned int J = (frame_len == P3_FRAME_LEN_FM) ? 4 : 2;
+    const unsigned int N = (interleaver->frame_length == P3_FRAME_LEN_MP3_MP11) ? 147456 : 73728;
+    const unsigned int J = (interleaver->frame_length == P3_FRAME_LEN_MP3_MP11) ? 4 : 2;
     const unsigned int B = 32;
     const unsigned int C = 36;
-    const unsigned int M = (frame_len == P3_FRAME_LEN_FM) ? 2 : 4;
-    const unsigned int N = (frame_len == P3_FRAME_LEN_FM) ? 147456 : 73728;
+    const unsigned int M = (interleaver->frame_length == P3_FRAME_LEN_MP3_MP11) ? 2 : 4;
     const unsigned int bk_bits = 32 * C;
     const unsigned int bk_adj = 32 * C - 1;
-    unsigned int i, out = 0;
-    for (i = 0; i < frame_len * 2; i++)
+
+    if (interleaver->i == N)
     {
-        int partition = ((interleaver->i + 2 * (M / 4)) / M) % J;
-        unsigned int pti = interleaver->pt[partition]++;
-        int block = (pti + (partition * 7) - (bk_adj * (pti / bk_bits))) % B;
-        int row = ((11 * pti) % bk_bits) / C;
-        int column = (pti * 11) % C;
+        interleaver->i = 0;
+        memset(interleaver->pt, 0, sizeof(unsigned int) * 4);
+        interleaver->ready = 1;
+    }
+
+    unsigned int out = 0;
+    for (unsigned int i = 0; i < interleaver->frame_length * 2; i++)
+    {
+        const int partition = ((interleaver->i + 2 * (M / 4)) / M) % J;
+        const unsigned int pti = interleaver->pt[partition]++;
+        const int block = (pti + (partition * 7) - (bk_adj * (pti / bk_bits))) % B;
+        const int row = ((11 * pti) % bk_bits) / C;
+        const int column = (pti * 11) % C;
         viterbi[out++] = interleaver->internal[(block * 32 + row) * (J * C) + partition * C + column];
         if ((out % 6) == 1 || (out % 6) == 4) // depuncture, [1, 0, 1, 1, 0, 1]
             viterbi[out++] = 0;
@@ -343,21 +365,111 @@ void decode_process_p3_p4(decode_t *st, interleaver_iv_t *interleaver, int8_t *v
         interleaver->internal[interleaver->i] = interleaver->buffer[i];
         interleaver->i++;
     }
-    if (interleaver->ready)
+}
+
+void decode_push_pm(decode_t *st, const int8_t* sbit, const unsigned int bc)
+{
+    memcpy(st->buffer_pm + PM_BLOCK_SIZE * bc, sbit, PM_BLOCK_SIZE * sizeof(int8_t));
+    decode_process_pids(st, bc);
+
+    if (bc == 0)
+        st->started_pm = 1;
+
+    if (st->started_pm)
     {
-        nrsc5_conv_decode_p3_p4(viterbi, scrambler, frame_len);
-        descramble(scrambler, frame_len);
-        frame_push(&st->input->frame, scrambler, frame_len, lc);
-    }
-    if (interleaver->i == N)
-    {
-        interleaver->i = 0;
-        memset(interleaver->pt, 0, sizeof(unsigned int) * 4);
-        interleaver->ready = 1;
+        if (bc == 15)
+            decode_process_p1(st);
     }
 }
 
-void decode_process_pids_am(decode_t *st)
+void decode_push_px1(decode_t *st, const int8_t* sbit, const unsigned int bc)
+{
+    if (bc % 2 == 0)
+        st->interleaver_px1.started = 1;
+
+    if (st->interleaver_px1.started)
+    {
+        const unsigned int pos = st->interleaver_px1.frame_length * (bc % 2);
+
+        memcpy(st->interleaver_px1.buffer + pos, sbit,
+            st->interleaver_px1.frame_length * sizeof(int8_t));
+
+        if (bc % 2 == 1)
+        {
+            interleaver_iv(&st->interleaver_px1, st->viterbi_p3);
+
+            if (st->interleaver_px1.ready)
+            {
+                nrsc5_conv_decode_p3_p4(st->viterbi_p3, st->scrambler_p3, st->interleaver_px1.frame_length);
+                descramble(st->scrambler_p3, st->interleaver_px1.frame_length);
+                frame_push(&st->input->frame, st->scrambler_p3, st->interleaver_px1.frame_length, P3_LOGICAL_CHANNEL);
+            }
+        }
+    }
+}
+
+void decode_push_px2(decode_t* st, const int8_t* sbit, const unsigned int bc)
+{
+    if (bc % 2 == 0)
+        st->interleaver_px2.started = 1;
+
+    if (st->interleaver_px2.started)
+    {
+        const unsigned int pos = st->interleaver_px2.frame_length * (bc % 2);
+
+        memcpy(st->interleaver_px2.buffer + pos, sbit,
+            st->interleaver_px2.frame_length * sizeof(int8_t));
+
+        if (bc % 2 == 1)
+        {
+            interleaver_iv(&st->interleaver_px2, st->viterbi_p4);
+
+            if (st->interleaver_px2.ready)
+            {
+                nrsc5_conv_decode_p3_p4(st->viterbi_p4, st->scrambler_p4, st->interleaver_px2.frame_length);
+                descramble(st->scrambler_p4, st->interleaver_px2.frame_length);
+                frame_push(&st->input->frame, st->scrambler_p4, st->interleaver_px2.frame_length, P4_LOGICAL_CHANNEL);
+            }
+        }
+    }
+}
+
+void decode_push_pl_pu_s_t(decode_t* st,
+    const uint8_t* sym_pl, const uint8_t* sym_pu, const uint8_t* sym_s,
+    const uint8_t* sym_t, const unsigned int bc)
+{
+    memcpy(st->buffer_pl + (bc * BLKSZ * PARTITION_WIDTH_AM), sym_pl, BLKSZ * PARTITION_WIDTH_AM);
+    memcpy(st->buffer_pu + (bc * BLKSZ * PARTITION_WIDTH_AM), sym_pu, BLKSZ * PARTITION_WIDTH_AM);
+    memcpy(st->buffer_s + (bc * BLKSZ * PARTITION_WIDTH_AM), sym_s, BLKSZ * PARTITION_WIDTH_AM);
+    memcpy(st->buffer_t + (bc * BLKSZ * PARTITION_WIDTH_AM), sym_t, BLKSZ * PARTITION_WIDTH_AM);
+
+    decode_process_p1_p3_am(st, bc);
+}
+
+void decode_process_p1(decode_t *st)
+{
+    const int J = 20, B = 16, C = 36;
+    interleaver_i(st->buffer_pm, st->viterbi_p1,
+        J, B, C, 1, V_PM, P1_FRAME_LEN_ENCODED_FM);
+
+    nrsc5_conv_decode_p1(st->viterbi_p1, st->scrambler_p1);
+    nrsc5_report_ber(st->input->radio, (float) bit_errors_p_fm(st->viterbi_p1, st->scrambler_p1, P1_FRAME_LEN_FM) / P1_FRAME_LEN_ENCODED_FM);
+    descramble(st->scrambler_p1, P1_FRAME_LEN_FM);
+    frame_push(&st->input->frame, st->scrambler_p1, P1_FRAME_LEN_FM, P1_LOGICAL_CHANNEL);
+}
+
+void decode_process_pids(decode_t *st, const unsigned int bc)
+{
+    const int J = 20, B = 16, C = 36;
+    interleaver_ii(st->buffer_pm, st->viterbi_pids, (int)bc, J, B, C, V_PM, PIDS_FRAME_LEN_ENCODED_FM,
+        P1_FRAME_LEN_ENCODED_FM, PIDS_FRAME_LEN_ENCODED_FM * 16);
+
+    nrsc5_conv_decode_pids(st->viterbi_pids, st->scrambler_pids);
+    descramble(st->scrambler_pids, PIDS_FRAME_LEN);
+    pids_frame_push(&st->pids, st->scrambler_pids);
+}
+
+void decode_process_pids_am(decode_t *st, const uint8_t* sbit)
 {
     uint8_t il[120], iu[120];
 
@@ -369,15 +481,15 @@ void decode_process_pids_am(decode_t *st)
 
         k = (n + (n/60) + 11) % 30;
         row = (11 * (k + (k/15)) + 3) % 32;
-        il[n] = (st->buffer_pids_am[row*2] >> p) & 1;
+        il[n] = (sbit[row*2] >> p) & 1;
 
         k = (n + (n/60)) % 30;
         row = (11 * (k + (k/15)) + 3) % 32;
-        iu[n] = (st->buffer_pids_am[row*2 + 1] >> p) & 1;
+        iu[n] = (sbit[row*2 + 1] >> p) & 1;
     }
 
     /* 1012s.pdf figure 10-5 */
-    int pids1_disabled = (st->input->sync.psmi == 1) && st->input->sync.rdbi;
+    const int pids1_disabled = (st->input->sync.psmi == 1) && st->input->sync.rdbi;
     for (int i = 0; i < 10; i++) {
       for (int j = 0; j < 12; j++) {
         st->viterbi_pids[i*24 + pids_il_delay[j]] = pids1_disabled ? 0 : (il[i*12 + j] ? 1 : -1);
@@ -385,26 +497,24 @@ void decode_process_pids_am(decode_t *st)
       }
     }
 
-    nrsc5_conv_decode_e3(st->viterbi_pids, st->scrambler_pids, PIDS_FRAME_LEN);
+    nrsc5_conv_decode_e2(st->viterbi_pids, st->scrambler_pids, PIDS_FRAME_LEN);
     descramble(st->scrambler_pids, PIDS_FRAME_LEN);
     pids_frame_push(&st->pids, st->scrambler_pids);
 }
 
-void decode_process_p1_p3_am(decode_t *st)
+void decode_process_p1_p3_am(decode_t *st, const unsigned int bc)
 {
-    unsigned int block = st->idx_pu_pl_s_t / (PARTITION_WIDTH_AM * BLKSZ) - 1;
-
-    if (block == 0)
+    if (bc == 0)
         st->am_errors = 0;
 
     if (st->am_diversity_wait == 0)
     {
-        nrsc5_conv_decode_e1(st->viterbi_p1_am + (block * P1_FRAME_LEN_AM * 3), st->scrambler_p1_am, P1_FRAME_LEN_AM);
-        st->am_errors += bit_errors_p1_am(st->viterbi_p1_am + (block * P1_FRAME_LEN_AM * 3), st->scrambler_p1_am);
+        nrsc5_conv_decode_e1(st->viterbi_p1_am + (bc * P1_FRAME_LEN_AM * 3), st->scrambler_p1_am, P1_FRAME_LEN_AM);
+        st->am_errors += bit_errors_e1(st->viterbi_p1_am + (bc * P1_FRAME_LEN_AM * 3), st->scrambler_p1_am, P1_FRAME_LEN_AM);
         descramble(st->scrambler_p1_am, P1_FRAME_LEN_AM);
         frame_push(&st->input->frame, st->scrambler_p1_am, P1_FRAME_LEN_AM, P1_LOGICAL_CHANNEL);
 
-        if (block == 7)
+        if (bc == 7)
         {
             unsigned int total_frame_length = 8 * P1_FRAME_LEN_ENCODED_AM;
 
@@ -413,8 +523,8 @@ void decode_process_p1_p3_am(decode_t *st)
                 if (st->input->sync.psmi != SERVICE_MODE_MA3)
                 {
                     total_frame_length += P3_FRAME_LEN_ENCODED_MA1;
-                    nrsc5_conv_decode_e2(st->viterbi_p3_am, st->scrambler_p3_am, P3_FRAME_LEN_MA1);
-                    st->am_errors += bit_errors_p3_ma1(st->viterbi_p3_am, st->scrambler_p3_am);
+                    nrsc5_conv_decode_e1(st->viterbi_p3_am, st->scrambler_p3_am, P3_FRAME_LEN_MA1);
+                    st->am_errors += bit_errors_e2(st->viterbi_p3_am, st->scrambler_p3_am, P3_FRAME_LEN_MA1);
                     descramble(st->scrambler_p3_am, P3_FRAME_LEN_MA1);
                     frame_push(&st->input->frame, st->scrambler_p3_am, P3_FRAME_LEN_MA1, P3_LOGICAL_CHANNEL);
                 }
@@ -422,7 +532,7 @@ void decode_process_p1_p3_am(decode_t *st)
                 {
                     total_frame_length += P3_FRAME_LEN_ENCODED_MA3;
                     nrsc5_conv_decode_e1(st->viterbi_p3_am, st->scrambler_p3_am, P3_FRAME_LEN_MA3);
-                    st->am_errors += bit_errors_p3_ma3(st->viterbi_p3_am, st->scrambler_p3_am);
+                    st->am_errors += bit_errors_e1(st->viterbi_p3_am, st->scrambler_p3_am, P3_FRAME_LEN_MA3);
                     descramble(st->scrambler_p3_am, P3_FRAME_LEN_MA3);
                     frame_push(&st->input->frame, st->scrambler_p3_am, P3_FRAME_LEN_MA3, P3_LOGICAL_CHANNEL);
                 }
@@ -432,7 +542,7 @@ void decode_process_p1_p3_am(decode_t *st)
         }
     }
 
-    if (block == 7)
+    if (bc == 7)
     {
         interleaver_ma1(st);
 
@@ -441,32 +551,24 @@ void decode_process_p1_p3_am(decode_t *st)
     }
 }
 
-void decode_set_block(decode_t *st, unsigned int bc)
+int decode_set_psmi(decode_t *st, const int mode, const unsigned int psmi)
 {
-    st->idx_pm = 720 * BLKSZ * bc;
-    if (bc == 0)
-        st->started_pm = 1;
-
-    st->interleaver_px1.idx = (st->interleaver_px1.length / 2) * (bc % 2);
-    st->interleaver_px2.idx = (st->interleaver_px2.length / 2) * (bc % 2);
-    if ((bc % 2) == 0)
+    if (mode == NRSC5_MODE_FM)
     {
-        st->interleaver_px1.started = 1;
-        st->interleaver_px2.started = 1;
+        if (psmi == 2)
+            st->interleaver_px1.frame_length = P3_FRAME_LEN_MP2;
+        else
+            st->interleaver_px1.frame_length = P3_FRAME_LEN_MP3_MP11;
+        st->interleaver_px2.frame_length = P3_FRAME_LEN_MP3_MP11;
     }
-}
-
-void decode_set_px1_length(decode_t *st, unsigned int frame_len)
-{
-    st->interleaver_px1.length = frame_len;
+    return 0;
 }
 
 static void interleaver_iv_reset(interleaver_iv_t *interleaver)
 {
-    interleaver->idx = 0;
     interleaver->i = 0;
     memset(interleaver->pt, 0, sizeof(unsigned int) * 4);
-    interleaver->length = P3_FRAME_LEN_FM * 2;
+    interleaver->frame_length = P3_FRAME_LEN_MP3_MP11;
     interleaver->started = 0;
     interleaver->ready = 0;
 }
@@ -475,7 +577,6 @@ void decode_reset(decode_t *st)
 {
     st->idx_pm = 0;
     st->started_pm = 0;
-    st->idx_pu_pl_s_t = 0;
     st->am_errors = 0;
     st->am_diversity_wait = 4;
     interleaver_iv_reset(&st->interleaver_px1);
@@ -483,7 +584,7 @@ void decode_reset(decode_t *st)
     pids_init(&st->pids, st->input);
 }
 
-void decode_init(decode_t *st, struct input_t *input)
+void decode_init(decode_t *st, input_t *input)
 {
     st->input = input;
     decode_reset(st);

--- a/src/decode.c
+++ b/src/decode.c
@@ -21,6 +21,8 @@
 #include "pids.h"
 #include "private.h"
 
+#define PM_V_SIZE 20
+
 /* 1012s.pdf figure 10-4 */
 static const int bl_delay[] = { 2, 1, 5 };
 static const int ml_delay[] = { 11, 6, 7 };
@@ -29,12 +31,12 @@ static const int mu_delay[] = { 4, 3, 0 };
 static const int el_delay[] = { 0, 1 };
 static const int eu_delay[] = { 2, 3, 5, 4 };
 
-static const int8_t V_PM[] = {
+static const int8_t PM_V[PM_V_SIZE] = {
     10, 2, 18, 6, 14, 8, 16, 0, 12, 4,
     11, 3, 19, 7, 15, 9, 17, 1, 13, 5
 };
 
-static const struct lte_conv_code conv_code_p = {
+static const struct lte_conv_code conv_code_k7 = {
     .n = 3,
     .k = 7,
     .len = P1_FRAME_LEN_FM,
@@ -256,10 +258,10 @@ static int bit_errors(int8_t *coded, uint8_t *decoded, const unsigned int k, uns
     return errors;
 }
 
-static int bit_errors_p_fm(int8_t *coded, uint8_t *decoded, const int len)
+static int bit_errors_2_5_fm(int8_t *coded, uint8_t *decoded, const int len)
 {
     const uint8_t puncture[] = {1, 1, 1, 1, 1, 0};
-    return bit_errors(coded, decoded, conv_code_p.k, len, conv_code_p.gen, puncture, 6);
+    return bit_errors(coded, decoded, conv_code_k7.k, len, conv_code_k7.gen, puncture, 6);
 }
 
 static int bit_errors_e1(int8_t *coded, uint8_t *decoded, const int len)
@@ -293,53 +295,59 @@ static void descramble(uint8_t *buf, unsigned int length)
 
 static void interleaver_i(const int8_t* in,
                           int8_t* viterbi,
-                          int J,
-                          int B,
-                          int C,
-                          int M,
+                          const int J,
+                          const int B,
+                          const int C,
+                          const int M,
                           const int8_t* V,
+                          const unsigned int length_v,
                           const unsigned int N)
 {
-    unsigned int i, out = 0;
-    for (i = 0; i < N; i++)
+    unsigned int out = 0;
+    for (unsigned int i = 0; i < N; i++)
     {
-        const int partition = V[((i + 2 * (M / 4)) / M) % J];
-        const int block = ((i / J) + (partition * 7)) % B;
-        const int k = i / (J * B);
-        const int row = (k * 11) % 32;
-        const int column = (k * 11 + k / (32 * 9)) % C;
-        viterbi[out++] = in[(block * 32 + row) * 720 + partition * C + column];
+        const int8_t partition = V[((i + 2 * (M / 4)) / M) % length_v];
+        unsigned int block;
+        if (M == 1)
+            block = ((i / J) + (partition * 7)) % B;
+        else
+            block = (i + (i / (J * B))) % B;
+        const unsigned int k = i / (J * B);
+        const unsigned int row = (k * 11) % 32;
+        const unsigned int column = (k * 11 + k / (32 * 9)) % C;
+        viterbi[out++] = in[(block * 32 + row) * (J * C) + partition * C + column];
         if ((out % 6) == 5) // depuncture, [1, 1, 1, 1, 1, 0]
             viterbi[out++] = 0;
     }
 }
 
-static void interleaver_ii(const int8_t* in, int8_t* viterbi, const int bc,
-                           const int J, const int B, const int C, const int8_t* V,
-                           const int b, const int I0, const int N)
+static void interleaver_ii(const int8_t* in, int8_t* viterbi, const unsigned int bc,
+                           const int J, const int B, const int C,
+                           const int8_t* V, const unsigned int length_v,
+                           const int b, const int I0)
 {
     int out = 0;
 
-    for (int i = bc * b; i < (bc+1) * b; i++)
+    for (unsigned int i = bc * b; i < (bc+1) * b; i++)
     {
-        const int partition = V[i % J];
-        const int block = i / b;
-        const int k = ((i / J) % (N / J)) + (I0 / (J * B));
-        const int row = (k * 11) % 32;
-        const int column = (k * 11 + k / (32*9)) % C;
-        viterbi[out++] = in[(block * 32 + row) * 720 + partition * C + column];
+        const int8_t partition = V[i % length_v];
+        const unsigned int block = i / b;
+        const unsigned int k = ((i / J) % (b / J)) + (I0 / (J * B));
+        const unsigned int row = (k * 11) % 32;
+        const unsigned int column = (k * 11 + k / (32 * 9)) % C;
+        viterbi[out++] = in[(block * 32 + row) * (J * C) + partition * C + column];
         if ((out % 6) == 5) // depuncture, [1, 1, 1, 1, 1, 0]
             viterbi[out++] = 0;
     };
 }
 
-void interleaver_iv(interleaver_iv_t* interleaver, int8_t* viterbi)
+void interleaver_iv(interleaver_iv_t* interleaver, int8_t* viterbi, const unsigned int frame_len)
 {
-    const unsigned int N = (interleaver->frame_length == P3_FRAME_LEN_MP3_MP11) ? 147456 : 73728;
-    const unsigned int J = (interleaver->frame_length == P3_FRAME_LEN_MP3_MP11) ? 4 : 2;
+    const unsigned int J = (frame_len == P3_FRAME_LEN_MP3_MP11) ? 4 : 2;
     const unsigned int B = 32;
     const unsigned int C = 36;
-    const unsigned int M = (interleaver->frame_length == P3_FRAME_LEN_MP3_MP11) ? 2 : 4;
+    const unsigned int M = (frame_len == P3_FRAME_LEN_MP3_MP11) ? 2 : 4;
+    const unsigned int N = (frame_len == P3_FRAME_LEN_MP3_MP11) ? 147456 : 73728;
     const unsigned int bk_bits = 32 * C;
     const unsigned int bk_adj = 32 * C - 1;
 
@@ -351,13 +359,13 @@ void interleaver_iv(interleaver_iv_t* interleaver, int8_t* viterbi)
     }
 
     unsigned int out = 0;
-    for (unsigned int i = 0; i < interleaver->frame_length * 2; i++)
+    for (unsigned int i = 0; i < frame_len * 2; i++)
     {
-        const int partition = ((interleaver->i + 2 * (M / 4)) / M) % J;
+        const unsigned int partition = ((interleaver->i + 2 * (M / 4)) / M) % J;
         const unsigned int pti = interleaver->pt[partition]++;
-        const int block = (pti + (partition * 7) - (bk_adj * (pti / bk_bits))) % B;
-        const int row = ((11 * pti) % bk_bits) / C;
-        const int column = (pti * 11) % C;
+        const unsigned int block = (pti + (partition * 7) - (bk_adj * (pti / bk_bits))) % B;
+        const unsigned int row = ((11 * pti) % bk_bits) / C;
+        const unsigned int column = (pti * 11) % C;
         viterbi[out++] = interleaver->internal[(block * 32 + row) * (J * C) + partition * C + column];
         if ((out % 6) == 1 || (out % 6) == 4) // depuncture, [1, 0, 1, 1, 0, 1]
             viterbi[out++] = 0;
@@ -382,53 +390,47 @@ void decode_push_pm(decode_t *st, const int8_t* sbit, const unsigned int bc)
     }
 }
 
-void decode_push_px1(decode_t *st, const int8_t* sbit, const unsigned int bc)
+void decode_push_px1(decode_t *st, const int8_t* sbit, const unsigned int len, const unsigned int bc)
 {
     if (bc % 2 == 0)
         st->interleaver_px1.started = 1;
 
     if (st->interleaver_px1.started)
     {
-        const unsigned int pos = st->interleaver_px1.frame_length * (bc % 2);
-
-        memcpy(st->interleaver_px1.buffer + pos, sbit,
-            st->interleaver_px1.frame_length * sizeof(int8_t));
+        memcpy(st->interleaver_px1.buffer + len * (bc % 2), sbit,len * sizeof(int8_t));
 
         if (bc % 2 == 1)
         {
-            interleaver_iv(&st->interleaver_px1, st->viterbi_p3);
+            interleaver_iv(&st->interleaver_px1, st->viterbi_p3, len);
 
             if (st->interleaver_px1.ready)
             {
-                nrsc5_conv_decode_p3_p4(st->viterbi_p3, st->scrambler_p3, st->interleaver_px1.frame_length);
-                descramble(st->scrambler_p3, st->interleaver_px1.frame_length);
-                frame_push(&st->input->frame, st->scrambler_p3, st->interleaver_px1.frame_length, P3_LOGICAL_CHANNEL);
+                nrsc5_conv_decode_p3_p4(st->viterbi_p3, st->scrambler_p3, len);
+                descramble(st->scrambler_p3, len);
+                frame_push(&st->input->frame, st->scrambler_p3, len, P3_LOGICAL_CHANNEL);
             }
         }
     }
 }
 
-void decode_push_px2(decode_t* st, const int8_t* sbit, const unsigned int bc)
+void decode_push_px2(decode_t* st, const int8_t* sbit, const unsigned int len, const unsigned int bc)
 {
     if (bc % 2 == 0)
         st->interleaver_px2.started = 1;
 
     if (st->interleaver_px2.started)
     {
-        const unsigned int pos = st->interleaver_px2.frame_length * (bc % 2);
-
-        memcpy(st->interleaver_px2.buffer + pos, sbit,
-            st->interleaver_px2.frame_length * sizeof(int8_t));
+        memcpy(st->interleaver_px2.buffer + len * (bc % 2), sbit, len * sizeof(int8_t));
 
         if (bc % 2 == 1)
         {
-            interleaver_iv(&st->interleaver_px2, st->viterbi_p4);
+            interleaver_iv(&st->interleaver_px2, st->viterbi_p4, len);
 
             if (st->interleaver_px2.ready)
             {
-                nrsc5_conv_decode_p3_p4(st->viterbi_p4, st->scrambler_p4, st->interleaver_px2.frame_length);
-                descramble(st->scrambler_p4, st->interleaver_px2.frame_length);
-                frame_push(&st->input->frame, st->scrambler_p4, st->interleaver_px2.frame_length, P4_LOGICAL_CHANNEL);
+                nrsc5_conv_decode_p3_p4(st->viterbi_p4, st->scrambler_p4, len);
+                descramble(st->scrambler_p4, len);
+                frame_push(&st->input->frame, st->scrambler_p4, len, P4_LOGICAL_CHANNEL);
             }
         }
     }
@@ -448,12 +450,12 @@ void decode_push_pl_pu_s_t(decode_t* st,
 
 void decode_process_p1(decode_t *st)
 {
-    const int J = 20, B = 16, C = 36;
+    const int J = 20, B = 16, C = 36, M = 1;
     interleaver_i(st->buffer_pm, st->viterbi_p1,
-        J, B, C, 1, V_PM, P1_FRAME_LEN_ENCODED_FM);
+        J, B, C, M, PM_V, PM_V_SIZE, P1_FRAME_LEN_ENCODED_FM);
 
     nrsc5_conv_decode_p1(st->viterbi_p1, st->scrambler_p1);
-    nrsc5_report_ber(st->input->radio, (float) bit_errors_p_fm(st->viterbi_p1, st->scrambler_p1, P1_FRAME_LEN_FM) / P1_FRAME_LEN_ENCODED_FM);
+    nrsc5_report_ber(st->input->radio, (float) bit_errors_2_5_fm(st->viterbi_p1, st->scrambler_p1, P1_FRAME_LEN_FM) / P1_FRAME_LEN_ENCODED_FM);
     descramble(st->scrambler_p1, P1_FRAME_LEN_FM);
     frame_push(&st->input->frame, st->scrambler_p1, P1_FRAME_LEN_FM, P1_LOGICAL_CHANNEL);
 }
@@ -461,8 +463,8 @@ void decode_process_p1(decode_t *st)
 void decode_process_pids(decode_t *st, const unsigned int bc)
 {
     const int J = 20, B = 16, C = 36;
-    interleaver_ii(st->buffer_pm, st->viterbi_pids, (int)bc, J, B, C, V_PM, PIDS_FRAME_LEN_ENCODED_FM,
-        P1_FRAME_LEN_ENCODED_FM, PIDS_FRAME_LEN_ENCODED_FM * 16);
+    interleaver_ii(st->buffer_pm, st->viterbi_pids, (int)bc, J, B, C, PM_V, PM_V_SIZE, PIDS_FRAME_LEN_ENCODED_FM,
+        P1_FRAME_LEN_ENCODED_FM);
 
     nrsc5_conv_decode_pids(st->viterbi_pids, st->scrambler_pids);
     descramble(st->scrambler_pids, PIDS_FRAME_LEN);
@@ -497,7 +499,7 @@ void decode_process_pids_am(decode_t *st, const uint8_t* sbit)
       }
     }
 
-    nrsc5_conv_decode_e2(st->viterbi_pids, st->scrambler_pids, PIDS_FRAME_LEN);
+    nrsc5_conv_decode_e2_e3(st->viterbi_pids, st->scrambler_pids, PIDS_FRAME_LEN);
     descramble(st->scrambler_pids, PIDS_FRAME_LEN);
     pids_frame_push(&st->pids, st->scrambler_pids);
 }
@@ -538,7 +540,7 @@ void decode_process_p1_p3_am(decode_t *st, const unsigned int bc)
                 }
             }
 
-            nrsc5_report_ber(st->input->radio, (float) st->am_errors / total_frame_length);
+            nrsc5_report_ber(st->input->radio, (float) st->am_errors / (float) total_frame_length);
         }
     }
 
@@ -551,24 +553,10 @@ void decode_process_p1_p3_am(decode_t *st, const unsigned int bc)
     }
 }
 
-int decode_set_psmi(decode_t *st, const int mode, const unsigned int psmi)
-{
-    if (mode == NRSC5_MODE_FM)
-    {
-        if (psmi == 2)
-            st->interleaver_px1.frame_length = P3_FRAME_LEN_MP2;
-        else
-            st->interleaver_px1.frame_length = P3_FRAME_LEN_MP3_MP11;
-        st->interleaver_px2.frame_length = P3_FRAME_LEN_MP3_MP11;
-    }
-    return 0;
-}
-
 static void interleaver_iv_reset(interleaver_iv_t *interleaver)
 {
     interleaver->i = 0;
     memset(interleaver->pt, 0, sizeof(unsigned int) * 4);
-    interleaver->frame_length = P3_FRAME_LEN_MP3_MP11;
     interleaver->started = 0;
     interleaver->ready = 0;
 }

--- a/src/decode.h
+++ b/src/decode.h
@@ -9,28 +9,24 @@
 typedef struct
 {
   int8_t buffer[144 * BLKSZ * 2];
-  unsigned int idx;
-  int8_t internal[P3_FRAME_LEN_FM * 32];
+  int8_t internal[P3_FRAME_LEN_MP3_MP11 * 32];
   unsigned int i;
   unsigned int pt[4];
-  int length;
-  int started;
+  unsigned int frame_length;
   int ready;
+  int started;
 } interleaver_iv_t;
 
 typedef struct
 {
     struct input_t *input;
-    int8_t buffer_pm[720 * BLKSZ * 16];
+    int8_t buffer_pm[PM_BLOCK_SIZE * 16];
     unsigned int idx_pm;
     int started_pm;
-    uint8_t buffer_pids_am[2 * BLKSZ];
-    unsigned int idx_pids_am;
     uint8_t buffer_pu[PARTITION_WIDTH_AM * BLKSZ * 8];
     uint8_t buffer_pl[PARTITION_WIDTH_AM * BLKSZ * 8];
     uint8_t buffer_s[PARTITION_WIDTH_AM * BLKSZ * 8];
     uint8_t buffer_t[PARTITION_WIDTH_AM * BLKSZ * 8];
-    unsigned int idx_pu_pl_s_t;
     unsigned int am_errors;
     unsigned int am_diversity_wait;
 
@@ -51,10 +47,10 @@ typedef struct
     uint8_t scrambler_pids[PIDS_FRAME_LEN];
     interleaver_iv_t interleaver_px1;
     interleaver_iv_t interleaver_px2;
-    int8_t viterbi_p3[P3_FRAME_LEN_FM * 3];
-    int8_t viterbi_p4[P3_FRAME_LEN_FM * 3];
-    uint8_t scrambler_p3[P3_FRAME_LEN_FM];
-    uint8_t scrambler_p4[P3_FRAME_LEN_FM];
+    int8_t viterbi_p3[P3_FRAME_LEN_MP3_MP11 * 3];
+    int8_t viterbi_p4[P3_FRAME_LEN_MP3_MP11 * 3];
+    uint8_t scrambler_p3[P3_FRAME_LEN_MP3_MP11];
+    uint8_t scrambler_p4[P3_FRAME_LEN_MP3_MP11];
 
     uint8_t p1_am[8 * P1_FRAME_LEN_ENCODED_AM];
     int8_t viterbi_p1_am[8 * P1_FRAME_LEN_AM * 3];
@@ -67,63 +63,19 @@ typedef struct
 } decode_t;
 
 void decode_process_p1(decode_t *st);
-void decode_process_pids(decode_t *st);
-void decode_process_p3_p4(decode_t *st, interleaver_iv_t *interleaver, int8_t *viterbi, uint8_t *scrambler, unsigned int frame_len, logical_channel_t lc);
-void decode_process_pids_am(decode_t *st);
-void decode_process_p1_p3_am(decode_t *st);
-static inline unsigned int decode_get_block(decode_t *st)
-{
-    return st->idx_pm / (720 * BLKSZ);
-}
-static inline void decode_push_pm(decode_t *st, int8_t sbit)
-{
-    st->buffer_pm[st->idx_pm++] = sbit;
-    if (st->idx_pm % (720 * BLKSZ) == 0)
-        decode_process_pids(st);
-    if (st->idx_pm == 720 * BLKSZ * 16)
-        if (st->started_pm)
-            decode_process_p1(st);
-}
-static inline void decode_push_px1_px2(decode_t *st, interleaver_iv_t *interleaver, int8_t *viterbi, uint8_t *scrambler, int8_t sbit)
-{
-    interleaver->buffer[interleaver->idx++] = sbit;
-    if (interleaver->idx % interleaver->length == 0)
-        if (interleaver->started)
-            decode_process_p3_p4(st, interleaver, viterbi, scrambler, interleaver->length / 2, (interleaver == &st->interleaver_px1) ? P3_LOGICAL_CHANNEL : P4_LOGICAL_CHANNEL);
-}
-static inline void decode_push_px1(decode_t *st, int8_t sbit)
-{
-    decode_push_px1_px2(st, &st->interleaver_px1, st->viterbi_p3, st->scrambler_p3, sbit);
-}
-static inline void decode_push_px2(decode_t *st, int8_t sbit)
-{
-    decode_push_px1_px2(st, &st->interleaver_px2, st->viterbi_p4, st->scrambler_p4, sbit);
-}
-static inline void decode_push_pids(decode_t *st, uint8_t sym)
-{
-    st->buffer_pids_am[st->idx_pids_am++] = sym;
-    if (st->idx_pids_am == 2 * BLKSZ)
-    {
-        decode_process_pids_am(st);
-        st->idx_pids_am = 0;
-    }
-}
-static inline void decode_push_pl_pu_s_t(decode_t *st, uint8_t sym_pl, uint8_t sym_pu, uint8_t sym_s, uint8_t sym_t)
-{
-    st->buffer_pl[st->idx_pu_pl_s_t] = sym_pl;
-    st->buffer_pu[st->idx_pu_pl_s_t] = sym_pu;
-    st->buffer_s[st->idx_pu_pl_s_t] = sym_s;
-    st->buffer_t[st->idx_pu_pl_s_t] = sym_t;
-    st->idx_pu_pl_s_t++;
-    if (st->idx_pu_pl_s_t % (PARTITION_WIDTH_AM * BLKSZ) == 0)
-    {
-        decode_process_p1_p3_am(st);
+void decode_process_pids(decode_t *st, unsigned int bc);
+void decode_process_p3_p4(const decode_t *st, interleaver_iv_t *interleaver, int8_t *viterbi, uint8_t *scrambler, logical_channel_t lc);
+void decode_process_pids_am(decode_t *st, const uint8_t* sbit);
+void decode_process_p1_p3_am(decode_t *st, unsigned int bc);
 
-        if (st->idx_pu_pl_s_t == PARTITION_WIDTH_AM * BLKSZ * 8)
-            st->idx_pu_pl_s_t = 0;
-    }
-}
-void decode_set_block(decode_t *st, unsigned int bc);
-void decode_set_px1_length(decode_t *st, unsigned int frame_len);
+void decode_push_pm(decode_t *st, const int8_t* sbit, unsigned int bc);
+void decode_push_px1(decode_t *st, const int8_t* sbit, unsigned int bc);
+void decode_push_px2(decode_t *st, const int8_t* sbit, unsigned int bc);
+
+void decode_push_pl_pu_s_t(decode_t *st,
+    const uint8_t* sym_pl, const uint8_t* sym_pu, const uint8_t* sym_s, const uint8_t* sym_t,
+    unsigned int bc);
+
+int decode_set_psmi(decode_t *st, int mode, unsigned int psmi);
 void decode_reset(decode_t *st);
 void decode_init(decode_t *st, struct input_t *input);

--- a/src/decode.h
+++ b/src/decode.h
@@ -12,7 +12,6 @@ typedef struct
   int8_t internal[P3_FRAME_LEN_MP3_MP11 * 32];
   unsigned int i;
   unsigned int pt[4];
-  unsigned int frame_length;
   int ready;
   int started;
 } interleaver_iv_t;
@@ -69,13 +68,12 @@ void decode_process_pids_am(decode_t *st, const uint8_t* sbit);
 void decode_process_p1_p3_am(decode_t *st, unsigned int bc);
 
 void decode_push_pm(decode_t *st, const int8_t* sbit, unsigned int bc);
-void decode_push_px1(decode_t *st, const int8_t* sbit, unsigned int bc);
-void decode_push_px2(decode_t *st, const int8_t* sbit, unsigned int bc);
+void decode_push_px1(decode_t *st, const int8_t* sbit, unsigned int len, unsigned int bc);
+void decode_push_px2(decode_t *st, const int8_t* sbit, unsigned int len, unsigned int bc);
 
 void decode_push_pl_pu_s_t(decode_t *st,
     const uint8_t* sym_pl, const uint8_t* sym_pu, const uint8_t* sym_s, const uint8_t* sym_t,
     unsigned int bc);
 
-int decode_set_psmi(decode_t *st, int mode, unsigned int psmi);
 void decode_reset(decode_t *st);
 void decode_init(decode_t *st, struct input_t *input);

--- a/src/defines.h
+++ b/src/defines.h
@@ -49,7 +49,8 @@
 #define PIDS_FRAME_LEN_ENCODED_FM (PIDS_FRAME_LEN * 5 / 2)
 #define PIDS_FRAME_LEN_ENCODED_AM (PIDS_FRAME_LEN * 3)
 // bits per P3 frame
-#define P3_FRAME_LEN_FM 4608
+#define P3_FRAME_LEN_MP3_MP11 4608
+#define P3_FRAME_LEN_MP2 (P3_FRAME_LEN_MP3_MP11 / 2)
 #define P3_FRAME_LEN_MA1 24000
 #define P3_FRAME_LEN_MA3 30000
 // bits per encoded P3 frame
@@ -70,6 +71,14 @@
 #define ELASTIC_BUFFER_LEN 64
 // number of subcarriers per AM partition
 #define PARTITION_WIDTH_AM 25
+// number of subcarriers per FM partition
+#define PARTITION_WIDTH_FM 19
+// number of data carries per FM partition
+#define PARTITION_DATA_CARRIERS 18
+// number of partitions on PM
+#define PM_PARTITIONS 10
+// PM block size
+#define PM_BLOCK_SIZE (2 * 2 * PM_PARTITIONS * PARTITION_DATA_CARRIERS * BLKSZ)
 
 #define log_debug(...) \
             do { if (LIBRARY_DEBUG_LEVEL <= 1) { fprintf(stderr, __VA_ARGS__); fprintf(stderr, "\n"); } } while (0)

--- a/src/defines.h
+++ b/src/defines.h
@@ -49,8 +49,8 @@
 #define PIDS_FRAME_LEN_ENCODED_FM (PIDS_FRAME_LEN * 5 / 2)
 #define PIDS_FRAME_LEN_ENCODED_AM (PIDS_FRAME_LEN * 3)
 // bits per P3 frame
+#define P3_FRAME_LEN_MP2 2304
 #define P3_FRAME_LEN_MP3_MP11 4608
-#define P3_FRAME_LEN_MP2 (P3_FRAME_LEN_MP3_MP11 / 2)
 #define P3_FRAME_LEN_MA1 24000
 #define P3_FRAME_LEN_MA3 30000
 // bits per encoded P3 frame
@@ -75,9 +75,9 @@
 #define PARTITION_WIDTH_FM 19
 // number of data carries per FM partition
 #define PARTITION_DATA_CARRIERS 18
-// number of partitions on PM
+// number of partitions in each Primary Main (PM) sideband
 #define PM_PARTITIONS 10
-// PM block size
+// size of one block in the PM interleaver matrix
 #define PM_BLOCK_SIZE (2 * 2 * PM_PARTITIONS * PARTITION_DATA_CARRIERS * BLKSZ)
 
 #define log_debug(...) \

--- a/src/frame.c
+++ b/src/frame.c
@@ -655,12 +655,12 @@ void frame_push(frame_t *st, uint8_t *bits, size_t length, logical_channel_t lc)
         offset = 1248;
         pci_len = 24;
         break;
-    case P3_FRAME_LEN_FM:
+    case P3_FRAME_LEN_MP3_MP11:
         start = 120;
         offset = 184;
         pci_len = 24;
         break;
-    case P3_FRAME_LEN_FM / 2:
+    case P3_FRAME_LEN_MP2:
         start = 120;
         offset = 88;
         pci_len = 24;

--- a/src/sync.c
+++ b/src/sync.c
@@ -23,10 +23,7 @@
 #include "private.h"
 #include "sync.h"
 
-#define PM_PARTITIONS 10
 #define MAX_PARTITIONS 14
-#define PARTITION_DATA_CARRIERS 18
-#define PARTITION_WIDTH 19
 #define MIDDLE_REF_SC 30 // midpoint of Table 11-3 in 1011s.pdf
 
 // Table 6-4 in 1011s.pdf
@@ -185,7 +182,7 @@ static int decode_ref_fm(sync_t *st, unsigned int ref, unsigned int rsid, unsign
     decode_dbpsk(st->buffer[ref], data, BLKSZ);
     *bc = (data[16] << 3) | (data[17] << 2) | (data[18] << 1) | data[19];
     *psmi = (data[25] << 5) | (data[26] << 4) | (data[27] << 3) | (data[28] << 2) | (data[29] << 1) | data[30];
-    return 0;    
+    return 0;
 }
 
 static int find_ref_fm(sync_t *st, unsigned int ref, unsigned int rsid)
@@ -274,10 +271,10 @@ static void adjust_data(sync_t *st, unsigned int lower, unsigned int upper)
         float complex upper_phase = cexpf(st->phases[upper][n] * I);
         float complex lower_phase = cexpf(st->phases[lower][n] * I);
 
-        for (int k = 1; k < PARTITION_WIDTH; k++)
+        for (int k = 1; k < PARTITION_WIDTH_FM; k++)
         {
             // average phase difference
-            float complex C = CMPLXF(PARTITION_WIDTH, PARTITION_WIDTH) / (k * smag19 * upper_phase + (PARTITION_WIDTH - k) * smag0 * lower_phase);
+            float complex C = CMPLXF(PARTITION_WIDTH_FM, PARTITION_WIDTH_FM) / (k * smag19 * upper_phase + (PARTITION_WIDTH_FM - k) * smag0 * lower_phase);
             // adjust sample
             st->buffer[lower + k][n] *= C;
         }
@@ -294,7 +291,7 @@ float phase_diff(float a, float b)
 
 void detect_cfo(sync_t *st)
 {
-    for (int cfo = -2 * PARTITION_WIDTH; cfo < 2 * PARTITION_WIDTH; cfo++)
+    for (int cfo = -2 * PARTITION_WIDTH_FM; cfo < 2 * PARTITION_WIDTH_FM; cfo++)
     {
         int offset;
         int best_offset = -1;
@@ -305,15 +302,15 @@ void detect_cfo(sync_t *st)
 
         for (int i = 0; i <= PM_PARTITIONS; i++)
         {
-            adjust_ref(st, cfo + LB_START + i * PARTITION_WIDTH, cfo);
-            offset = find_ref_fm(st, cfo + LB_START + i * PARTITION_WIDTH, (MIDDLE_REF_SC-i) & 0x3);
-            reset_ref(st, cfo + LB_START + i * PARTITION_WIDTH);
+            adjust_ref(st, cfo + LB_START + i * PARTITION_WIDTH_FM, cfo);
+            offset = find_ref_fm(st, cfo + LB_START + i * PARTITION_WIDTH_FM, (MIDDLE_REF_SC-i) & 0x3);
+            reset_ref(st, cfo + LB_START + i * PARTITION_WIDTH_FM);
             if (offset >= 0)
                 offset_count[offset]++;
 
-            adjust_ref(st, cfo + UB_END - i * PARTITION_WIDTH, cfo);
-            offset = find_ref_fm(st, cfo + UB_END - i * PARTITION_WIDTH, (MIDDLE_REF_SC-i) & 0x3);
-            reset_ref(st, cfo + UB_END - i * PARTITION_WIDTH);
+            adjust_ref(st, cfo + UB_END - i * PARTITION_WIDTH_FM, cfo);
+            offset = find_ref_fm(st, cfo + UB_END - i * PARTITION_WIDTH_FM, (MIDDLE_REF_SC-i) & 0x3);
+            reset_ref(st, cfo + UB_END - i * PARTITION_WIDTH_FM);
             if (offset >= 0)
                 offset_count[offset]++;
         }
@@ -359,7 +356,7 @@ void sync_process_fm(sync_t *st)
             partitions_per_band = 10;
     }
 
-    for (i = 0; i < partitions_per_band * PARTITION_WIDTH + 1; i += PARTITION_WIDTH)
+    for (i = 0; i < partitions_per_band * PARTITION_WIDTH_FM + 1; i += PARTITION_WIDTH_FM)
     {
         adjust_ref(st, LB_START + i, 0);
         adjust_ref(st, UB_END - i, 0);
@@ -374,13 +371,13 @@ void sync_process_fm(sync_t *st)
         for (i = 0; i <= partitions_per_band; i++)
         {
             unsigned int bc, psmi;
-            if (decode_ref_fm(st, LB_START + i * PARTITION_WIDTH, (MIDDLE_REF_SC-i) & 0x3, &bc, &psmi) == 0)
+            if (decode_ref_fm(st, LB_START + i * PARTITION_WIDTH_FM, (MIDDLE_REF_SC-i) & 0x3, &bc, &psmi) == 0)
             {
                 good_refs++;
                 seen_bc[bc]++;
                 seen_psmi[psmi]++;
             }
-            if (decode_ref_fm(st, UB_END - i * PARTITION_WIDTH, (MIDDLE_REF_SC-i) & 0x3, &bc, &psmi) == 0)
+            if (decode_ref_fm(st, UB_END - i * PARTITION_WIDTH_FM, (MIDDLE_REF_SC-i) & 0x3, &bc, &psmi) == 0)
             {
                 good_refs++;
                 seen_bc[bc]++;
@@ -408,8 +405,7 @@ void sync_process_fm(sync_t *st)
                 input_set_sync_state(st->input, SYNC_STATE_FINE);
 
                 decode_reset(&st->input->decode);
-                decode_set_px1_length(&st->input->decode,
-                    (compatibility_mode[st->psmi] == 2) ? P3_FRAME_LEN_FM : P3_FRAME_LEN_FM * 2);
+                decode_set_psmi(&st->input->decode, NRSC5_MODE_FM, compatibility_mode[st->psmi]);
 
                 frame_reset(&st->input->frame);
             }
@@ -430,17 +426,17 @@ void sync_process_fm(sync_t *st)
     {
         float samperr = 0, angle = 0;
         float sum_xy = 0, sum_x2 = 0;
-        for (i = 0; i < partitions_per_band * PARTITION_WIDTH; i += PARTITION_WIDTH)
+        for (i = 0; i < partitions_per_band * PARTITION_WIDTH_FM; i += PARTITION_WIDTH_FM)
         {
-            adjust_data(st, LB_START + i, LB_START + i + PARTITION_WIDTH);
-            adjust_data(st, UB_END - i - PARTITION_WIDTH, UB_END - i);
+            adjust_data(st, LB_START + i, LB_START + i + PARTITION_WIDTH_FM);
+            adjust_data(st, UB_END - i - PARTITION_WIDTH_FM, UB_END - i);
 
-            samperr += phase_diff(st->phases[LB_START + i][0], st->phases[LB_START + i + PARTITION_WIDTH][0]);
-            samperr += phase_diff(st->phases[UB_END - i - PARTITION_WIDTH][0], st->phases[UB_END - i][0]);
+            samperr += phase_diff(st->phases[LB_START + i][0], st->phases[LB_START + i + PARTITION_WIDTH_FM][0]);
+            samperr += phase_diff(st->phases[UB_END - i - PARTITION_WIDTH_FM][0], st->phases[UB_END - i][0]);
         }
-        samperr = samperr / (partitions_per_band * 2) * FFT_FM / PARTITION_WIDTH / (2 * M_PI);
+        samperr = samperr / (partitions_per_band * 2) * FFT_FM / PARTITION_WIDTH_FM / (2 * M_PI);
 
-        for (i = 0; i < partitions_per_band * PARTITION_WIDTH + 1; i += PARTITION_WIDTH)
+        for (i = 0; i < partitions_per_band * PARTITION_WIDTH_FM + 1; i += PARTITION_WIDTH_FM)
         {
             float x, y;
 
@@ -461,7 +457,7 @@ void sync_process_fm(sync_t *st)
 
         angle /= (partitions_per_band + 1) * 2;
         st->angle = angle;
-        for (i = 0; i < partitions_per_band * PARTITION_WIDTH + 1; i += PARTITION_WIDTH)
+        for (i = 0; i < partitions_per_band * PARTITION_WIDTH_FM + 1; i += PARTITION_WIDTH_FM)
         {
             st->costas_freq[LB_START + i] -= angle;
             st->costas_freq[UB_END - i] -= angle;
@@ -472,16 +468,16 @@ void sync_process_fm(sync_t *st)
         for (int n = 0; n < BLKSZ; n++)
         {
             float complex c, ideal;
-            for (i = 0; i < partitions_per_band * PARTITION_WIDTH; i += PARTITION_WIDTH)
+            for (i = 0; i < partitions_per_band * PARTITION_WIDTH_FM; i += PARTITION_WIDTH_FM)
             {
                 unsigned int j;
-                for (j = 1; j < PARTITION_WIDTH; j++)
+                for (j = 1; j < PARTITION_WIDTH_FM; j++)
                 {
                     c = st->buffer[LB_START + i + j][n];
                     ideal = CMPLXF(crealf(c) >= 0 ? 1 : -1, cimagf(c) >= 0 ? 1 : -1);
                     error_lb += normf(ideal - c);
 
-                    c = st->buffer[UB_END - i - PARTITION_WIDTH + j][n];
+                    c = st->buffer[UB_END - i - PARTITION_WIDTH_FM + j][n];
                     ideal = CMPLXF(crealf(c) >= 0 ? 1 : -1, cimagf(c) >= 0 ? 1 : -1);
                     error_ub += normf(ideal - c);
                 }
@@ -506,95 +502,108 @@ void sync_process_fm(sync_t *st)
         }
 
         // Soft demod based on MER for each sideband
-        float mer_lb = 2 * BLKSZ * (partitions_per_band * PARTITION_DATA_CARRIERS) / error_lb;
-        float mer_ub = 2 * BLKSZ * (partitions_per_band * PARTITION_DATA_CARRIERS) / error_ub;
-        float mult_lb = fmaxf(fminf(mer_lb * 10, 127), 1);
-        float mult_ub = fmaxf(fminf(mer_ub * 10, 127), 1);
+        const float mer_lb = 2.0f * BLKSZ * (float)(partitions_per_band * PARTITION_DATA_CARRIERS) / error_lb;
+        const float mer_ub = 2.0f * BLKSZ * (float)(partitions_per_band * PARTITION_DATA_CARRIERS) / error_ub;
+        const float mult_lb = fmaxf(fminf(mer_lb * 10, 127), 1);
+        const float mult_ub = fmaxf(fminf(mer_ub * 10, 127), 1);
 
-        decode_set_block(&st->input->decode, st->bc);
+        int8_t buffer_pm[PM_BLOCK_SIZE];
+        int8_t buffer_px1[P3_FRAME_LEN_MP3_MP11];
+        int8_t buffer_px2[P3_FRAME_LEN_MP3_MP11];
+        int out_pm = 0, out_px1 = 0, out_px2 = 0;
 
         for (int n = 0; n < BLKSZ; n++)
         {
             float complex c;
-            for (i = LB_START; i < LB_START + (PM_PARTITIONS * PARTITION_WIDTH); i += PARTITION_WIDTH)
+            for (i = LB_START; i < LB_START + (PM_PARTITIONS * PARTITION_WIDTH_FM); i += PARTITION_WIDTH_FM)
             {
                 unsigned int j;
-                for (j = 1; j < PARTITION_WIDTH; j++)
+                for (j = 1; j < PARTITION_WIDTH_FM; j++)
                 {
                     c = st->buffer[i + j][n];
-                    decode_push_pm(&st->input->decode, demod(crealf(c), mult_lb));
-                    decode_push_pm(&st->input->decode, demod(cimagf(c), mult_lb));
+                    buffer_pm[out_pm++] = demod(crealf(c), mult_lb);
+                    buffer_pm[out_pm++] = demod(cimagf(c), mult_lb);
                 }
             }
-            for (i = UB_END - (PM_PARTITIONS * PARTITION_WIDTH); i < UB_END; i += PARTITION_WIDTH)
+            for (i = UB_END - (PM_PARTITIONS * PARTITION_WIDTH_FM); i < UB_END; i += PARTITION_WIDTH_FM)
             {
                 unsigned int j;
-                for (j = 1; j < PARTITION_WIDTH; j++)
+                for (j = 1; j < PARTITION_WIDTH_FM; j++)
                 {
                     c = st->buffer[i + j][n];
-                    decode_push_pm(&st->input->decode, demod(crealf(c), mult_ub));
-                    decode_push_pm(&st->input->decode, demod(cimagf(c), mult_ub));
+                    buffer_pm[out_pm++] = demod(crealf(c), mult_ub);
+                    buffer_pm[out_pm++] = demod(cimagf(c), mult_ub);
                 }
             }
             if (compatibility_mode[st->psmi] == 2) {
                 unsigned int j;
-                for (j = 1; j < PARTITION_WIDTH; j++)
+                for (j = 1; j < PARTITION_WIDTH_FM; j++)
                 {
-                    c = st->buffer[LB_START + (PM_PARTITIONS * PARTITION_WIDTH) + j][n];
-                    decode_push_px1(&st->input->decode, demod(crealf(c), mult_lb));
-                    decode_push_px1(&st->input->decode, demod(cimagf(c), mult_lb));
+                    c = st->buffer[LB_START + (PM_PARTITIONS * PARTITION_WIDTH_FM) + j][n];
+                    buffer_px1[out_px1++] = demod(crealf(c), mult_lb);
+                    buffer_px1[out_px1++] = demod(cimagf(c), mult_lb);
                 }
-                for (j = 1; j < PARTITION_WIDTH; j++)
+                for (j = 1; j < PARTITION_WIDTH_FM; j++)
                 {
-                    c = st->buffer[UB_END - (PM_PARTITIONS + 1) * PARTITION_WIDTH + j][n];
-                    decode_push_px1(&st->input->decode, demod(crealf(c), mult_ub));
-                    decode_push_px1(&st->input->decode, demod(cimagf(c), mult_ub));
+                    c = st->buffer[UB_END - (PM_PARTITIONS + 1) * PARTITION_WIDTH_FM + j][n];
+                    buffer_px1[out_px1++] = demod(crealf(c), mult_ub);
+                    buffer_px1[out_px1++] = demod(cimagf(c), mult_ub);
                 }
             }
             if ((compatibility_mode[st->psmi] == 3) || (compatibility_mode[st->psmi] == 11)) {
-                for (i = LB_START + (PM_PARTITIONS * PARTITION_WIDTH); i < LB_START + (PM_PARTITIONS + 2) * PARTITION_WIDTH; i += PARTITION_WIDTH)
+                for (i = LB_START + (PM_PARTITIONS * PARTITION_WIDTH_FM); i < LB_START + (PM_PARTITIONS + 2) * PARTITION_WIDTH_FM; i += PARTITION_WIDTH_FM)
                 {
                     unsigned int j;
-                    for (j = 1; j < PARTITION_WIDTH; j++)
+                    for (j = 1; j < PARTITION_WIDTH_FM; j++)
                     {
                         c = st->buffer[i + j][n];
-                        decode_push_px1(&st->input->decode, demod(crealf(c), mult_lb));
-                        decode_push_px1(&st->input->decode, demod(cimagf(c), mult_lb));
+                        buffer_px1[out_px1++] = demod(crealf(c), mult_lb);
+                        buffer_px1[out_px1++] = demod(cimagf(c), mult_lb);
                     }
                 }
-                for (i = UB_END - (PM_PARTITIONS + 2) * PARTITION_WIDTH; i < UB_END - (PM_PARTITIONS * PARTITION_WIDTH); i += PARTITION_WIDTH)
+                for (i = UB_END - (PM_PARTITIONS + 2) * PARTITION_WIDTH_FM; i < UB_END - (PM_PARTITIONS * PARTITION_WIDTH_FM); i += PARTITION_WIDTH_FM)
                 {
                     unsigned int j;
-                    for (j = 1; j < PARTITION_WIDTH; j++)
+                    for (j = 1; j < PARTITION_WIDTH_FM; j++)
                     {
                         c = st->buffer[i + j][n];
-                        decode_push_px1(&st->input->decode, demod(crealf(c), mult_ub));
-                        decode_push_px1(&st->input->decode, demod(cimagf(c), mult_ub));
+                        buffer_px1[out_px1++] = demod(crealf(c), mult_ub);
+                        buffer_px1[out_px1++] = demod(cimagf(c), mult_ub);
                     }
                 }
             }
             if (compatibility_mode[st->psmi] == 11) {
-                for (i = LB_START + (PM_PARTITIONS + 2) * PARTITION_WIDTH; i < LB_START + (PM_PARTITIONS + 4) * PARTITION_WIDTH; i += PARTITION_WIDTH)
+                for (i = LB_START + (PM_PARTITIONS + 2) * PARTITION_WIDTH_FM; i < LB_START + (PM_PARTITIONS + 4) * PARTITION_WIDTH_FM; i += PARTITION_WIDTH_FM)
                 {
                     unsigned int j;
-                    for (j = 1; j < PARTITION_WIDTH; j++)
+                    for (j = 1; j < PARTITION_WIDTH_FM; j++)
                     {
                         c = st->buffer[i + j][n];
-                        decode_push_px2(&st->input->decode, demod(crealf(c), mult_lb));
-                        decode_push_px2(&st->input->decode, demod(cimagf(c), mult_lb));
+                        buffer_px2[out_px2++] = demod(crealf(c), mult_lb);
+                        buffer_px2[out_px2++] = demod(cimagf(c), mult_lb);
                     }
                 }
-                for (i = UB_END - (PM_PARTITIONS + 4) * PARTITION_WIDTH; i < UB_END - (PM_PARTITIONS + 2) * PARTITION_WIDTH; i += PARTITION_WIDTH)
+                for (i = UB_END - (PM_PARTITIONS + 4) * PARTITION_WIDTH_FM; i < UB_END - (PM_PARTITIONS + 2) * PARTITION_WIDTH_FM; i += PARTITION_WIDTH_FM)
                 {
                     unsigned int j;
-                    for (j = 1; j < PARTITION_WIDTH; j++)
+                    for (j = 1; j < PARTITION_WIDTH_FM; j++)
                     {
                         c = st->buffer[i + j][n];
-                        decode_push_px2(&st->input->decode, demod(crealf(c), mult_ub));
-                        decode_push_px2(&st->input->decode, demod(cimagf(c), mult_ub));
+                        buffer_px2[out_px2++] = demod(crealf(c), mult_lb);
+                        buffer_px2[out_px2++] = demod(cimagf(c), mult_lb);
                     }
                 }
             }
+        }
+
+        decode_push_pm(&st->input->decode, buffer_pm, st->bc);
+        if (out_px1 > 0)
+        {
+            decode_push_px1(&st->input->decode, buffer_px1, st->bc);
+        }
+        if (out_px2 > 0)
+        {
+            decode_push_px2(&st->input->decode, buffer_px2, st->bc);
         }
 
         st->bc = (st->bc + 1) % 16;
@@ -652,6 +661,7 @@ void sync_process_am(sync_t *st)
             st->bc = 0;
             input_set_sync_state(st->input, SYNC_STATE_FINE);
             decode_reset(&st->input->decode);
+            decode_set_psmi(&st->input->decode, NRSC5_MODE_AM, st->psmi);
             frame_reset(&st->input->frame);
             st->offset_history = 0;
         }
@@ -659,29 +669,33 @@ void sync_process_am(sync_t *st)
 
     if (st->input->sync_state == SYNC_STATE_FINE)
     {
-        int pids1_index = (st->psmi != SERVICE_MODE_MA3) ? PIDS_INNER_INDEX_AM : -PIDS_INNER_INDEX_AM;
-        int pids2_index = (st->psmi != SERVICE_MODE_MA3) ? PIDS_OUTER_INDEX_AM : PIDS_INNER_INDEX_AM;
+        const int pids1_index = (st->psmi != SERVICE_MODE_MA3) ? PIDS_INNER_INDEX_AM : -PIDS_INNER_INDEX_AM;
+        const int pids2_index = (st->psmi != SERVICE_MODE_MA3) ? PIDS_OUTER_INDEX_AM : PIDS_INNER_INDEX_AM;
 
-        float complex pids1_mult = 2 * CMPLXF(1.5, -0.5) / (st->buffer[CENTER_AM + pids1_index][8] + st->buffer[CENTER_AM + pids1_index][24]);
-        float complex pids2_mult = 2 * CMPLXF(1.5, -0.5) / (st->buffer[CENTER_AM + pids2_index][8] + st->buffer[CENTER_AM + pids2_index][24]);
+        const float complex pids1_mult = 2 * CMPLXF(1.5, -0.5) / (st->buffer[CENTER_AM + pids1_index][8] + st->buffer[CENTER_AM + pids1_index][24]);
+        const float complex pids2_mult = 2 * CMPLXF(1.5, -0.5) / (st->buffer[CENTER_AM + pids2_index][8] + st->buffer[CENTER_AM + pids2_index][24]);
+        uint8_t pids[2 * BLKSZ];
+        int pids_out = 0;
 
         for (int n = 0; n < BLKSZ; n++)
         {
             st->buffer[CENTER_AM + pids1_index][n] *= pids1_mult;
-            decode_push_pids(&st->input->decode, qam16(st->buffer[CENTER_AM + pids1_index][n]));
+            pids[pids_out++] = qam16(st->buffer[CENTER_AM + pids1_index][n]);
 
             st->buffer[CENTER_AM + pids2_index][n] *= pids2_mult;
-            decode_push_pids(&st->input->decode, qam16(st->buffer[CENTER_AM + pids2_index][n]));
+            pids[pids_out++] = qam16(st->buffer[CENTER_AM + pids2_index][n]);
         }
+
+        decode_process_pids_am(&st->input->decode, pids);
 
         float complex pl_mult[PARTITION_WIDTH_AM];
         float complex pu_mult[PARTITION_WIDTH_AM];
         float complex s_mult[PARTITION_WIDTH_AM];
         float complex t_mult[PARTITION_WIDTH_AM];
 
-        int primary_index = (st->psmi != SERVICE_MODE_MA3) ? OUTER_PARTITION_START_AM : INNER_PARTITION_START_AM;
-        int secondary_index = MIDDLE_PARTITION_START_AM;
-        int tertiary_index = (st->psmi != SERVICE_MODE_MA3) ? INNER_PARTITION_START_AM : MIDDLE_PARTITION_START_AM;
+        const int primary_index = (st->psmi != SERVICE_MODE_MA3) ? OUTER_PARTITION_START_AM : INNER_PARTITION_START_AM;
+        const int secondary_index = MIDDLE_PARTITION_START_AM;
+        const int tertiary_index = (st->psmi != SERVICE_MODE_MA3) ? INNER_PARTITION_START_AM : MIDDLE_PARTITION_START_AM;
 
         float samperr = 0;
         for (int col = 0; col < PARTITION_WIDTH_AM; col++)
@@ -711,6 +725,11 @@ void sync_process_am(sync_t *st)
         samperr = samperr / (2 * (PARTITION_WIDTH_AM-1)) * FFT_AM / (2 * M_PI);
         st->samperr = roundf(samperr);
 
+        uint8_t pl[BLKSZ * PARTITION_WIDTH_AM];
+        uint8_t pu[BLKSZ * PARTITION_WIDTH_AM];
+        uint8_t s[BLKSZ * PARTITION_WIDTH_AM];
+        uint8_t t[BLKSZ * PARTITION_WIDTH_AM];
+
         for (int n = 0; n < BLKSZ; n++)
         {
             for (int col = 0; col < PARTITION_WIDTH_AM; col++)
@@ -725,26 +744,25 @@ void sync_process_am(sync_t *st)
 
                 if (st->psmi != SERVICE_MODE_MA3)
                 {
-                    decode_push_pl_pu_s_t(
-                        &st->input->decode,
-                        qam64(st->buffer[CENTER_AM - primary_index - col][n]),
-                        qam64(st->buffer[CENTER_AM + primary_index + col][n]),
-                        qam16(st->buffer[CENTER_AM + secondary_index + col][n]),
-                        qpsk(st->buffer[CENTER_AM + tertiary_index + col][n])
-                    );
+                    pl[n * PARTITION_WIDTH_AM + col] = qam64(st->buffer[CENTER_AM - primary_index - col][n]);
+                    pu[n * PARTITION_WIDTH_AM + col] = qam64(st->buffer[CENTER_AM + primary_index + col][n]);
+                    s[n * PARTITION_WIDTH_AM + col] = qam16(st->buffer[CENTER_AM + secondary_index + col][n]);
+                    t[n * PARTITION_WIDTH_AM + col] = qpsk(st->buffer[CENTER_AM + tertiary_index + col][n]);
                 }
                 else
                 {
-                    decode_push_pl_pu_s_t(
-                        &st->input->decode,
-                        qam64(st->buffer[CENTER_AM - primary_index - col][n]),
-                        qam64(st->buffer[CENTER_AM + primary_index + col][n]),
-                        qam64(st->buffer[CENTER_AM + secondary_index + col][n]),
-                        qam64(st->buffer[CENTER_AM - tertiary_index - col][n])
-                    );
+                    pl[n * PARTITION_WIDTH_AM + col] = qam64(st->buffer[CENTER_AM - primary_index - col][n]);
+                    pu[n * PARTITION_WIDTH_AM + col] = qam64(st->buffer[CENTER_AM + primary_index + col][n]);
+                    s[n * PARTITION_WIDTH_AM + col] = qam64(st->buffer[CENTER_AM + secondary_index + col][n]);
+                    t[n * PARTITION_WIDTH_AM + col] = qam64(st->buffer[CENTER_AM - tertiary_index - col][n]);
                 }
             }
         }
+
+        decode_push_pl_pu_s_t(
+            &st->input->decode,
+            pl, pu, s, t, st->bc
+        );
 
         st->bc = (st->bc + 1) % 8;
     }
@@ -753,7 +771,7 @@ void sync_process_am(sync_t *st)
 void sync_adjust(sync_t *st, int sample_adj)
 {
     int i;
-    for (i = 0; i < MAX_PARTITIONS * PARTITION_WIDTH + 1; i++)
+    for (i = 0; i < MAX_PARTITIONS * PARTITION_WIDTH_FM + 1; i++)
     {
         st->costas_phase[LB_START + i] -= sample_adj * (LB_START + i - (FFT_FM / 2)) * 2 * M_PI / FFT_FM;
         st->costas_phase[UB_END - i] -= sample_adj * (UB_END - i - (FFT_FM / 2)) * 2 * M_PI / FFT_FM;
@@ -766,7 +784,7 @@ void sync_push(sync_t *st, float complex *fftout)
 
     if (st->input->radio->mode == NRSC5_MODE_FM)
     {
-        for (i = 0; i < MAX_PARTITIONS * PARTITION_WIDTH + 1; i++)
+        for (i = 0; i < MAX_PARTITIONS * PARTITION_WIDTH_FM + 1; i++)
         {
             st->buffer[LB_START + i][st->idx] = fftout[LB_START + i];
             st->buffer[UB_END - i][st->idx] = fftout[UB_END - i];

--- a/src/sync.c
+++ b/src/sync.c
@@ -405,7 +405,6 @@ void sync_process_fm(sync_t *st)
                 input_set_sync_state(st->input, SYNC_STATE_FINE);
 
                 decode_reset(&st->input->decode);
-                decode_set_psmi(&st->input->decode, NRSC5_MODE_FM, compatibility_mode[st->psmi]);
 
                 frame_reset(&st->input->frame);
             }
@@ -599,11 +598,11 @@ void sync_process_fm(sync_t *st)
         decode_push_pm(&st->input->decode, buffer_pm, st->bc);
         if (out_px1 > 0)
         {
-            decode_push_px1(&st->input->decode, buffer_px1, st->bc);
+            decode_push_px1(&st->input->decode, buffer_px1, out_px1, st->bc);
         }
         if (out_px2 > 0)
         {
-            decode_push_px2(&st->input->decode, buffer_px2, st->bc);
+            decode_push_px2(&st->input->decode, buffer_px2, out_px2, st->bc);
         }
 
         st->bc = (st->bc + 1) % 16;
@@ -661,7 +660,6 @@ void sync_process_am(sync_t *st)
             st->bc = 0;
             input_set_sync_state(st->input, SYNC_STATE_FINE);
             decode_reset(&st->input->decode);
-            decode_set_psmi(&st->input->decode, NRSC5_MODE_AM, st->psmi);
             frame_reset(&st->input->frame);
             st->offset_history = 0;
         }


### PR DESCRIPTION
~~Fixes an issue raised in #457~~ (to be moved in a different pr)

While working on the API for the local_time SIS parameter, I wanted to try out decoding the ALFN to experiment with what stations are sending out. That requires the current block count to construct ALFN. 
The current block count isn't directly associated with each PIDS. To make this easier, I decided to refactor the decoder to make the current block count more accessible.

This is the improvements:

- `decode_set_block` is removed since block count is now provided with each call. 
- For any decoding changes based on PSMI can be changed through `decode_set_psmi` now. `decode_set_px1_length` is not needed. 
- Each deinterleaver is now into their own individual functions. This can make deinterleaving a lot easier for advanced service modes. This can also the possibly to deinterleave per block instead of by a complete frame a bit easier. 
- Constants for the convolutional decoder of P, E1, E2 
- ~~The convolutional decoder's path and trellis is now separated. The possibly for stack allocation is easier.~~ (to be moved in a different pr)
- ~~The convolutional decoder's path and trellis is now allocated upfront before decoding and freed after decoding is finished. This does make memory usage (\~18.7 MB) from convolutional decoder noticeable. For example, Task Manager on Windows now shows the memory usage from the convolutional decoder.~~ (to be moved in a different pr)

There is still some code duplication but good enough for what it is at the moment.

I did learn a lot by asking @argilo many questions to make sure this was refactored properly.
