### PR TITLE
Commercial tags to API.

### DIFF
--- a/include/nrsc5.h
+++ b/include/nrsc5.h
@@ -455,12 +455,12 @@ struct nrsc5_event_t
             nrsc5_id3_comment_t *comments;
             struct
             {
-                char* price;
-                char valid_until[8];
-                char* contact_url;
-                char* seller;
-                char* description;
-                uint8_t received_as;
+                char* price;         /** price of the product */
+                char valid_until[8]; /** describes for how long the price is valid in YYYYMMDD format */
+                char* contact_url;   /** URL for contacting the seller */
+                char* seller;        /** Name of the seller */
+                char* description;   /** Short description of the product */
+                uint8_t received_as; /** How audio was delivered when bought */
             } commercial;
         } id3;
         struct {

--- a/include/nrsc5.h
+++ b/include/nrsc5.h
@@ -453,6 +453,15 @@ struct nrsc5_event_t
                 int lot;
             } xhdr;
             nrsc5_id3_comment_t *comments;
+            struct
+            {
+                char* price;
+                char valid_until[8];
+                char* contact_url;
+                char* seller;
+                char* description;
+                uint8_t received_as;
+            } commercial;
         } id3;
         struct {
             uint16_t port;  /**< DEPRECATED: Use `component->data.port` instead */

--- a/include/nrsc5.h
+++ b/include/nrsc5.h
@@ -455,12 +455,12 @@ struct nrsc5_event_t
             nrsc5_id3_comment_t *comments;
             struct
             {
-                char* price;            /** price of the product */
-                char* contact_url;      /** URL for contacting the seller */
-                char* seller;           /** Name of the seller */
-                char* description;      /** Short description of the product */
+                char *price;            /** price of the product */
+                char *contact_url;      /** URL for contacting the seller */
+                char *seller;           /** Name of the seller */
+                char *description;      /** Short description of the product */
                 uint8_t received_as;    /** How audio is delivered when bought */
-                struct tm* valid_until; /** Date when the price expires */
+                struct tm *valid_until; /** Date when the price expires. Note that only the `tm_year`, `tm_mon`, and `tm_mday` fields are set. */
             } commercial;
         } id3;
         struct {

--- a/include/nrsc5.h
+++ b/include/nrsc5.h
@@ -455,12 +455,12 @@ struct nrsc5_event_t
             nrsc5_id3_comment_t *comments;
             struct
             {
-                char* price;         /** price of the product */
-                char valid_until[8]; /** describes for how long the price is valid in YYYYMMDD format */
-                char* contact_url;   /** URL for contacting the seller */
-                char* seller;        /** Name of the seller */
-                char* description;   /** Short description of the product */
-                uint8_t received_as; /** How audio was delivered when bought */
+                char* price;            /** price of the product */
+                char* contact_url;      /** URL for contacting the seller */
+                char* seller;           /** Name of the seller */
+                char* description;      /** Short description of the product */
+                uint8_t received_as;    /** How audio is delivered when bought */
+                struct tm* valid_until; /** Date when the price expires */
             } commercial;
         } id3;
         struct {

--- a/src/main.c
+++ b/src/main.c
@@ -414,7 +414,7 @@ static void callback(const nrsc5_event_t *evt, void *opaque)
             if (evt->id3.xhdr.param >= 0)
                 log_info("XHDR: %d %08X %d", evt->id3.xhdr.param, evt->id3.xhdr.mime, evt->id3.xhdr.lot);
             strftime(time_str, sizeof(time_str), "%Y-%m-%d", evt->id3.commercial.valid_until);
-            if (evt->id3.commercial.price != NULL)
+            if (evt->id3.commercial.price)
                 log_info("Commercial: price=%s until=%s url=\"%s\" seller=\"%s\" desc=\"%s\" received_as=%d",
                     evt->id3.commercial.price, time_str, evt->id3.commercial.contact_url, evt->id3.commercial.seller,
                     evt->id3.commercial.description, evt->id3.commercial.received_as);

--- a/src/main.c
+++ b/src/main.c
@@ -413,10 +413,11 @@ static void callback(const nrsc5_event_t *evt, void *opaque)
                 log_info("Unique file identifier: %s %s", evt->id3.ufid.owner, evt->id3.ufid.id);
             if (evt->id3.xhdr.param >= 0)
                 log_info("XHDR: %d %08X %d", evt->id3.xhdr.param, evt->id3.xhdr.mime, evt->id3.xhdr.lot);
+            strftime(time_str, sizeof(time_str), "%Y-%m-%d", evt->id3.commercial.valid_until);
             if (evt->id3.commercial.price != NULL)
-                log_info("Commercial: price=%s until=%.4s-%.2s-%.2s url=\"%s\" seller=\"%s\" desc=\"%s\" received_as=%d",
-                    evt->id3.commercial.price, evt->id3.commercial.valid_until, &evt->id3.commercial.valid_until[4], &evt->id3.commercial.valid_until[6],
-                    evt->id3.commercial.contact_url, evt->id3.commercial.seller, evt->id3.commercial.description, evt->id3.commercial.received_as);
+                log_info("Commercial: price=%s until=%s url=\"%s\" seller=\"%s\" desc=\"%s\" received_as=%d",
+                    evt->id3.commercial.price, time_str, evt->id3.commercial.contact_url, evt->id3.commercial.seller,
+                    evt->id3.commercial.description, evt->id3.commercial.received_as);
         }
         break;
     case NRSC5_EVENT_SIG:

