### PR TITLE
ALFN Decode & Add to API

### DIFF
--- a/include/nrsc5.h
+++ b/include/nrsc5.h
@@ -613,8 +613,8 @@ struct nrsc5_event_t
         } local_time;
         struct
         {
-            unsigned int alfn;  /**< Absolute L1 Frame Number (ALFN) of the previous L1 Frame. */
-            int gps_locked;     /**< 1 if GPS is locked, otherwise 0. */
+            unsigned int alfn;  /**< Absolute L1 Frame Number (ALFN) of the most recent L1 Frame. */
+            int time_locked;    /**< 1 if time is locked to GPS, otherwise 0. */
         } alfn;
     };
 };

--- a/include/nrsc5.h
+++ b/include/nrsc5.h
@@ -192,6 +192,7 @@ enum
     NRSC5_EVENT_IMPORTER_INFO,
     NRSC5_EVENT_LEAP_SECOND_OFFSET,
     NRSC5_EVENT_LOCAL_TIME,
+    NRSC5_EVENT_ALFN,
 };
 
 enum
@@ -401,6 +402,7 @@ struct nrsc5_event_t
  * - `NRSC5_EVENT_IMPORTER_INFO` : importer data, see `importer_info` member
  * - `NRSC5_EVENT_LEAP_SECOND_OFFSET` : leap second offset, see `leap_second_offset` member
  * - `NRSC5_EVENT_LOCAL_TIME` : local time data, see `local_time` member
+ * - `NRSC5_EVENT_ALFN` : ALFN data, see `alfn` member
  */
     unsigned int event;
     union
@@ -609,6 +611,11 @@ struct nrsc5_event_t
             int dst_local;     /**< 1 if DST is practiced locally, otherwise 0. */
             int dst_schedule;  /**< DST Schedule. 0 means Daylight Saving Time is not practiced. 1 means U.S./Canada schedule. 2 means EU schedule. */
         } local_time;
+        struct
+        {
+            unsigned int alfn;  /**< Absolute L1 Frame Number (ALFN) of the previous L1 Frame. */
+            int gps_locked;     /**< 1 if GPS is locked, otherwise 0. */
+        } alfn;
     };
 };
 /**

--- a/include/nrsc5.h
+++ b/include/nrsc5.h
@@ -192,7 +192,7 @@ enum
     NRSC5_EVENT_IMPORTER_INFO,
     NRSC5_EVENT_LEAP_SECOND_OFFSET,
     NRSC5_EVENT_LOCAL_TIME,
-    NRSC5_EVENT_ALFN,
+    NRSC5_EVENT_L1_FRAME,
 };
 
 enum
@@ -402,7 +402,7 @@ struct nrsc5_event_t
  * - `NRSC5_EVENT_IMPORTER_INFO` : importer data, see `importer_info` member
  * - `NRSC5_EVENT_LEAP_SECOND_OFFSET` : leap second offset, see `leap_second_offset` member
  * - `NRSC5_EVENT_LOCAL_TIME` : local time data, see `local_time` member
- * - `NRSC5_EVENT_ALFN` : ALFN data, see `alfn` member
+ * - `NRSC5_EVENT_L1_FRAME` : L1 frame data, see `l1_frame` member
  */
     unsigned int event;
     union
