### PR TITLE
Reset AAS state when SIG table changes

### DIFF
--- a/src/output.c
+++ b/src/output.c
@@ -181,6 +181,10 @@ static void aas_free_lot(aas_file_t *file)
 
 static void aas_reset(output_t *st)
 {
+    free(st->sig_bytes);
+    st->sig_bytes = NULL;
+    st->sig_len = 0;
+
     for (int i = 0; i < MAX_SIG_SERVICES; i++)
     {
         sig_service_t *service = &st->services[i];
@@ -579,13 +583,22 @@ static void parse_sig(output_t *st, uint8_t *buf, unsigned int len)
     uint8_t *p = buf;
     sig_service_t *service = NULL;
 
-    if (st->services[0].type != SIG_SERVICE_NONE)
+    if (st->sig_bytes)
     {
-        // We assume that the SIG will never change, and only process it once.
-        return;
+        if ((len == st->sig_len) && (memcmp(buf, st->sig_bytes, len) == 0))
+        {
+            // previously parsed SIG table has not changed
+            return;
+        }
+        else
+        {
+            aas_reset(st);
+        }
     }
 
-    memset(st->services, 0, sizeof(st->services));
+    st->sig_bytes = (uint8_t *) malloc(len);
+    memcpy(st->sig_bytes, buf, len);
+    st->sig_len = len;
 
     while (p < buf + len)
     {

--- a/src/output.h
+++ b/src/output.h
@@ -124,6 +124,8 @@ typedef struct
     NeAACDecHandle aacdec[MAX_PROGRAMS];
     int16_t silence[NRSC5_AUDIO_FRAME_SAMPLES * 2];
 #endif
+    uint8_t *sig_bytes;
+    unsigned int sig_len;
     sig_service_t services[MAX_SIG_SERVICES];
     unsigned int lot_lru_counter;
     here_images_t here_images;


### PR DESCRIPTION
Fixes #458.
Replaces #525.

When a station changes its SIG table (a rare occurrence, it would appear), #525 updates the existing SIG structures in place. This is an interesting approach, and allows in-progress LOT file transfers to continue uninterrupted, but the code is rather complex. Since SIG table changes appear to be rare, I don't think it's a big deal to reset all AAS processing, so that's the approach I've taken here. To check for changes, I'm storing a copy of the SIG table bytes and comparing the new table using `memcmp`. This takes up a few hundred bytes of memory, but cuts down on CPU utilization and code complexity.