--- a/src/main.c
+++ b/src/main.c
@@ -413,6 +413,10 @@ static void callback(const nrsc5_event_t *evt, void *opaque)
                 log_info("Unique file identifier: %s %s", evt->id3.ufid.owner, evt->id3.ufid.id);
             if (evt->id3.xhdr.param >= 0)
                 log_info("XHDR: %d %08X %d", evt->id3.xhdr.param, evt->id3.xhdr.mime, evt->id3.xhdr.lot);
+            if (evt->id3.commercial.price != NULL)
+                log_info("Commercial: price=%s until=%.4s-%.2s-%.2s url=\"%s\" seller=\"%s\" desc=\"%s\" received_as=%d",
+                    evt->id3.commercial.price, evt->id3.commercial.valid_until, &evt->id3.commercial.valid_until[4], &evt->id3.commercial.valid_until[6],
+                    evt->id3.commercial.contact_url, evt->id3.commercial.seller, evt->id3.commercial.description, evt->id3.commercial.received_as);
         }
         break;
     case NRSC5_EVENT_SIG:

--- a/src/output.c
+++ b/src/output.c
@@ -274,7 +274,7 @@ static char *id3_text(uint8_t *buf, unsigned int frame_len)
         return id3_encode_utf8(0, NULL, 0);
 }
 
