### PR TITLE
`nrsc5_reset` function

### DIFF
--- a/include/nrsc5.h
+++ b/include/nrsc5.h
@@ -884,4 +884,13 @@ NRSC5_API int nrsc5_pipe_samples_cs16(nrsc5_t *st, const int16_t *samples, unsig
  */
 NRSC5_API int nrsc5_pipe_samples_cf32(nrsc5_t *st, const float *samples, unsigned int length);
 
+/**
+ * Resets the current session.
+ *
+ * @param[in] st  pointer to an `nrsc5_t` session object
+ * @return 0 on success, nonzero on error
+ *
+ */
+NRSC5_API int nrsc5_reset(nrsc5_t *st);
+
 #endif /* NRSC5_H_ */

--- a/include/nrsc5.h
+++ b/include/nrsc5.h
@@ -886,6 +886,7 @@ NRSC5_API int nrsc5_pipe_samples_cf32(nrsc5_t *st, const float *samples, unsigne
 
 /**
  * Resets the current session.
+ * Gain is reset if auto-gain is enabled
  *
  * @param[in] st  pointer to an `nrsc5_t` session object
  * @return 0 on success, nonzero on error

--- a/src/libnrsc5.map
+++ b/src/libnrsc5.map
@@ -24,6 +24,7 @@ LIBNRSC5_1.0 {
         nrsc5_pipe_samples_cu8;
         nrsc5_pipe_samples_cs16;
         nrsc5_pipe_samples_cf32;
+        nrsc5_reset;
 
     local:
         *;

--- a/src/libnrsc5.sym
+++ b/src/libnrsc5.sym
@@ -22,3 +22,4 @@ _nrsc5_set_callback
 _nrsc5_pipe_samples_cu8
 _nrsc5_pipe_samples_cs16
 _nrsc5_pipe_samples_cf32
+_nrsc5_reset

--- a/src/nrsc5.c
+++ b/src/nrsc5.c
@@ -543,12 +543,20 @@ int nrsc5_set_frequency(nrsc5_t *st, float freq)
     if (st->rtltcp && rtltcp_set_center_freq(st->rtltcp, freq) != 0)
         return 1;
 
-    if (st->auto_gain)
-        st->gain = -1;
-    input_reset(&st->input);
-    output_reset(&st->output);
+    nrsc5_reset(st);
 
     st->freq = freq;
+    return 0;
+}
+
+NRSC5_API int nrsc5_reset(nrsc5_t *st) {
+    if (!st->stopped)
+        return 1;
+    if (st->auto_gain)
+        st->gain = -1;
+
+    input_reset(&st->input);
+    output_reset(&st->output);
     return 0;
 }
 

--- a/support/nrsc5.py
+++ b/support/nrsc5.py
@@ -1071,3 +1071,9 @@ class NRSC5:
         result = NRSC5.libnrsc5.nrsc5_pipe_samples_cf32(self.radio, samples, len(samples) // 4)
         if result != 0:
             raise NRSC5Error("Failed to pipe samples.")
+
+    def reset(self):
+        self._check_session()
+        result = NRSC5.libnrsc5.nrsc5_reset(self.radio)
+        if result != 0:
+            raise NRSC5Error("Failed to set frequency.")

--- a/support/nrsc5.py
+++ b/support/nrsc5.py
@@ -1076,4 +1076,4 @@ class NRSC5:
         self._check_session()
         result = NRSC5.libnrsc5.nrsc5_reset(self.radio)
         if result != 0:
-            raise NRSC5Error("Failed to set frequency.")
+            raise NRSC5Error("Failed to reset session.")


### PR DESCRIPTION
#446 

Adds a `nrsc5_reset` function that resets the current nrsc5 session. Pretty simple and self explanatory I think. I also made ``nrsc5_reset`` reset the current auto gain. That might be helpful depending on the use case. 