### PR TITLE
Document the MER event

### DIFF
--- a/include/nrsc5.h
+++ b/include/nrsc5.h
@@ -423,8 +423,8 @@ struct nrsc5_event_t
             float cber;
         } ber;
         struct {
-            float lower;
-            float upper;
+            float lower;  /**< Modulation error ratio of the lower sideband in dB. Note that the NRSC-5 standard defines FM signals to be spectrally inverted, so the lower sideband is the one that is higher in frequency. AM signals are not inverted. */
+            float upper;  /**< Modulation error ratio of the upper sideband in dB. Note that the NRSC-5 standard defines FM signals to be spectrally inverted, so the upper sideband is the one that is lower in frequency. AM signals are not inverted. */
         } mer;
         struct {
             unsigned int program;


### PR DESCRIPTION
Addresses #503.

The definition of "upper" and "lower" sidebands for FM signals is a frequent source of confusion (see for instance #130, #503, and https://github.com/markjfine/nrsc5-dui/issues/60), so here I have added documentation to the `mer` struct to explain the subtlety.