-static uint8_t* strlen_enc(const int enc, uint8_t *buf, const unsigned int len)
+static uint8_t* memchr_enc(const int enc, uint8_t *buf, const unsigned int len)
 {
     if (enc == 0)
     {
@@ -376,34 +376,49 @@ static void output_id3(output_t *st, unsigned int program, uint8_t *buf, unsigne
         }
         else if (memcmp(tag, "COMR", 4) == 0)
         {
-            uint8_t enc = data[0];
-            uint8_t *delim[4];
-            uint8_t *pos = data + 1;
+            uint8_t *pos = data;
             uint8_t *end = data + frame_len;
+            if (pos + 1 > end)
+            {
+                log_warn("bad COMR tag (frame_len %d)", frame_len);
+                break;
+            }
+            uint8_t enc = data[0];
+            pos += 1;
 
+            uint8_t *delim[4];
+            uint8_t *delim_end[4];
+            int year, mon, mday;
             int i;
 
             for (i = 0; i < 4; i++)
             {
-                int delim_enc = i > 1 ? enc : 0;
-                if ((delim[i] = strlen_enc(delim_enc, pos, end - pos)) == NULL)
+                int delim_enc = (i >= 2) ? enc : 0;
+                int delim_len = (delim_enc == 1) ? 2 : 1;
+                delim[i] = memchr_enc(delim_enc, pos, end - pos);
+                if (delim[i] == NULL)
+                {
+                    log_warn("bad COMR tag (frame_len %d)", frame_len);
                     break;
+                }
+                delim_end[i] = delim[i] + delim_len;
+                pos = delim_end[i];
 
-                pos = delim[i] + (delim_enc == 1 ? 2 : 1);
                 if (i == 0)
                 {
-                    until.tm_year = parse_digits((char *) delim[0] + 1, 4) - 1900;
-                    until.tm_mon = parse_digits((char *) delim[0] + 5, 2) - 1;
-                    until.tm_mday = parse_digits((char *) delim[0] + 7, 2);
-
-                    if (until.tm_mday < 0 || until.tm_mon < 0 || until.tm_year < 0)
-                    {
-                        log_warn("Fail to parse valid_until on COMR tag.");
-                        break;
-                    }
                     if (pos + 8 > end)
                     {
-                        log_warn("bad COMM tag (frame_len %d)", frame_len);
+                        log_warn("bad COMR tag (frame_len %d)", frame_len);
+                        break;
+                    }
+
+                    year = parse_digits((char *) delim[0] + 1, 4) - 1900;
+                    mon = parse_digits((char *) delim[0] + 5, 2) - 1;
+                    mday = parse_digits((char *) delim[0] + 7, 2);
+
+                    if (year < 0 || mon < 0 || mday < 0)
+                    {
+                        log_warn("Failed to parse valid_until on COMR tag.");
                         break;
                     }
 
@@ -413,7 +428,7 @@ static void output_id3(output_t *st, unsigned int program, uint8_t *buf, unsigne
                 {
                     if (pos + 1 > end)
                     {
-                        log_warn("bad COMM tag (frame_len %d)", frame_len);
+                        log_warn("bad COMR tag (frame_len %d)", frame_len);
                         break;
                     }
 
@@ -423,12 +438,14 @@ static void output_id3(output_t *st, unsigned int program, uint8_t *buf, unsigne
 
             if (i == 4)
             {
-                uint8_t* end_text = enc == 1 ? delim[2] + 2 : delim[2] + 1;
-                price = strdup((char *) data + 1);
-                url = strdup((char *) delim[0] + 9);
-                received_as = *(delim[1] + 1);
-                seller = id3_encode_utf8(enc, delim[1] + 2, delim[2] - (delim[1] + 2));
-                desc = id3_encode_utf8(enc, end_text, end - end_text);
+                price = (char *) data + 1;
+                until.tm_year = year;
+                until.tm_mon = mon;
+                until.tm_mday = mday;
+                url = (char *) delim_end[0] + 8;
+                received_as = *(delim_end[1]);
+                seller = id3_encode_utf8(enc, delim_end[1] + 1, delim[2] - (delim_end[1] + 1));
+                desc = id3_encode_utf8(enc, delim_end[2], delim[3] - delim_end[2]);
             }
         }
         else if (memcmp(tag, "COMM", 4) == 0)
@@ -440,13 +457,13 @@ static void output_id3(output_t *st, unsigned int program, uint8_t *buf, unsigne
             else
             {
                 uint8_t enc = data[0];
-                uint8_t *delim = strlen_enc(enc, data + 4, frame_len - 4);
+                uint8_t *delim = memchr_enc(enc, data + 4, frame_len - 4);
                 uint8_t *end = data + frame_len;
 
                 if (delim)
                 {
                     nrsc5_id3_comment_t* prev = comm;
-                    uint8_t* end_text = enc == 1 ? delim + 2 : delim + 1;
+                    uint8_t* end_text = delim + (enc == 1 ? 2 : 1);
 
                     comm = calloc(1, sizeof(nrsc5_id3_comment_t));
                     comm->lang = strndup((char*) data + 1, 3);
@@ -522,8 +539,6 @@ static void output_id3(output_t *st, unsigned int program, uint8_t *buf, unsigne
     free(genre);
     free(ufid_owner);
     free(ufid_id);
-    free(price);
-    free(url);
     free(seller);
     free(desc);
 

--- a/src/output.c
+++ b/src/output.c
@@ -274,12 +274,37 @@ static char *id3_text(uint8_t *buf, unsigned int frame_len)
         return id3_encode_utf8(0, NULL, 0);
 }
 
+static uint8_t* strlen_enc(const int enc, uint8_t *buf, const unsigned int len)
+{
+    if (enc == 0)
+    {
+        return memchr(buf, 0, len);
+    }
+    else if (enc == 1)
+    {
+        for (unsigned int i = 0; i < len - 1; i += 2)
+        {
+            if (buf[i] == 0 && buf[i + 1] == 0)
+            {
+                return buf + i;
+            }
+        }
+        return NULL;
+    }
+    else
+        log_warn("Invalid encoding: %d", enc);
+    return NULL;
+}
+
 static void output_id3(output_t *st, unsigned int program, uint8_t *buf, unsigned int len)
 {
     char *title = NULL, *artist = NULL, *album = NULL, *genre = NULL, *ufid_owner = NULL, *ufid_id = NULL;
     uint32_t xhdr_mime = 0;
     int xhdr_param = -1, xhdr_lot = -1;
     nrsc5_id3_comment_t *comm = NULL;
+    char *price = NULL, *url = NULL, *seller = NULL, *desc = NULL;
+    char until[8] = { 0 };
+    uint8_t received_as = 0;
 
     unsigned int off = 0, id3_len;
     nrsc5_event_t evt;
@@ -336,22 +361,20 @@ static void output_id3(output_t *st, unsigned int program, uint8_t *buf, unsigne
         }
         else if (memcmp(tag, "COMR", 4) == 0)
         {
-            int i;
+            uint8_t enc = data[0];
             uint8_t *delim[4];
             uint8_t *pos = data + 1;
             uint8_t *end = data + frame_len;
 
-            char *price, until[11], *url, *seller, *desc;
-            int received_as;
+            int i;
 
             for (i = 0; i < 4; i++)
             {
-                if (pos >= end)
-                    break;
-                if ((delim[i] = memchr(pos, 0, end - pos)) == NULL)
+                int delim_enc = i > 1 ? enc : 0;
+                if ((delim[i] = strlen_enc(delim_enc, pos, end - pos)) == NULL)
                     break;
 
-                pos = delim[i] + 1;
+                pos = delim[i] + (delim_enc == 1 ? 2 : 1);
                 if (i == 0)
                     pos += 8;
                 else if (i == 1)
@@ -360,14 +383,14 @@ static void output_id3(output_t *st, unsigned int program, uint8_t *buf, unsigne
 
             if (i == 4)
             {
-                price = (char *) data + 1;
-                sprintf(until, "%.4s-%.2s-%.2s", delim[0] + 1, delim[0] + 5, delim[0] + 7);
-                url = (char *) delim[0] + 9;
+                uint8_t* end_text = enc == 1 ? delim[2] + 2 : delim[2] + 1;
+
+                price = strdup((char *) data + 1);
+                memcpy(until, (char *) delim[0] + 1, sizeof(until));
+                url = strdup((char *) delim[0] + 9);
                 received_as = *(delim[1] + 1);
-                seller = (char *) delim[1] + 2;
-                desc = (char *) delim[2] + 1;
-                log_debug("Commercial: price=%s until=%s url=\"%s\" seller=\"%s\" desc=\"%s\" received_as=%d",
-                          price, until, url, seller, desc, received_as);
+                seller = id3_encode_utf8(enc, delim[1] + 2, delim[2] - (delim[1] + 2));
+                desc = id3_encode_utf8(enc, end_text, end - end_text);
             }
         }
         else if (memcmp(tag, "COMM", 4) == 0)
@@ -379,39 +402,18 @@ static void output_id3(output_t *st, unsigned int program, uint8_t *buf, unsigne
             else
             {
                 uint8_t enc = data[0];
-                uint8_t *delim = NULL;
-                uint8_t *text = NULL;
+                uint8_t *delim = strlen_enc(enc, data + 4, frame_len - 4);
                 uint8_t *end = data + frame_len;
-
-                if (enc == 0)
-                {
-                    delim = memchr(data + 4, 0, frame_len - 4);
-                    if (delim)
-                        text = delim + 1;
-                }
-                else if (enc == 1)
-                {
-                    unsigned int i;
-            
-                    for (i = 0; i < len - 1; i += 2)
-                    {
-                        if (buf[i] == 0 && buf[i + 1] == 0)
-                        {
-                            delim = buf + i;
-                            text = buf + i + 2;
-                            break;
-                        }
-                    }
-                }      
 
                 if (delim)
                 {
                     nrsc5_id3_comment_t* prev = comm;
+                    uint8_t* end_text = enc == 1 ? delim + 2 : delim + 1;
 
                     comm = calloc(1, sizeof(nrsc5_id3_comment_t));
                     comm->lang = strndup((char*) data + 1, 3);
                     comm->short_content_desc = id3_encode_utf8(enc, data + 4, delim - (data + 4));
-                    comm->full_text = id3_encode_utf8(enc, text, end - text);
+                    comm->full_text = id3_encode_utf8(enc, end_text, end - end_text);
 
                     if (prev == NULL)
                         evt.id3.comments = comm;
@@ -467,6 +469,12 @@ static void output_id3(output_t *st, unsigned int program, uint8_t *buf, unsigne
     evt.id3.xhdr.mime = xhdr_mime;
     evt.id3.xhdr.param = xhdr_param;
     evt.id3.xhdr.lot = xhdr_lot;
+    evt.id3.commercial.price = price;
+    evt.id3.commercial.contact_url = url;
+    evt.id3.commercial.seller = seller;
+    evt.id3.commercial.description = desc;
+    evt.id3.commercial.received_as = received_as;
+    memcpy(evt.id3.commercial.valid_until, until, sizeof(until));
 
     nrsc5_report(st->radio, &evt);
 
@@ -476,6 +484,10 @@ static void output_id3(output_t *st, unsigned int program, uint8_t *buf, unsigne
     free(genre);
     free(ufid_owner);
     free(ufid_id);
+    free(price);
+    free(url);
+    free(seller);
+    free(desc);
 
     for (comm = evt.id3.comments; comm != NULL; )
     {

--- a/src/output.c
+++ b/src/output.c
@@ -296,6 +296,21 @@ static uint8_t* strlen_enc(const int enc, uint8_t *buf, const unsigned int len)
     return NULL;
 }
 
+static int parse_digits(const char *p, size_t n)
+{
+    int value = 0;
+
+    for (size_t i = 0; i < n; i++)
+    {
+        if (p[i] < '0' || p[i] > '9')
+            return -1;
+
+        value = value * 10 + (p[i] - '0');
+    }
+
+    return value;
+}
+
 static void output_id3(output_t *st, unsigned int program, uint8_t *buf, unsigned int len)
 {
     char *title = NULL, *artist = NULL, *album = NULL, *genre = NULL, *ufid_owner = NULL, *ufid_id = NULL;
@@ -303,7 +318,7 @@ static void output_id3(output_t *st, unsigned int program, uint8_t *buf, unsigne
     int xhdr_param = -1, xhdr_lot = -1;
     nrsc5_id3_comment_t *comm = NULL;
     char *price = NULL, *url = NULL, *seller = NULL, *desc = NULL;
-    char until[8] = { 0 };
+    struct tm until = { 0 };
     uint8_t received_as = 0;
 
     unsigned int off = 0, id3_len;
@@ -376,17 +391,40 @@ static void output_id3(output_t *st, unsigned int program, uint8_t *buf, unsigne
 
                 pos = delim[i] + (delim_enc == 1 ? 2 : 1);
                 if (i == 0)
+                {
+                    until.tm_year = parse_digits((char *) delim[0] + 1, 4) - 1900;
+                    until.tm_mon = parse_digits((char *) delim[0] + 5, 2) - 1;
+                    until.tm_mday = parse_digits((char *) delim[0] + 7, 2);
+
+                    if (until.tm_mday < 0 || until.tm_mon < 0 || until.tm_year < 0)
+                    {
+                        log_debug("Fail to parse valid_until on COMR tag.");
+                        break;
+                    }
+                    if (pos + 8 > end)
+                    {
+                        log_warn("bad COMM tag (frame_len %d)", frame_len);
+                        break;
+                    }
+
                     pos += 8;
+                }
                 else if (i == 1)
+                {
+                    if (pos + 1 > end)
+                    {
+                        log_warn("bad COMM tag (frame_len %d)", frame_len);
+                        break;
+                    }
+
                     pos += 1;
+                }
             }
 
             if (i == 4)
             {
                 uint8_t* end_text = enc == 1 ? delim[2] + 2 : delim[2] + 1;
-
                 price = strdup((char *) data + 1);
-                memcpy(until, (char *) delim[0] + 1, sizeof(until));
                 url = strdup((char *) delim[0] + 9);
                 received_as = *(delim[1] + 1);
                 seller = id3_encode_utf8(enc, delim[1] + 2, delim[2] - (delim[1] + 2));
@@ -474,7 +512,7 @@ static void output_id3(output_t *st, unsigned int program, uint8_t *buf, unsigne
     evt.id3.commercial.seller = seller;
     evt.id3.commercial.description = desc;
     evt.id3.commercial.received_as = received_as;
-    memcpy(evt.id3.commercial.valid_until, until, sizeof(until));
+    evt.id3.commercial.valid_until = &until;
 
     nrsc5_report(st->radio, &evt);
 

--- a/src/output.c
+++ b/src/output.c
@@ -398,7 +398,7 @@ static void output_id3(output_t *st, unsigned int program, uint8_t *buf, unsigne
 
                     if (until.tm_mday < 0 || until.tm_mon < 0 || until.tm_year < 0)
                     {
-                        log_debug("Fail to parse valid_until on COMR tag.");
+                        log_warn("Fail to parse valid_until on COMR tag.");
                         break;
                     }
                     if (pos + 8 > end)

--- a/support/cli.py
+++ b/support/cli.py
@@ -298,9 +298,10 @@ class NRSC5CLI:
                     logging.info("XHDR: param=%s mime=%s lot=%s",
                                  evt.xhdr.param, evt.xhdr.mime.name, evt.xhdr.lot)
                 if evt.commercial:
-                    logging.info("Commercial: price=%s until=%.4s-%.2s-%.2s url=\"%s\" seller=\"%s\" desc=\"%s\" received_as=%d",
-                                 evt.commercial.price, evt.commercial.valid_until, evt.commercial.valid_until[4:5], evt.commercial.valid_until[6:8],
-                                 evt.commercial.contact_url, evt.commercial.seller, evt.commercial.description, evt.commercial.received_as)
+                    date_str = evt.commercial.valid_until.strftime("%Y-%m-%d")
+                    logging.info("Commercial: price=%s until=%s url=\"%s\" seller=\"%s\" desc=\"%s\" received_as=%d",
+                                 evt.commercial.price, date_str, evt.commercial.contact_url, evt.commercial.seller,
+                                 evt.commercial.description, evt.commercial.received_as)
         elif evt_type == nrsc5.EventType.SIG:
             for service in evt:
                 logging.info("SIG Service: type=%s number=%s name=%s",

--- a/support/cli.py
+++ b/support/cli.py
@@ -297,6 +297,10 @@ class NRSC5CLI:
                 if evt.xhdr:
                     logging.info("XHDR: param=%s mime=%s lot=%s",
                                  evt.xhdr.param, evt.xhdr.mime.name, evt.xhdr.lot)
+                if evt.commercial:
+                    logging.info("Commercial: price=%s until=%.4s-%.2s-%.2s url=\"%s\" seller=\"%s\" desc=\"%s\" received_as=%d",
+                                 evt.commercial.price, evt.commercial.valid_until, evt.commercial.valid_until[4:5], evt.commercial.valid_until[6:8],
+                                 evt.commercial.contact_url, evt.commercial.seller, evt.commercial.description, evt.commercial.received_as)
         elif evt_type == nrsc5.EventType.SIG:
             for service in evt:
                 logging.info("SIG Service: type=%s number=%s name=%s",

--- a/support/nrsc5.py
+++ b/support/nrsc5.py
@@ -770,7 +770,11 @@ class NRSC5:
                                         self._decode(id3.commercial.seller),
                                         self._decode(id3.commercial.description),
                                         id3.commercial.received_as,
-                                        self._timestruct_to_datetime(id3.commercial.valid_until))
+                                        datetime.date(
+                                            id3.commercial.valid_until.contents.tm_year + 1900,
+                                            id3.commercial.valid_until.contents.tm_mon + 1,
+                                            id3.commercial.valid_until.contents.tm_mday
+                                        ))
 
             evt = ID3(id3.program, self._decode(id3.title), self._decode(id3.artist),
                       self._decode(id3.album), self._decode(id3.genre), ufid, xhdr, comments, commercial)

--- a/support/nrsc5.py
+++ b/support/nrsc5.py
@@ -764,7 +764,7 @@ class NRSC5:
                 comments.append(Comment(self._decode(c.lang), self._decode(c.short_content_desc), self._decode(c.full_text)))
                 comment_ptr = c.next
             commercial = None
-            if id3.commercial.price:
+            if id3.commercial.price is not None:
                 commercial = Commercial(self._decode(id3.commercial.price),
                                         self._decode(id3.commercial.contact_url),
                                         self._decode(id3.commercial.seller),

--- a/support/nrsc5.py
+++ b/support/nrsc5.py
@@ -204,7 +204,7 @@ Audio = collections.namedtuple("Audio", ["program", "data"])
 Comment = collections.namedtuple("Comment", ["lang", "short_content_desc", "full_text"])
 UFID = collections.namedtuple("UFID", ["owner", "id"])
 XHDR = collections.namedtuple("XHDR", ["mime", "param", "lot"])
-Commercial = collections.namedtuple("Commercial", ["price", "valid_until", "contact_url", "seller", "description", "received_as"])
+Commercial = collections.namedtuple("Commercial", ["price", "contact_url", "seller", "description", "received_as", "valid_until"])
 ID3 = collections.namedtuple("ID3", ["program", "title", "artist", "album", "genre", "ufid", "xhdr", "comments", "commercial"])
 SIGAudioComponent = collections.namedtuple("SIGAudioComponent", ["port", "type", "mime"])
 SIGDataComponent = collections.namedtuple("SIGDataComponent", ["port", "service_data_type", "type", "mime"])
@@ -236,6 +236,19 @@ ExciterInfo = collections.namedtuple("ExciterInfo", ["manufacturer_id", "core_ve
 ImporterInfo = collections.namedtuple("ImporterInfo", ["manufacturer_id", "core_version", "core_status", "manufacturer_version", "manufacturer_status"])
 LeapSecondOffset = collections.namedtuple("LeapOffset", ["pending_offset", "current_offset", "pending_alfn"])
 LocalTime = collections.namedtuple("LocalTime", ["utc_offset", "dst_regional", "dst_local", "dst_schedule"])
+
+class _TimeStruct(ctypes.Structure):
+    _fields_ = [
+        ("tm_sec", ctypes.c_int),
+        ("tm_min", ctypes.c_int),
+        ("tm_hour", ctypes.c_int),
+        ("tm_mday", ctypes.c_int),
+        ("tm_mon", ctypes.c_int),
+        ("tm_year", ctypes.c_int),
+        ("tm_wday", ctypes.c_int),
+        ("tm_yday", ctypes.c_int),
+        ("tm_isdst", ctypes.c_int),
+    ]
 
 class _IQ(ctypes.Structure):
     _fields_ = [
@@ -314,11 +327,11 @@ class _XHDR(ctypes.Structure):
 class _Commercial(ctypes.Structure):
     _fields_ = [
         ("price", ctypes.c_char_p),
-        ("valid_until", ctypes.c_char * 8),
         ("contact_url", ctypes.c_char_p),
         ("seller", ctypes.c_char_p),
         ("description", ctypes.c_char_p),
         ("received_as", ctypes.c_ubyte),
+        ("valid_until", ctypes.POINTER(_TimeStruct)),
     ]
 
 class _ID3(ctypes.Structure):
@@ -413,21 +426,6 @@ class _PACKET(ctypes.Structure):
         ("service", ctypes.POINTER(_SIGService)),
         ("component", ctypes.POINTER(_SIGComponent)),
     ]
-
-
-class _TimeStruct(ctypes.Structure):
-    _fields_ = [
-        ("tm_sec", ctypes.c_int),
-        ("tm_min", ctypes.c_int),
-        ("tm_hour", ctypes.c_int),
-        ("tm_mday", ctypes.c_int),
-        ("tm_mon", ctypes.c_int),
-        ("tm_year", ctypes.c_int),
-        ("tm_wday", ctypes.c_int),
-        ("tm_yday", ctypes.c_int),
-        ("tm_isdst", ctypes.c_int),
-    ]
-
 
 class _LOT(ctypes.Structure):
     _fields_ = [
@@ -768,11 +766,11 @@ class NRSC5:
             commercial = None
             if id3.commercial.price:
                 commercial = Commercial(self._decode(id3.commercial.price),
-                                        self._decode(id3.commercial.valid_until),
                                         self._decode(id3.commercial.contact_url),
                                         self._decode(id3.commercial.seller),
                                         self._decode(id3.commercial.description),
-                                        id3.commercial.received_as)
+                                        id3.commercial.received_as,
+                                        self._timestruct_to_datetime(id3.commercial.valid_until))
 
             evt = ID3(id3.program, self._decode(id3.title), self._decode(id3.artist),
                       self._decode(id3.album), self._decode(id3.genre), ufid, xhdr, comments, commercial)

--- a/support/nrsc5.py
+++ b/support/nrsc5.py
@@ -204,7 +204,8 @@ Audio = collections.namedtuple("Audio", ["program", "data"])
 Comment = collections.namedtuple("Comment", ["lang", "short_content_desc", "full_text"])
 UFID = collections.namedtuple("UFID", ["owner", "id"])
 XHDR = collections.namedtuple("XHDR", ["mime", "param", "lot"])
-ID3 = collections.namedtuple("ID3", ["program", "title", "artist", "album", "genre", "ufid", "xhdr", "comments"])
+Commercial = collections.namedtuple("Commercial", ["price", "valid_until", "contact_url", "seller", "description", "received_as"])
+ID3 = collections.namedtuple("ID3", ["program", "title", "artist", "album", "genre", "ufid", "xhdr", "comments", "commercial"])
 SIGAudioComponent = collections.namedtuple("SIGAudioComponent", ["port", "type", "mime"])
 SIGDataComponent = collections.namedtuple("SIGDataComponent", ["port", "service_data_type", "type", "mime"])
 SIGComponent = collections.namedtuple("SIGComponent", ["type", "id", "audio", "data"])
@@ -310,6 +311,15 @@ class _XHDR(ctypes.Structure):
         ("lot", ctypes.c_int),
     ]
 
+class _Commercial(ctypes.Structure):
+    _fields_ = [
+        ("price", ctypes.c_char_p),
+        ("valid_until", ctypes.c_char * 8),
+        ("contact_url", ctypes.c_char_p),
+        ("seller", ctypes.c_char_p),
+        ("description", ctypes.c_char_p),
+        ("received_as", ctypes.c_ubyte),
+    ]
 
 class _ID3(ctypes.Structure):
     _fields_ = [
@@ -321,6 +331,7 @@ class _ID3(ctypes.Structure):
         ("ufid", _UFID),
         ("xhdr", _XHDR),
         ("comments", ctypes.POINTER(_Comment)),
+        ("commercial", _Commercial),
     ]
 
 
@@ -754,9 +765,17 @@ class NRSC5:
                 c = comment_ptr.contents
                 comments.append(Comment(self._decode(c.lang), self._decode(c.short_content_desc), self._decode(c.full_text)))
                 comment_ptr = c.next
+            commercial = None
+            if id3.commercial.price:
+                commercial = Commercial(self._decode(id3.commercial.price),
+                                        self._decode(id3.commercial.valid_until),
+                                        self._decode(id3.commercial.contact_url),
+                                        self._decode(id3.commercial.seller),
+                                        self._decode(id3.commercial.description),
+                                        id3.commercial.received_as)
 
             evt = ID3(id3.program, self._decode(id3.title), self._decode(id3.artist),
-                      self._decode(id3.album), self._decode(id3.genre), ufid, xhdr, comments)
+                      self._decode(id3.album), self._decode(id3.genre), ufid, xhdr, comments, commercial)
         elif evt_type == EventType.SIG:
             evt = []
             self.services = {}

--- a/support/nrsc5.py
+++ b/support/nrsc5.py
@@ -330,7 +330,7 @@ class _Commercial(ctypes.Structure):
         ("contact_url", ctypes.c_char_p),
         ("seller", ctypes.c_char_p),
         ("description", ctypes.c_char_p),
-        ("received_as", ctypes.c_ubyte),
+        ("received_as", ctypes.c_uint8),
         ("valid_until", ctypes.POINTER(_TimeStruct)),
     ]
 


### PR DESCRIPTION
Continuation of #372 

Commercial tags are currently only printed out when libnrsc5 is compiled with debug logging. This adds commercial tags to the API and prints commercial tags in the CLIs. 

Comment tags were also completely broken if the encoding was UCS-2. `buf` and `len` were used instead of the proper `frame_len` and `data`

Example from CFMI:
```
22:11:09 Audio service 0: public, type: None, codec: 0, blend: 2, gain: 0 dB, delay: 96, latency: 8
22:11:09 Title: Wish You Were Here
22:11:09 Artist: Pink Floyd
22:11:09 Genre: ROCK
22:11:09 Commercial: price=USD000.00 until=2027-06-27 url="-" seller="-" desc="-" received_as=0
22:11:09 Audio service 2: public, type: None, codec: 0, blend: 0, gain: 0 dB, delay: 0, latency: 8
22:11:09 Audio service 1: public, type: None, codec: 0, blend: 0, gain: 0 dB, delay: 0, latency: 8
22:11:09 MER: 9.6 dB (lower), 11.4 dB (upper)
22:11:09 BER: 0.000358, avg: 0.000367, min: 0.000358, max: 0.000375
22:11:09 Title: Wish You Were Here
22:11:09 Artist: Pink Floyd
22:11:09 Genre: ROCK
22:11:09 Commercial: price=USD000.00 until=2027-06-27 url="-" seller="-" desc="-" received_as=0
```