### PR TITLE
Default to cs16 input when file extension is .cs16

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -53,6 +53,7 @@ typedef struct buffer_t {
 } audio_buffer_t;
 
 enum iq_format {
+    IQ_FORMAT_NONE,
     IQ_FORMAT_CU8,
     IQ_FORMAT_CS16
 };
@@ -815,7 +816,7 @@ static int parse_args(state_t *st, int argc, char *argv[])
     st->bias_tee = 0;
     st->direct_sampling = -1;
     st->ppm_error = INT_MIN;
-    st->iq_input_format = IQ_FORMAT_CU8;
+    st->iq_input_format = IQ_FORMAT_NONE;
     log_set_level(LOG_INFO);
 
     while ((opt = getopt_long(argc, argv, "r:w:o:t:d:p:g:ql:vH:TD:", long_opts, NULL)) != -1)
@@ -920,6 +921,17 @@ static int parse_args(state_t *st, int argc, char *argv[])
         // compatibility with previous versions
         if (st->freq < 10000.0f)
             st->freq *= 1e6f;
+    }
+
+    if (st->input_name && (st->iq_input_format == IQ_FORMAT_NONE))
+    {
+        const char *suffix = ".cs16";
+        size_t suffix_len = strlen(suffix);
+        size_t len = strlen(st->input_name);
+        if ((len >= suffix_len) && (strcmp(st->input_name + len - suffix_len, suffix) == 0))
+            st->iq_input_format = IQ_FORMAT_CS16;
+        else
+            st->iq_input_format = IQ_FORMAT_CU8;
     }
 
     st->program = strtoul(argv[optind++], &endptr, 0);

--- a/support/cli.py
+++ b/support/cli.py
@@ -50,7 +50,7 @@ class NRSC5CLI:
         parser.add_argument("-p", metavar="ppm-error", type=int)
         parser.add_argument("-g", metavar="gain", type=float)
         input_group.add_argument("-r", metavar="iq-input")
-        parser.add_argument("--iq-input-format", choices=["cu8", "cs16"], default="cu8")
+        parser.add_argument("--iq-input-format", choices=["cu8", "cs16"])
         parser.add_argument("-w", metavar="iq-output")
         parser.add_argument("-o", metavar="audio-output")
         parser.add_argument("-t", choices=["wav", "raw"], default="wav")
@@ -64,6 +64,12 @@ class NRSC5CLI:
 
         if self.args.frequency and self.args.frequency < 10000:
             self.args.frequency *= 1e6
+
+        if self.args.r and not self.args.iq_input_format:
+            if self.args.r.endswith(".cs16"):
+                self.args.iq_input_format = "cs16"
+            else:
+                self.args.iq_input_format = "cu8"
 
     def run(self):
         logging.basicConfig(level=self.args.l * 10,


### PR DESCRIPTION
Addresses https://github.com/theori-io/nrsc5/issues/511#issuecomment-4719594337.

It's common for tools to detect input file type based on the file extension. It would be convenient for nrsc5 to do this, eliminating the need to specify `--iq-input-format cs16` when reading I/Q files in complex signed 16-bit format.

If the `--iq-input-format` argument is specified, it is respected. If not, and the file extension is `.cs16`, then cs16 input format is chosen. Otherwise the default cu8 input format is chosen.