@@ -614,8 +614,9 @@ struct nrsc5_event_t
         struct
         {
             unsigned int alfn;  /**< Absolute L1 Frame Number (ALFN) of the most recent L1 Frame. */
+            int alfn_known;     /**< 1 if ALFN is known, otherwise 0. */
             int time_locked;    /**< 1 if time is locked to GPS, otherwise 0. */
-        } alfn;
+        } l1_frame;
     };
 };
 /**

--- a/src/decode.c
+++ b/src/decode.c
@@ -468,10 +468,13 @@ void decode_process_pids(decode_t *st, const unsigned int bc)
 
     nrsc5_conv_decode_pids(st->viterbi_pids, st->scrambler_pids);
     descramble(st->scrambler_pids, PIDS_FRAME_LEN);
-    pids_frame_push(&st->pids, st->scrambler_pids);
+    pids_frame_push(&st->pids, st->scrambler_pids, bc);
+
+    if (bc == 15)
+        pids_complete_fm(&st->pids);
 }
 
-void decode_process_pids_am(decode_t *st, const uint8_t* sbit)
+void decode_process_pids_am(decode_t *st, const uint8_t* sbit, const unsigned int bc)
 {
     uint8_t il[120], iu[120];
 
@@ -501,7 +504,10 @@ void decode_process_pids_am(decode_t *st, const uint8_t* sbit)
 
     nrsc5_conv_decode_e2_e3(st->viterbi_pids, st->scrambler_pids, PIDS_FRAME_LEN);
     descramble(st->scrambler_pids, PIDS_FRAME_LEN);
-    pids_frame_push(&st->pids, st->scrambler_pids);
+    pids_frame_push(&st->pids, st->scrambler_pids, bc);
+
+    if (bc == 7)
+        pids_complete_am(&st->pids);
 }
 
 void decode_process_p1_p3_am(decode_t *st, const unsigned int bc)

--- a/src/decode.h
+++ b/src/decode.h
@@ -64,7 +64,7 @@ typedef struct
 void decode_process_p1(decode_t *st);
 void decode_process_pids(decode_t *st, unsigned int bc);
 void decode_process_p3_p4(const decode_t *st, interleaver_iv_t *interleaver, int8_t *viterbi, uint8_t *scrambler, logical_channel_t lc);
-void decode_process_pids_am(decode_t *st, const uint8_t* sbit);
+void decode_process_pids_am(decode_t *st, const uint8_t* sbit, unsigned int bc);
 void decode_process_p1_p3_am(decode_t *st, unsigned int bc);
 
 void decode_push_pm(decode_t *st, const int8_t* sbit, unsigned int bc);

--- a/src/main.c
+++ b/src/main.c
@@ -599,12 +599,9 @@ static void callback(const nrsc5_event_t *evt, void *opaque)
                  evt->local_time.dst_regional ? "yes" : "no",
                  evt->local_time.dst_local ? "yes" : "no");
         break;
-    case NRSC5_EVENT_ALFN:
-        {
-            const unsigned int alfn = evt->alfn.alfn + 1;
-            log_debug("ALFN: %u, GPS locked? %s", alfn, evt->alfn.time_locked ? "yes" : "no");
-            break;
-        }
+    case NRSC5_EVENT_L1_FRAME:
+        log_debug("L1 Frame: ALFN=%u, ALFN known? %s, time locked to GPS? %s", evt->l1_frame.alfn, evt->l1_frame.alfn_known ? "yes" : "no", evt->l1_frame.time_locked ? "yes" : "no");
+        break;
     }
 }
 

--- a/src/main.c
+++ b/src/main.c
@@ -83,6 +83,7 @@ typedef struct {
     unsigned int audio_bytes;
     unsigned int audio_errors;
     int done;
+    int current_leap;
 } state_t;
 
 static ao_sample_format sample_format = {
@@ -271,6 +272,11 @@ static void dump_ber(float cber)
     log_info("BER: %f, avg: %f, min: %f, max: %f", cber, sum / count, min, max);
 }
 
+static void format_time(char *buf, const size_t bufsize, const struct tm *tm)
+{
+    strftime(buf, bufsize, "%Y-%m-%dT%H:%M:%SZ", tm);
+}
+
 static void done_signal(state_t *st)
 {
     pthread_mutex_lock(&st->mutex);
@@ -445,11 +451,11 @@ static void callback(const nrsc5_event_t *evt, void *opaque)
     case NRSC5_EVENT_LOT:
         if (st->aas_files_path)
             dump_aas_file(st, evt);
-        strftime(time_str, sizeof(time_str), "%Y-%m-%dT%H:%M:%SZ", evt->lot.expiry_utc);
+        format_time(time_str, sizeof(time_str), evt->lot.expiry_utc);
         log_info("LOT file: port=%04X lot=%d name=%s size=%d mime=%08X expiry=%s", evt->lot.component->data.port, evt->lot.lot, evt->lot.name, evt->lot.size, evt->lot.mime, time_str);
         break;
     case NRSC5_EVENT_LOT_HEADER:
-        strftime(time_str, sizeof(time_str), "%Y-%m-%dT%H:%M:%SZ", evt->lot.expiry_utc);
+        format_time(time_str, sizeof(time_str), evt->lot.expiry_utc);
         log_debug("LOT header: port=%04X lot=%d name=%s size=%d mime=%08X expiry=%s",
                   evt->lot.component->data.port, evt->lot.lot, evt->lot.name, evt->lot.size, evt->lot.mime, time_str);
         break;
@@ -550,7 +556,7 @@ static void callback(const nrsc5_event_t *evt, void *opaque)
     case NRSC5_EVENT_HERE_IMAGE:
         if (st->aas_files_path)
             dump_aas_file(st, evt);
-        strftime(time_str, sizeof(time_str), "%Y-%m-%dT%H:%M:%SZ", evt->here_image.time_utc);
+        format_time(time_str, sizeof(time_str), evt->here_image.time_utc);
         log_info("HERE Image: type=%s, seq=%d, n1=%d, n2=%d, time=%s, lat1=%.5f, lon1=%.5f, lat2=%.5f, lon2=%.5f, name=%s, size=%d",
                  evt->here_image.image_type == NRSC5_HERE_IMAGE_TRAFFIC ? "TRAFFIC" : "WEATHER",
                  evt->here_image.seq,
@@ -582,6 +588,7 @@ static void callback(const nrsc5_event_t *evt, void *opaque)
                   evt->importer_info.manufacturer_version[3], evt->importer_info.manufacturer_status);
         break;
     case NRSC5_EVENT_LEAP_SECOND_OFFSET:
+        st->current_leap = evt->leap_second_offset.current_offset;
         log_debug("Leap second offset: pending=%d, current=%d, ALFN of pending adjustment=%d",
                  evt->leap_second_offset.pending_offset,
                  evt->leap_second_offset.current_offset,
@@ -594,7 +601,25 @@ static void callback(const nrsc5_event_t *evt, void *opaque)
                  evt->local_time.dst_regional ? "yes" : "no",
                  evt->local_time.dst_local ? "yes" : "no");
         break;
+    case NRSC5_EVENT_ALFN:
+        {
+            // Add 1 for current ALFN.
+            char alfn_details[512];
 
+            const unsigned int alfn = evt->alfn.alfn + 1;
+
+            const int len = sprintf(alfn_details, "ALFN: %u, GPS locked? %s", alfn, evt->alfn.gps_locked ? "yes" : "no");
+            if (st->current_leap != -1)
+            {
+                const time_t utc = (65536 * (time_t)alfn / 44100) + 315964800 - (time_t)st->current_leap;
+                const struct tm *time = gmtime(&utc);
+
+                format_time(time_str, sizeof(time_str), time);
+                snprintf(alfn_details + len, sizeof(alfn_details) - len, ", time: %s", time_str);
+            }
+            log_debug(alfn_details);
+            break;
+        }
     }
 }
 
@@ -816,6 +841,7 @@ static int parse_args(state_t *st, int argc, char *argv[])
     st->direct_sampling = -1;
     st->ppm_error = INT_MIN;
     st->iq_input_format = IQ_FORMAT_CU8;
+    st->current_leap = -1;
     log_set_level(LOG_INFO);
 
     while ((opt = getopt_long(argc, argv, "r:w:o:t:d:p:g:ql:vH:TD:", long_opts, NULL)) != -1)

--- a/src/main.c
+++ b/src/main.c
@@ -602,7 +602,7 @@ static void callback(const nrsc5_event_t *evt, void *opaque)
     case NRSC5_EVENT_ALFN:
         {
             const unsigned int alfn = evt->alfn.alfn + 1;
-            log_debug("ALFN: %u, GPS locked? %s", alfn, evt->alfn.gps_locked ? "yes" : "no");
+            log_debug("ALFN: %u, GPS locked? %s", alfn, evt->alfn.time_locked ? "yes" : "no");
             break;
         }
     }

--- a/src/main.c
+++ b/src/main.c
@@ -83,7 +83,6 @@ typedef struct {
     unsigned int audio_bytes;
     unsigned int audio_errors;
     int done;
-    int current_leap;
 } state_t;
 
 static ao_sample_format sample_format = {
@@ -588,7 +587,6 @@ static void callback(const nrsc5_event_t *evt, void *opaque)
                   evt->importer_info.manufacturer_version[3], evt->importer_info.manufacturer_status);
         break;
     case NRSC5_EVENT_LEAP_SECOND_OFFSET:
-        st->current_leap = evt->leap_second_offset.current_offset;
         log_debug("Leap second offset: pending=%d, current=%d, ALFN of pending adjustment=%d",
                  evt->leap_second_offset.pending_offset,
                  evt->leap_second_offset.current_offset,
@@ -603,21 +601,8 @@ static void callback(const nrsc5_event_t *evt, void *opaque)
         break;
     case NRSC5_EVENT_ALFN:
         {
-            // Add 1 for current ALFN.
-            char alfn_details[512];
-
             const unsigned int alfn = evt->alfn.alfn + 1;
-
-            const int len = sprintf(alfn_details, "ALFN: %u, GPS locked? %s", alfn, evt->alfn.gps_locked ? "yes" : "no");
-            if (st->current_leap != -1)
-            {
-                const time_t utc = (65536 * (time_t)alfn / 44100) + 315964800 - (time_t)st->current_leap;
-                const struct tm *time = gmtime(&utc);
-
-                format_time(time_str, sizeof(time_str), time);
-                snprintf(alfn_details + len, sizeof(alfn_details) - len, ", time: %s", time_str);
-            }
-            log_debug(alfn_details);
+            log_debug("ALFN: %u, GPS locked? %s", alfn, evt->alfn.gps_locked ? "yes" : "no");
             break;
         }
     }
@@ -841,7 +826,6 @@ static int parse_args(state_t *st, int argc, char *argv[])
     st->direct_sampling = -1;
     st->ppm_error = INT_MIN;
     st->iq_input_format = IQ_FORMAT_CU8;
-    st->current_leap = -1;
     log_set_level(LOG_INFO);
 
     while ((opt = getopt_long(argc, argv, "r:w:o:t:d:p:g:ql:vH:TD:", long_opts, NULL)) != -1)

--- a/src/nrsc5.c
+++ b/src/nrsc5.c
@@ -1162,7 +1162,7 @@ void nrsc5_report_alfn(nrsc5_t* st, const unsigned int alfn, const int gps_locke
 
     evt.event = NRSC5_EVENT_ALFN;
     evt.alfn.alfn = alfn;
-    evt.alfn.gps_locked = gps_locked;
+    evt.alfn.time_locked = gps_locked;
 
     nrsc5_report(st, &evt);
 }

--- a/src/nrsc5.c
+++ b/src/nrsc5.c
@@ -1156,6 +1156,17 @@ void nrsc5_report_local_time(nrsc5_t *st, const int tzo, const int dst_regional,
     nrsc5_report(st, &evt);
 }
 
+void nrsc5_report_alfn(nrsc5_t* st, const unsigned int alfn, const int gps_locked)
+{
+    nrsc5_event_t evt;
+
+    evt.event = NRSC5_EVENT_ALFN;
+    evt.alfn.alfn = alfn;
+    evt.alfn.gps_locked = gps_locked;
+
+    nrsc5_report(st, &evt);
+}
+
 void nrsc5_report_here_image(nrsc5_t *st, int image_type, int seq, int n1, int n2, unsigned int timestamp,
                              float latitude1, float longitude1, float latitude2, float longitude2,
                              const char *name, unsigned int size, const uint8_t *data)

--- a/src/nrsc5.c
+++ b/src/nrsc5.c
@@ -1156,13 +1156,14 @@ void nrsc5_report_local_time(nrsc5_t *st, const int tzo, const int dst_regional,
     nrsc5_report(st, &evt);
 }
 
-void nrsc5_report_alfn(nrsc5_t* st, const unsigned int alfn, const int gps_locked)
+void nrsc5_report_l1_frame(nrsc5_t* st, const unsigned int alfn, const int alfn_known, const int time_locked)
 {
     nrsc5_event_t evt;
 
-    evt.event = NRSC5_EVENT_ALFN;
-    evt.alfn.alfn = alfn;
-    evt.alfn.time_locked = gps_locked;
+    evt.event = NRSC5_EVENT_L1_FRAME;
+    evt.l1_frame.alfn = alfn;
+    evt.l1_frame.alfn_known = alfn_known;
+    evt.l1_frame.time_locked = time_locked;
 
     nrsc5_report(st, &evt);
 }

--- a/src/pids.c
+++ b/src/pids.c
@@ -932,7 +932,7 @@ static int sis_decode_emergency_alerts(pids_t *st, const uint8_t *bits)
     return updated;
 }
 
-static void sis_decode(pids_t *st, const uint8_t *bits)
+static void sis_decode(pids_t *st, const uint8_t *bits, const unsigned int bc)
 {
     int off = 0;
     int updated = 0;
@@ -1018,6 +1018,21 @@ static void sis_decode(pids_t *st, const uint8_t *bits)
         }
     }
 
+    const uint8_t time_locked = bits[64];
+    const uint8_t adv_alfn = bits[65] << 1 | bits[66];
+
+    if (bc == 0)
+    {
+        st->alfn_pairs[st->alfn_am_curr] = 0;
+        st->alfn_has_lsb[st->alfn_am_curr] = 1;
+    }
+
+    const unsigned int idx = bc + st->alfn_am_curr * 8;
+
+    st->alfn_time_locked = time_locked;
+    st->alfn_frame |= (uint64_t)adv_alfn << (2 * idx);
+    st->alfn_pairs[st->alfn_am_curr]++;
+
     if (st->alert_displayed && (st->alert_timeout >= ALERT_TIMEOUT_LIMIT))
     {
         reset_alert(st);
@@ -1029,7 +1044,7 @@ static void sis_decode(pids_t *st, const uint8_t *bits)
         report(st);
 }
 
-void pids_frame_push(pids_t *st, const uint8_t *bits)
+void pids_frame_push(pids_t *st, const uint8_t *bits, const unsigned int bc)
 {
     uint8_t pids[PIDS_FRAME_LEN];
 
@@ -1043,10 +1058,88 @@ void pids_frame_push(pids_t *st, const uint8_t *bits)
         const int type = pids[0];
 
         if (type == PIDS_TYPE_SIS)
-            sis_decode(st, pids + 1);
+            sis_decode(st, pids + 1, bc);
         else if (type == PIDS_TYPE_LLDS)
             log_debug("Ignoring LLDS frame");
     }
+}
+
+void pids_complete_fm(pids_t* st)
+{
+    if (st->alfn_pairs[0] == ALFN_FM_PAIRS_PER_FRAME)
+        nrsc5_report_alfn(st->input->radio, (int32_t)st->alfn_frame, st->alfn_time_locked);
+    st->alfn_pairs[0] = 0;
+    st->alfn_frame = 0;
+}
+
+static void pids_report_alfn_am(const pids_t* st)
+{
+    // Use latest ALFN lower bits.
+    int lower_idx = st->alfn_am_curr;
+    if (st->alfn_upper_idx == st->alfn_am_curr)
+        lower_idx = (ALFN_AM_FRAMES + st->alfn_am_curr - 1) % ALFN_AM_FRAMES;
+
+    if (st->alfn_pairs[lower_idx] != ALFN_AM_PAIRS_PER_FRAME ||
+        st->alfn_pairs[st->alfn_upper_idx] != ALFN_AM_PAIRS_PER_FRAME)
+        return;
+
+    const uint16_t upper = (uint16_t)(st->alfn_frame >> (16 * st->alfn_upper_idx) & 0xFFFF);
+    uint16_t lower = (uint16_t)(st->alfn_frame >> (16 * lower_idx) & 0xFFFF);
+    // If current frame was upper, lower wasn't updated. Assume lower was increased.
+    if (st->alfn_upper_idx == st->alfn_am_curr)
+        lower++;
+
+    nrsc5_report_alfn(st->input->radio, (int32_t)upper << 16 | (int32_t)lower, st->alfn_time_locked);
+}
+
+static int find_mod4(const int lower[4])
+{
+    for (int i = 0; i < 4; i++)
+    {
+        if (lower[i % 4] == 1 &&
+            lower[(i + 1) % 4] == 2 &&
+            lower[(i + 2) % 4] == 3)
+        {
+            return (i + 3) % 4;
+        }
+    }
+    return -1;
+}
+
+void pids_complete_am(pids_t* st)
+{
+    if (st->alfn_pairs[st->alfn_am_curr] == ALFN_AM_PAIRS_PER_FRAME)
+    {
+        if (st->alfn_am_curr == 3 && st->alfn_upper_idx == -1)
+        {
+            const int lower[ALFN_AM_FRAMES] = {
+                (int)(st->alfn_frame & 0x3),
+                (int)(st->alfn_frame >> 16 & 0x3),
+                (int)(st->alfn_frame >> 32 & 0x3),
+                (int)(st->alfn_frame >> 48 & 0x3),
+            };
+            int finished = 1;
+            for (int i = 0; i < ALFN_AM_FRAMES; i++)
+            {
+                if (!st->alfn_has_lsb[i])
+                {
+                    finished = 0;
+                    break;
+                }
+            }
+            if (finished)
+                st->alfn_upper_idx = find_mod4(lower);
+        }
+
+        if (st->alfn_upper_idx != -1)
+            pids_report_alfn_am(st);
+    }
+
+    st->alfn_am_curr = (st->alfn_am_curr + 1) % 4;
+    // Clear for new frame
+    st->alfn_frame &= ~(0xFFFFLL << (16 * st->alfn_am_curr));
+    st->alfn_pairs[st->alfn_am_curr] = 0;
+    st->alfn_has_lsb[st->alfn_am_curr] = 0;
 }
 
 void pids_init(pids_t *st, input_t *input)
@@ -1097,6 +1190,15 @@ void pids_init(pids_t *st, input_t *input)
     st->slogan_displayed = 0;
 
     reset_alert(st);
+
+    st->alfn_frame = 0;
+    st->alfn_am_curr = 0;
+    st->alfn_upper_idx = -1;
+    for (i = 0; i < 4; i++)
+    {
+        st->alfn_pairs[i] = 0;
+        st->alfn_has_lsb[i] = 0;
+    }
 
     st->input = input;
 }

--- a/src/pids.c
+++ b/src/pids.c
@@ -1021,17 +1021,12 @@ static void sis_decode(pids_t *st, const uint8_t *bits, const unsigned int bc)
     const uint8_t time_locked = bits[64];
     const uint8_t adv_alfn = bits[65] << 1 | bits[66];
 
-    if (bc == 0)
-    {
-        st->alfn_pairs[st->alfn_am_curr] = 0;
-        st->alfn_has_lsb[st->alfn_am_curr] = 1;
-    }
+    alfn_t* alfn = &st->alfn[st->alfn_frame];
 
-    const unsigned int idx = bc + st->alfn_am_curr * 8;
+    alfn->value |= (uint32_t)adv_alfn << (2 * bc);
+    alfn->received |= (1 << bc);
 
     st->alfn_time_locked = time_locked;
-    st->alfn_frame |= (uint64_t)adv_alfn << (2 * idx);
-    st->alfn_pairs[st->alfn_am_curr]++;
 
     if (st->alert_displayed && (st->alert_timeout >= ALERT_TIMEOUT_LIMIT))
     {
@@ -1042,6 +1037,90 @@ static void sis_decode(pids_t *st, const uint8_t *bits, const unsigned int bc)
 
     if (updated)
         report(st);
+}
+
+void pids_complete_fm(pids_t* st)
+{
+    alfn_t* alfn = &st->alfn[0];
+
+    if (alfn->received == 0xFFFF)
+        nrsc5_report_alfn(st->input->radio, alfn->value, st->alfn_time_locked);
+    alfn->value = 0;
+    alfn->received = 0;
+}
+
+static void pids_report_alfn_am(const pids_t* st)
+{
+    // Use latest ALFN lower bits.
+    int lower_idx = st->alfn_frame;
+    if (st->alfn_upper_idx == st->alfn_frame)
+        lower_idx = (ALFN_AM_FRAMES + st->alfn_frame - 1) % ALFN_AM_FRAMES;
+
+    const alfn_t* upper_frame = &st->alfn[st->alfn_upper_idx];
+    const alfn_t* lower_frame = &st->alfn[lower_idx];
+
+    if (upper_frame->received != 0xFF ||
+        lower_frame->received != 0xFF)
+        return;
+
+    const uint16_t upper = upper_frame->value & 0xFFFF;
+    uint16_t lower = lower_frame->value & 0xFFFF;
+
+    // If current frame was upper, lower wasn't updated. Assume lower was increased.
+    if (st->alfn_upper_idx == st->alfn_frame)
+        lower++;
+
+    const uint32_t alfn = (int32_t)upper << 16 | (int32_t)lower;
+    nrsc5_report_alfn(st->input->radio, alfn, st->alfn_time_locked);
+}
+
+static int find_mod4(const int lower[4])
+{
+    for (int i = 0; i < 4; i++)
+    {
+        if (lower[i % 4] == 1 &&
+            lower[(i + 1) % 4] == 2 &&
+            lower[(i + 2) % 4] == 3)
+        {
+            return (i + 3) % 4;
+        }
+    }
+    return -1;
+}
+
+void pids_complete_am(pids_t* st)
+{
+    if (st->alfn[st->alfn_frame].received == 0xFF)
+    {
+        if (st->alfn_frame == 3 && st->alfn_upper_idx == -1)
+        {
+            const int lower[ALFN_AM_FRAMES] = {
+                (int)(st->alfn[0].value & 0x3),
+                (int)(st->alfn[1].value & 0x3),
+                (int)(st->alfn[2].value & 0x3),
+                (int)(st->alfn[3].value & 0x3),
+            };
+            int finished = 1;
+            for (int i = 0; i < ALFN_AM_FRAMES; i++)
+            {
+                if ((st->alfn[i].received & 0x1) == 0)
+                {
+                    finished = 0;
+                    break;
+                }
+            }
+            if (finished)
+                st->alfn_upper_idx = find_mod4(lower);
+        }
+
+        if (st->alfn_upper_idx != -1)
+            pids_report_alfn_am(st);
+    }
+
+    st->alfn_frame = (st->alfn_frame + 1) % 4;
+    // Clear for new frame
+    st->alfn[st->alfn_frame].value = 0;
+    st->alfn[st->alfn_frame].received = 0;
 }
 
 void pids_frame_push(pids_t *st, const uint8_t *bits, const unsigned int bc)
@@ -1062,84 +1141,6 @@ void pids_frame_push(pids_t *st, const uint8_t *bits, const unsigned int bc)
         else if (type == PIDS_TYPE_LLDS)
             log_debug("Ignoring LLDS frame");
     }
-}
-
-void pids_complete_fm(pids_t* st)
-{
-    if (st->alfn_pairs[0] == ALFN_FM_PAIRS_PER_FRAME)
-        nrsc5_report_alfn(st->input->radio, (int32_t)st->alfn_frame, st->alfn_time_locked);
-    st->alfn_pairs[0] = 0;
-    st->alfn_frame = 0;
-}
-
-static void pids_report_alfn_am(const pids_t* st)
-{
-    // Use latest ALFN lower bits.
-    int lower_idx = st->alfn_am_curr;
-    if (st->alfn_upper_idx == st->alfn_am_curr)
-        lower_idx = (ALFN_AM_FRAMES + st->alfn_am_curr - 1) % ALFN_AM_FRAMES;
-
-    if (st->alfn_pairs[lower_idx] != ALFN_AM_PAIRS_PER_FRAME ||
-        st->alfn_pairs[st->alfn_upper_idx] != ALFN_AM_PAIRS_PER_FRAME)
-        return;
-
-    const uint16_t upper = (uint16_t)(st->alfn_frame >> (16 * st->alfn_upper_idx) & 0xFFFF);
-    uint16_t lower = (uint16_t)(st->alfn_frame >> (16 * lower_idx) & 0xFFFF);
-    // If current frame was upper, lower wasn't updated. Assume lower was increased.
-    if (st->alfn_upper_idx == st->alfn_am_curr)
-        lower++;
-
-    nrsc5_report_alfn(st->input->radio, (int32_t)upper << 16 | (int32_t)lower, st->alfn_time_locked);
-}
-
-static int find_mod4(const int lower[4])
-{
-    for (int i = 0; i < 4; i++)
-    {
-        if (lower[i % 4] == 1 &&
-            lower[(i + 1) % 4] == 2 &&
-            lower[(i + 2) % 4] == 3)
-        {
-            return (i + 3) % 4;
-        }
-    }
-    return -1;
-}
-
-void pids_complete_am(pids_t* st)
-{
-    if (st->alfn_pairs[st->alfn_am_curr] == ALFN_AM_PAIRS_PER_FRAME)
-    {
-        if (st->alfn_am_curr == 3 && st->alfn_upper_idx == -1)
-        {
-            const int lower[ALFN_AM_FRAMES] = {
-                (int)(st->alfn_frame & 0x3),
-                (int)(st->alfn_frame >> 16 & 0x3),
-                (int)(st->alfn_frame >> 32 & 0x3),
-                (int)(st->alfn_frame >> 48 & 0x3),
-            };
-            int finished = 1;
-            for (int i = 0; i < ALFN_AM_FRAMES; i++)
-            {
-                if (!st->alfn_has_lsb[i])
-                {
-                    finished = 0;
-                    break;
-                }
-            }
-            if (finished)
-                st->alfn_upper_idx = find_mod4(lower);
-        }
-
-        if (st->alfn_upper_idx != -1)
-            pids_report_alfn_am(st);
-    }
-
-    st->alfn_am_curr = (st->alfn_am_curr + 1) % 4;
-    // Clear for new frame
-    st->alfn_frame &= ~(0xFFFFLL << (16 * st->alfn_am_curr));
-    st->alfn_pairs[st->alfn_am_curr] = 0;
-    st->alfn_has_lsb[st->alfn_am_curr] = 0;
 }
 
 void pids_init(pids_t *st, input_t *input)
@@ -1192,12 +1193,12 @@ void pids_init(pids_t *st, input_t *input)
     reset_alert(st);
 
     st->alfn_frame = 0;
-    st->alfn_am_curr = 0;
+    st->alfn_frame = 0;
     st->alfn_upper_idx = -1;
-    for (i = 0; i < 4; i++)
+    for (i = 0; i < ALFN_AM_FRAMES; i++)
     {
-        st->alfn_pairs[i] = 0;
-        st->alfn_has_lsb[i] = 0;
+        st->alfn[i].value = 0;
+        st->alfn[i].received = 0;
     }
 
     st->input = input;

--- a/src/pids.c
+++ b/src/pids.c
@@ -1021,10 +1021,13 @@ static void sis_decode(pids_t *st, const uint8_t *bits, const unsigned int bc)
     const uint8_t time_locked = bits[64];
     const uint8_t adv_alfn = bits[65] << 1 | bits[66];
 
-    alfn_t* alfn = &st->alfn[st->alfn_frame];
+    alfn_t* alfn = &st->alfn_frames[st->alfn_frame_idx];
 
-    alfn->value |= (uint32_t)adv_alfn << (2 * bc);
-    alfn->received |= (1 << bc);
+    if ((alfn->received & (1 << bc)) == 0)
+    {
+        alfn->value |= (uint32_t)adv_alfn << (2 * bc);
+        alfn->received |= (1 << bc);
+    }
 
     st->alfn_time_locked = time_locked;
 
@@ -1041,37 +1044,21 @@ static void sis_decode(pids_t *st, const uint8_t *bits, const unsigned int bc)
 
 void pids_complete_fm(pids_t* st)
 {
-    alfn_t* alfn = &st->alfn[0];
+    alfn_t* alfn = &st->alfn_frames[0];
 
     if (alfn->received == 0xFFFF)
-        nrsc5_report_alfn(st->input->radio, alfn->value, st->alfn_time_locked);
+    {
+        st->alfn_value = alfn->value;
+        st->alfn_known = 1;
+    }
+
+    nrsc5_report_l1_frame(st->input->radio, st->alfn_value, st->alfn_known, st->alfn_time_locked);
+
     alfn->value = 0;
     alfn->received = 0;
-}
 
-static void pids_report_alfn_am(const pids_t* st)
-{
-    // Use latest ALFN lower bits.
-    int lower_idx = st->alfn_frame;
-    if (st->alfn_upper_idx == st->alfn_frame)
-        lower_idx = (ALFN_AM_FRAMES + st->alfn_frame - 1) % ALFN_AM_FRAMES;
-
-    const alfn_t* upper_frame = &st->alfn[st->alfn_upper_idx];
-    const alfn_t* lower_frame = &st->alfn[lower_idx];
-
-    if (upper_frame->received != 0xFF ||
-        lower_frame->received != 0xFF)
-        return;
-
-    const uint16_t upper = upper_frame->value & 0xFFFF;
-    uint16_t lower = lower_frame->value & 0xFFFF;
-
-    // If current frame was upper, lower wasn't updated. Assume lower was increased.
-    if (st->alfn_upper_idx == st->alfn_frame)
-        lower++;
-
-    const uint32_t alfn = (int32_t)upper << 16 | (int32_t)lower;
-    nrsc5_report_alfn(st->input->radio, alfn, st->alfn_time_locked);
+    if (st->alfn_known)
+        st->alfn_value++;
 }
 
 static int find_mod4(const int lower[4])
@@ -1088,39 +1075,68 @@ static int find_mod4(const int lower[4])
     return -1;
 }
 
+static int pids_construct_alfn_am(pids_t* st)
+{
+    // Use latest ALFN lower bits.
+    int lower_idx = st->alfn_frame_idx;
+    if (st->alfn_upper_idx == st->alfn_frame_idx)
+        lower_idx = (ALFN_AM_FRAMES + st->alfn_frame_idx - 1) % ALFN_AM_FRAMES;
+
+    const alfn_t* upper_frame = &st->alfn_frames[st->alfn_upper_idx];
+    const alfn_t* lower_frame = &st->alfn_frames[lower_idx];
+
+    if (upper_frame->received != 0xFF ||
+        lower_frame->received != 0xFF)
+        return -1;
+
+    const uint16_t upper = upper_frame->value;
+    uint16_t lower = lower_frame->value;
+
+    // If current frame was upper, lower wasn't updated. Assume lower was increased.
+    if (st->alfn_upper_idx == st->alfn_frame_idx)
+        lower++;
+
+    st->alfn_value = (int32_t)upper << 16 | (int32_t)lower;
+    st->alfn_known = 1;
+    return 0;
+}
+
 void pids_complete_am(pids_t* st)
 {
-    if (st->alfn[st->alfn_frame].received == 0xFF)
+    const int lower[ALFN_AM_FRAMES] = {
+        (int)(st->alfn_frames[0].value & 0x3),
+        (int)(st->alfn_frames[1].value & 0x3),
+        (int)(st->alfn_frames[2].value & 0x3),
+        (int)(st->alfn_frames[3].value & 0x3),
+    };
+    int finished = 1;
+    for (int i = 0; i < ALFN_AM_FRAMES; i++)
     {
-        if (st->alfn_frame == 3 && st->alfn_upper_idx == -1)
+        if ((st->alfn_frames[i].received & 0x1) == 0)
         {
-            const int lower[ALFN_AM_FRAMES] = {
-                (int)(st->alfn[0].value & 0x3),
-                (int)(st->alfn[1].value & 0x3),
-                (int)(st->alfn[2].value & 0x3),
-                (int)(st->alfn[3].value & 0x3),
-            };
-            int finished = 1;
-            for (int i = 0; i < ALFN_AM_FRAMES; i++)
-            {
-                if ((st->alfn[i].received & 0x1) == 0)
-                {
-                    finished = 0;
-                    break;
-                }
-            }
-            if (finished)
-                st->alfn_upper_idx = find_mod4(lower);
+            finished = 0;
+            break;
         }
-
-        if (st->alfn_upper_idx != -1)
-            pids_report_alfn_am(st);
+    }
+    if (finished)
+    {
+        const int new_idx = find_mod4(lower);
+        if (new_idx != -1)
+            st->alfn_upper_idx = new_idx;
     }
 
-    st->alfn_frame = (st->alfn_frame + 1) % 4;
+    if (st->alfn_upper_idx != -1)
+        pids_construct_alfn_am(st);
+
+    nrsc5_report_l1_frame(st->input->radio, st->alfn_value, st->alfn_known, st->alfn_time_locked);
+
+    st->alfn_frame_idx = (st->alfn_frame_idx + 1) % 4;
     // Clear for new frame
-    st->alfn[st->alfn_frame].value = 0;
-    st->alfn[st->alfn_frame].received = 0;
+    st->alfn_frames[st->alfn_frame_idx].value = 0;
+    st->alfn_frames[st->alfn_frame_idx].received = 0;
+
+    if (st->alfn_known)
+        st->alfn_value++;
 }
 
 void pids_frame_push(pids_t *st, const uint8_t *bits, const unsigned int bc)
@@ -1192,14 +1208,16 @@ void pids_init(pids_t *st, input_t *input)
 
     reset_alert(st);
 
-    st->alfn_frame = 0;
-    st->alfn_frame = 0;
-    st->alfn_upper_idx = -1;
     for (i = 0; i < ALFN_AM_FRAMES; i++)
     {
-        st->alfn[i].value = 0;
-        st->alfn[i].received = 0;
+        st->alfn_frames[i].value = 0;
+        st->alfn_frames[i].received = 0;
     }
+    st->alfn_upper_idx = -1;
+    st->alfn_frame_idx = 0;
+    st->alfn_time_locked = 0;
+    st->alfn_known = 0;
+    st->alfn_value = 0;
 
     st->input = input;
 }

--- a/src/pids.h
+++ b/src/pids.h
@@ -101,11 +101,13 @@ typedef struct
     int alert_displayed;
     int alert_timeout;
 
-    alfn_t alfn[ALFN_AM_FRAMES];
-
+    alfn_t alfn_frames[ALFN_AM_FRAMES];
     int alfn_upper_idx;
-    int alfn_frame;
+    int alfn_frame_idx;
     uint8_t alfn_time_locked;
+
+    int alfn_known;
+    uint32_t alfn_value;
 } pids_t;
 
 void pids_frame_push(pids_t *st, const uint8_t *bits, unsigned int bc);

--- a/src/pids.h
+++ b/src/pids.h
@@ -17,6 +17,9 @@
 #define MAX_ALERT_FRAMES 64
 #define MAX_ALERT_CNT_LEN 63
 #define MAX_ALERT_LOCATIONS 31
+#define ALFN_AM_FRAMES 4
+#define ALFN_AM_PAIRS_PER_FRAME 8
+#define ALFN_FM_PAIRS_PER_FRAME 16
 
 typedef struct
 {
@@ -93,7 +96,16 @@ typedef struct
     int alert_cnt_len;
     int alert_displayed;
     int alert_timeout;
+
+    uint8_t alfn_time_locked;
+    uint64_t alfn_frame;
+    int alfn_pairs[ALFN_AM_FRAMES];
+    int alfn_am_curr;
+    int alfn_has_lsb[ALFN_AM_FRAMES];
+    int alfn_upper_idx;
 } pids_t;
 
-void pids_frame_push(pids_t *st, const uint8_t *bits);
+void pids_frame_push(pids_t *st, const uint8_t *bits, unsigned int bc);
+void pids_complete_am(pids_t* st);
+void pids_complete_fm(pids_t* st);
 void pids_init(pids_t *st, struct input_t *input);

--- a/src/pids.h
+++ b/src/pids.h
@@ -18,8 +18,6 @@
 #define MAX_ALERT_CNT_LEN 63
 #define MAX_ALERT_LOCATIONS 31
 #define ALFN_AM_FRAMES 4
-#define ALFN_AM_PAIRS_PER_FRAME 8
-#define ALFN_FM_PAIRS_PER_FRAME 16
 
 typedef struct
 {
@@ -34,6 +32,12 @@ typedef struct
     int type;
     int mime_type;
 } dsd_t;
+
+typedef struct
+{
+    uint32_t value;
+    uint16_t received;
+} alfn_t;
 
 typedef enum
 {
@@ -97,15 +101,14 @@ typedef struct
     int alert_displayed;
     int alert_timeout;
 
-    uint8_t alfn_time_locked;
-    uint64_t alfn_frame;
-    int alfn_pairs[ALFN_AM_FRAMES];
-    int alfn_am_curr;
-    int alfn_has_lsb[ALFN_AM_FRAMES];
+    alfn_t alfn[ALFN_AM_FRAMES];
+
     int alfn_upper_idx;
+    int alfn_frame;
+    uint8_t alfn_time_locked;
 } pids_t;
 
 void pids_frame_push(pids_t *st, const uint8_t *bits, unsigned int bc);
-void pids_complete_am(pids_t* st);
 void pids_complete_fm(pids_t* st);
+void pids_complete_am(pids_t* st);
 void pids_init(pids_t *st, struct input_t *input);

--- a/src/private.h
+++ b/src/private.h
@@ -93,6 +93,6 @@ void nrsc5_report_importer_info(nrsc5_t *st, const char* manufacturer_id, const 
                                 int core_status, int manufacturer_status);
 void nrsc5_report_leap_second_offset(nrsc5_t *st, int pending_offset, int current_offset,
                                      unsigned int pending_alfn);
-void nrsc5_report_alfn(nrsc5_t* st, unsigned int alfn, int gps_locked);
+void nrsc5_report_l1_frame(nrsc5_t* st, unsigned int alfn, int alfn_known, int time_locked);
 void nrsc5_report_local_time(nrsc5_t *st, int utc_offset, int dst_regional, int dst_local,
                              int dst_schedule);

--- a/src/private.h
+++ b/src/private.h
@@ -93,5 +93,6 @@ void nrsc5_report_importer_info(nrsc5_t *st, const char* manufacturer_id, const 
                                 int core_status, int manufacturer_status);
 void nrsc5_report_leap_second_offset(nrsc5_t *st, int pending_offset, int current_offset,
                                      unsigned int pending_alfn);
+void nrsc5_report_alfn(nrsc5_t* st, unsigned int alfn, int gps_locked);
 void nrsc5_report_local_time(nrsc5_t *st, int utc_offset, int dst_regional, int dst_local,
                              int dst_schedule);

--- a/src/sync.c
+++ b/src/sync.c
@@ -684,7 +684,7 @@ void sync_process_am(sync_t *st)
             pids[pids_out++] = qam16(st->buffer[CENTER_AM + pids2_index][n]);
         }
 
-        decode_process_pids_am(&st->input->decode, pids);
+        decode_process_pids_am(&st->input->decode, pids, st->bc);
 
         float complex pl_mult[PARTITION_WIDTH_AM];
         float complex pu_mult[PARTITION_WIDTH_AM];

--- a/support/cli.py
+++ b/support/cli.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
 
 import argparse
-import datetime
 import logging
 import os
 import queue
@@ -404,7 +403,7 @@ class NRSC5CLI:
                           "yes" if evt.dst_regional else "no", "yes" if evt.dst_local else "no")
         elif evt_type == nrsc5.EventType.ALFN:
             alfn = evt.alfn + 1
-            logging.debug("ALFN %u, GPS locked? %s", alfn,"yes" if evt.gps_locked else "no")
+            logging.debug("ALFN %u, GPS locked? %s", alfn,"yes" if evt.time_locked else "no")
 
 
 if __name__ == "__main__":

--- a/support/cli.py
+++ b/support/cli.py
@@ -401,9 +401,8 @@ class NRSC5CLI:
                           evt.utc_offset,
                           evt.dst_schedule,
                           "yes" if evt.dst_regional else "no", "yes" if evt.dst_local else "no")
-        elif evt_type == nrsc5.EventType.ALFN:
-            alfn = evt.alfn + 1
-            logging.debug("ALFN %u, GPS locked? %s", alfn,"yes" if evt.time_locked else "no")
+        elif evt_type == nrsc5.EventType.L1_FRAME:
+            logging.debug("L1 Frame: ALFN=%u, ALFN known? %s, time locked to GPS? %s", evt.alfn, "yes" if evt.alfn_known else "no", "yes" if evt.time_locked else "no")
 
 
 if __name__ == "__main__":

--- a/support/cli.py
+++ b/support/cli.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python3
 
 import argparse
+import datetime
 import logging
 import os
 import queue
@@ -30,6 +31,7 @@ class NRSC5CLI:
         self.audio_packets = 0
         self.audio_bytes = 0
         self.audio_errors = 0
+        self.current_leap = None
         signal.signal(signal.SIGINT, self._signal_handler)
 
     def _signal_handler(self, sig, frame):
@@ -206,6 +208,9 @@ class NRSC5CLI:
             parts.append(f'PIDS power: {"high" if evt.hppi else "low"}')
         return ", ".join(parts)
 
+    def format_time(self, time):
+        return time.strftime("%Y-%m-%dT%H:%M:%SZ")
+
     def callback(self, evt_type, evt):
         if evt_type == nrsc5.EventType.LOST_DEVICE:
             logging.info("Lost device")
@@ -315,11 +320,11 @@ class NRSC5CLI:
                         file.write(evt.data)
                 except OSError as e:
                     logging.warning(f"Failed to write AAS file: {e}")
-            time_str = evt.expiry_utc.strftime("%Y-%m-%dT%H:%M:%SZ")
+            time_str = self.format_time(evt.expiry_utc)
             logging.info("LOT file: port=%04X lot=%s name=%s size=%s mime=%s expiry=%s",
                          evt.component.data.port, evt.lot, evt.name, len(evt.data), evt.mime.name, time_str)
         elif evt_type == nrsc5.EventType.LOT_HEADER:
-            time_str = evt.expiry_utc.strftime("%Y-%m-%dT%H:%M:%SZ")
+            time_str = self.format_time(evt.expiry_utc)
             logging.debug("LOT header: port=%04X lot=%s name=%s size=%s mime=%s expiry=%s",
                           evt.component.data.port, evt.lot, evt.name, evt.size, evt.mime.name, time_str)
         elif evt_type == nrsc5.EventType.LOT_FRAGMENT:
@@ -372,7 +377,7 @@ class NRSC5CLI:
                         file.write(evt.data)
                 except OSError as e:
                     logging.warning(f"Failed to write HERE image: {e}")
-            time_str = evt.time_utc.strftime("%Y-%m-%dT%H:%M:%SZ")
+            time_str = self.format_time(evt.time_utc)
             logging.info("HERE Image: type=%s, seq=%d, n1=%d, n2=%d, time=%s, lat1=%.5f, lon1=%.5f, lat2=%.5f, lon2=%.5f, name=%s, size=%d",
                          evt.image_type.name, evt.seq, evt.n1, evt.n2, time_str, evt.latitude1, evt.longitude1,
                          evt.latitude2, evt.longitude2, evt.name, len(evt.data))
@@ -390,6 +395,7 @@ class NRSC5CLI:
                           evt.manufacturer_version[0], evt.manufacturer_version[1], evt.manufacturer_version[2],
                           evt.manufacturer_version[3], evt.manufacturer_status)
         elif evt_type == nrsc5.EventType.LEAP_SECOND_OFFSET:
+            self.current_leap = evt.current_offset
             logging.debug("Leap second offset: pending=%d, current=%d, ALFN of pending adjustment=%d",
                           evt.pending_offset, evt.current_offset,
                           evt.pending_alfn)
@@ -398,6 +404,15 @@ class NRSC5CLI:
                           evt.utc_offset,
                           evt.dst_schedule,
                           "yes" if evt.dst_regional else "no", "yes" if evt.dst_local else "no")
+        elif evt_type == nrsc5.EventType.ALFN:
+            alfn = evt.alfn + 1
+            alfn_details = f'ALFN: {alfn}, GPS locked {"yes" if evt.gps_locked else "no"}'
+            if self.current_leap:
+                utc = (65536 * alfn / 44100) + 315964800 - self.current_leap
+                time = datetime.datetime.fromtimestamp(utc, tz=datetime.timezone.utc)
+                time_str = self.format_time(time)
+                alfn_details += f", time: {time_str}"
+            logging.debug(alfn_details)
 
 
 if __name__ == "__main__":

--- a/support/cli.py
+++ b/support/cli.py
@@ -31,7 +31,6 @@ class NRSC5CLI:
         self.audio_packets = 0
         self.audio_bytes = 0
         self.audio_errors = 0
-        self.current_leap = None
         signal.signal(signal.SIGINT, self._signal_handler)
 
     def _signal_handler(self, sig, frame):
@@ -395,7 +394,6 @@ class NRSC5CLI:
                           evt.manufacturer_version[0], evt.manufacturer_version[1], evt.manufacturer_version[2],
                           evt.manufacturer_version[3], evt.manufacturer_status)
         elif evt_type == nrsc5.EventType.LEAP_SECOND_OFFSET:
-            self.current_leap = evt.current_offset
             logging.debug("Leap second offset: pending=%d, current=%d, ALFN of pending adjustment=%d",
                           evt.pending_offset, evt.current_offset,
                           evt.pending_alfn)
@@ -406,13 +404,7 @@ class NRSC5CLI:
                           "yes" if evt.dst_regional else "no", "yes" if evt.dst_local else "no")
         elif evt_type == nrsc5.EventType.ALFN:
             alfn = evt.alfn + 1
-            alfn_details = f'ALFN: {alfn}, GPS locked {"yes" if evt.gps_locked else "no"}'
-            if self.current_leap:
-                utc = (65536 * alfn / 44100) + 315964800 - self.current_leap
-                time = datetime.datetime.fromtimestamp(utc, tz=datetime.timezone.utc)
-                time_str = self.format_time(time)
-                alfn_details += f", time: {time_str}"
-            logging.debug(alfn_details)
+            logging.debug("ALFN %u, GPS locked? %s", alfn,"yes" if evt.gps_locked else "no")
 
 
 if __name__ == "__main__":

--- a/support/nrsc5.py
+++ b/support/nrsc5.py
@@ -45,7 +45,7 @@ class EventType(enum.Enum):
     IMPORTER_INFO = 28
     LEAP_SECOND_OFFSET = 29
     LOCAL_TIME = 30
-    ALFN = 31
+    L1_FRAME = 31
 
 
 AUDIO_FRAME_SAMPLES = 2048
@@ -234,7 +234,7 @@ ExciterInfo = collections.namedtuple("ExciterInfo", ["manufacturer_id", "core_ve
 ImporterInfo = collections.namedtuple("ImporterInfo", ["manufacturer_id", "core_version", "core_status", "manufacturer_version", "manufacturer_status"])
 LeapSecondOffset = collections.namedtuple("LeapOffset", ["pending_offset", "current_offset", "pending_alfn"])
 LocalTime = collections.namedtuple("LocalTime", ["utc_offset", "dst_regional", "dst_local", "dst_schedule"])
-ALFN = collections.namedtuple("ALFN", ["alfn", "time_locked"])
+L1Frame = collections.namedtuple("L1Frame", ["alfn", "alfn_known", "time_locked"])
 
 class _IQ(ctypes.Structure):
     _fields_ = [
@@ -628,9 +628,10 @@ class _LocalTime(ctypes.Structure):
         ("dst_schedule", ctypes.c_int)
     ]
 
-class _ALFN(ctypes.Structure):
+class _L1Frame(ctypes.Structure):
     _fields_ = [
         ("alfn", ctypes.c_uint),
+        ("alfn_known", ctypes.c_int),
         ("time_locked", ctypes.c_int),
     ]
 
@@ -664,7 +665,7 @@ class _EventUnion(ctypes.Union):
         ("importer_info", _ImporterInfo),
         ("leap_second_offset", _LeapSecondOffset),
         ("local_time", _LocalTime),
-        ("alfn", _ALFN),
+        ("l1_frame", _L1Frame),
     ]
 
 
@@ -934,9 +935,9 @@ class NRSC5:
         elif evt_type == EventType.LOCAL_TIME:
             local_time = c_evt.u.local_time
             evt = LocalTime(local_time.utc_offset, bool(local_time.dst_regional), bool(local_time.dst_local), local_time.dst_schedule)
-        elif evt_type == EventType.ALFN:
-            alfn = c_evt.u.alfn
-            evt = ALFN(alfn.alfn, bool(alfn.time_locked))
+        elif evt_type == EventType.L1_FRAME:
+            l1_frame = c_evt.u.l1_frame
+            evt = L1Frame(l1_frame.alfn, bool(l1_frame.alfn_known), bool(l1_frame.time_locked))
 
         self.callback(evt_type, evt, *self.callback_args)
 

--- a/support/nrsc5.py
+++ b/support/nrsc5.py
@@ -45,6 +45,7 @@ class EventType(enum.Enum):
     IMPORTER_INFO = 28
     LEAP_SECOND_OFFSET = 29
     LOCAL_TIME = 30
+    ALFN = 31
 
 
 AUDIO_FRAME_SAMPLES = 2048
@@ -233,6 +234,7 @@ ExciterInfo = collections.namedtuple("ExciterInfo", ["manufacturer_id", "core_ve
 ImporterInfo = collections.namedtuple("ImporterInfo", ["manufacturer_id", "core_version", "core_status", "manufacturer_version", "manufacturer_status"])
 LeapSecondOffset = collections.namedtuple("LeapOffset", ["pending_offset", "current_offset", "pending_alfn"])
 LocalTime = collections.namedtuple("LocalTime", ["utc_offset", "dst_regional", "dst_local", "dst_schedule"])
+ALFN = collections.namedtuple("ALFN", ["alfn", "gps_locked"])
 
 class _IQ(ctypes.Structure):
     _fields_ = [
@@ -626,6 +628,12 @@ class _LocalTime(ctypes.Structure):
         ("dst_schedule", ctypes.c_int)
     ]
 
+class _ALFN(ctypes.Structure):
+    _fields_ = [
+        ("alfn", ctypes.c_uint),
+        ("gps_locked", ctypes.c_int),
+    ]
+
 class _EventUnion(ctypes.Union):
     _fields_ = [
         ("iq", _IQ),
@@ -655,7 +663,8 @@ class _EventUnion(ctypes.Union):
         ("exciter_info", _ExciterInfo),
         ("importer_info", _ImporterInfo),
         ("leap_second_offset", _LeapSecondOffset),
-        ("local_time", _LocalTime)
+        ("local_time", _LocalTime),
+        ("alfn", _ALFN)
     ]
 
 
@@ -925,6 +934,9 @@ class NRSC5:
         elif evt_type == EventType.LOCAL_TIME:
             local_time = c_evt.u.local_time
             evt = LocalTime(local_time.utc_offset, bool(local_time.dst_regional), bool(local_time.dst_local), local_time.dst_schedule)
+        elif evt_type == EventType.ALFN:
+            alfn = c_evt.u.alfn
+            evt = ALFN(alfn.alfn, alfn.gps_locked)
 
         self.callback(evt_type, evt, *self.callback_args)
 

--- a/support/nrsc5.py
+++ b/support/nrsc5.py
@@ -936,7 +936,7 @@ class NRSC5:
             evt = LocalTime(local_time.utc_offset, bool(local_time.dst_regional), bool(local_time.dst_local), local_time.dst_schedule)
         elif evt_type == EventType.ALFN:
             alfn = c_evt.u.alfn
-            evt = ALFN(alfn.alfn, alfn.gps_locked)
+            evt = ALFN(alfn.alfn, bool(alfn.gps_locked))
 
         self.callback(evt_type, evt, *self.callback_args)
 

--- a/support/nrsc5.py
+++ b/support/nrsc5.py
@@ -234,7 +234,7 @@ ExciterInfo = collections.namedtuple("ExciterInfo", ["manufacturer_id", "core_ve
 ImporterInfo = collections.namedtuple("ImporterInfo", ["manufacturer_id", "core_version", "core_status", "manufacturer_version", "manufacturer_status"])
 LeapSecondOffset = collections.namedtuple("LeapOffset", ["pending_offset", "current_offset", "pending_alfn"])
 LocalTime = collections.namedtuple("LocalTime", ["utc_offset", "dst_regional", "dst_local", "dst_schedule"])
-ALFN = collections.namedtuple("ALFN", ["alfn", "gps_locked"])
+ALFN = collections.namedtuple("ALFN", ["alfn", "time_locked"])
 
 class _IQ(ctypes.Structure):
     _fields_ = [
@@ -631,7 +631,7 @@ class _LocalTime(ctypes.Structure):
 class _ALFN(ctypes.Structure):
     _fields_ = [
         ("alfn", ctypes.c_uint),
-        ("gps_locked", ctypes.c_int),
+        ("time_locked", ctypes.c_int),
     ]
 
 class _EventUnion(ctypes.Union):
@@ -664,7 +664,7 @@ class _EventUnion(ctypes.Union):
         ("importer_info", _ImporterInfo),
         ("leap_second_offset", _LeapSecondOffset),
         ("local_time", _LocalTime),
-        ("alfn", _ALFN)
+        ("alfn", _ALFN),
     ]
 
 
@@ -936,7 +936,7 @@ class NRSC5:
             evt = LocalTime(local_time.utc_offset, bool(local_time.dst_regional), bool(local_time.dst_local), local_time.dst_schedule)
         elif evt_type == EventType.ALFN:
             alfn = c_evt.u.alfn
-            evt = ALFN(alfn.alfn, bool(alfn.gps_locked))
+            evt = ALFN(alfn.alfn, bool(alfn.time_locked))
 
         self.callback(evt_type, evt, *self.callback_args)
 


### PR DESCRIPTION
ALFN (Absolute L1 Frame Number) is a number used to reference transmissions to absolute time. This field is required after `leap_seconds_offset` to calculate the current UTC timestamp from the station (#453 ). 

ALFN is sent through PIDS logical channel and different for AM and FM. AM was a pain in the butt. I was questioning my sanity. 

This PR only decodes such number and provides the number through the API. The number is then printed out using debug logging.

Calculation to resolve transmitted "time" from alfn is like so:
```const time_t utc = (65536 * (time_t)alfn / 44100) + 315964800 - (time_t)st->current_leap;``` This information is not printed due to tons of messed up stations.

Some reasons why to incorporate this silly number other than the terrible GPS timing:
- Relative time to determine what L1 frame you are at
- Allows someone else to investigate this time nonsense. 
- See what's being outputted like from gr-nrsc5 or a local station. 