### PR TITLE
Add Audio Flags for decoding failed & audio silence

### DIFF
--- a/include/nrsc5.h
+++ b/include/nrsc5.h
@@ -362,6 +362,13 @@ enum
     NRSC5_PKT_FLAGS_CRC_ERROR = 1 << 0, /** Failed the CRC check. Could be corrupted packet. */
 };
 
+enum
+{
+    NRSC5_AUDIO_FLAGS_NONE = 0,
+    NRSC5_AUDIO_FLAGS_UNAVAILABLE = 1 << 0 /** Digital audio was currently unavailable. */,
+    NRSC5_AUDIO_FLAGS_DECODING_ERROR = 2 << 0, /** Failed audio decoding. */
+};
+
 /**  Incoming event from receiver.
  *
  * This event structure is passed to your application supplied
@@ -436,6 +443,7 @@ struct nrsc5_event_t
             unsigned int program;
             const int16_t *data;
             size_t count;
+            unsigned int flags; /** The specific status of the audio sample. Example `NRSC5_AUDIO_FLAGS_DECODING_ERROR` **/
         } audio;
         struct {
             unsigned int program;

--- a/include/nrsc5.h
+++ b/include/nrsc5.h
@@ -366,7 +366,7 @@ enum
 {
     NRSC5_AUDIO_FLAGS_NONE = 0,
     NRSC5_AUDIO_FLAGS_UNAVAILABLE = 1 << 0 /** Digital audio was currently unavailable. */,
-    NRSC5_AUDIO_FLAGS_DECODING_ERROR = 2 << 0, /** Failed audio decoding. */
+    NRSC5_AUDIO_FLAGS_DECODING_ERROR = 1 << 1, /** Failed audio decoding. */
 };
 
 /**  Incoming event from receiver.

--- a/src/main.c
+++ b/src/main.c
@@ -123,13 +123,16 @@ static void reset_audio_buffers(state_t *st)
     st->tail = NULL;
 }
 
-static void push_audio_buffer(state_t *st, unsigned int program, const int16_t *data, size_t count)
+static void push_audio_buffer(state_t *st, unsigned int program, const int16_t *data, size_t count, unsigned int flags)
 {
     audio_buffer_t *b;
 
     pthread_mutex_lock(&st->mutex);
     if (program != st->program)
         goto unlock;
+
+    if (flags & NRSC5_AUDIO_FLAGS_DECODING_ERROR)
+        log_warn("Audio decoding error");
 
     if (st->input_name)
     {
@@ -367,9 +370,7 @@ static void callback(const nrsc5_event_t *evt, void *opaque)
         }
         break;
     case NRSC5_EVENT_AUDIO:
-        if (evt->audio.flags & NRSC5_AUDIO_FLAGS_DECODING_ERROR)
-            log_error("Audio decoding error");
-        push_audio_buffer(st, evt->audio.program, evt->audio.data, evt->audio.count);
+        push_audio_buffer(st, evt->audio.program, evt->audio.data, evt->audio.count, evt->audio.flags);
         break;
     case NRSC5_EVENT_SYNC:
         log_info("Synchronized");

--- a/src/main.c
+++ b/src/main.c
@@ -367,6 +367,8 @@ static void callback(const nrsc5_event_t *evt, void *opaque)
         }
         break;
     case NRSC5_EVENT_AUDIO:
+        if (evt->audio.flags & NRSC5_AUDIO_FLAGS_DECODING_ERROR)
+            log_error("Audio decoding error");
         push_audio_buffer(st, evt->audio.program, evt->audio.data, evt->audio.count);
         break;
     case NRSC5_EVENT_SYNC:

--- a/src/nrsc5.c
+++ b/src/nrsc5.c
@@ -746,7 +746,7 @@ void nrsc5_report_hdc(nrsc5_t *st, unsigned int program, const packet_t* pkt)
     nrsc5_report(st, &evt);
 }
 
-void nrsc5_report_audio(nrsc5_t *st, unsigned int program, const int16_t *data, size_t count)
+void nrsc5_report_audio(nrsc5_t *st, unsigned int program, const int16_t *data, size_t count, unsigned int flags)
 {
     nrsc5_event_t evt;
 
@@ -754,6 +754,7 @@ void nrsc5_report_audio(nrsc5_t *st, unsigned int program, const int16_t *data, 
     evt.audio.program = program;
     evt.audio.data = data;
     evt.audio.count = count;
+    evt.audio.flags = flags;
     nrsc5_report(st, &evt);
 }
 

--- a/src/output.c
+++ b/src/output.c
@@ -114,6 +114,7 @@ void output_advance(output_t *st)
             packet_t* pkt = &elastic->packets[elastic->audio_offset];
 #ifdef USE_FAAD2
             int produced_audio = 0;
+            unsigned int flags = NRSC5_AUDIO_FLAGS_NONE;
 #endif
 
             if (is_complete_pkt(pkt))
@@ -134,11 +135,14 @@ void output_advance(output_t *st)
 
                 buffer = NeAACDecDecode(st->aacdec[program], &info, pkt->data, pkt->size);
                 if (info.error > 0)
-                    log_error("Decode error: %s", NeAACDecGetErrorMessage(info.error));
+                {
+                    log_warn("Decode error: %s", NeAACDecGetErrorMessage(info.error));
+                    flags |= NRSC5_AUDIO_FLAGS_DECODING_ERROR;
+                }
 
                 if (info.error == 0 && info.samples > 0)
                 {
-                    nrsc5_report_audio(st->radio, program, buffer, info.samples);
+                    nrsc5_report_audio(st->radio, program, buffer, info.samples, flags);
                     produced_audio = 1;
                 }
 #endif
@@ -159,7 +163,10 @@ void output_advance(output_t *st)
 
 #ifdef USE_FAAD2
             if (!produced_audio)
-                nrsc5_report_audio(st->radio, program, st->silence, NRSC5_AUDIO_FRAME_SAMPLES * 2);
+            {
+                flags |= NRSC5_AUDIO_FLAGS_UNAVAILABLE;
+                nrsc5_report_audio(st->radio, program, st->silence, NRSC5_AUDIO_FRAME_SAMPLES * 2, flags);
+            }
 #endif
     
             elastic->audio_offset = (elastic->audio_offset + 1) % ELASTIC_BUFFER_LEN;

--- a/src/private.h
+++ b/src/private.h
@@ -53,7 +53,7 @@ void nrsc5_report_lost_sync(nrsc5_t *);
 void nrsc5_report_mer(nrsc5_t *, float lower, float upper);
 void nrsc5_report_ber(nrsc5_t *, float cber);
 void nrsc5_report_hdc(nrsc5_t *, unsigned int program, const packet_t* pkt);
-void nrsc5_report_audio(nrsc5_t *, unsigned int program, const int16_t *data, size_t count);
+void nrsc5_report_audio(nrsc5_t *, unsigned int program, const int16_t *data, size_t count, unsigned int flags);
 void nrsc5_report_stream(nrsc5_t *, uint16_t seq, unsigned int size, const uint8_t *data,
                          nrsc5_sig_service_t *service, nrsc5_sig_component_t *component);
 void nrsc5_report_packet(nrsc5_t *, uint16_t seq, unsigned int size, const uint8_t *data,

--- a/support/cli.py
+++ b/support/cli.py
@@ -266,6 +266,8 @@ class NRSC5CLI:
                     self.audio_errors = 0
         elif evt_type == nrsc5.EventType.AUDIO:
             if evt.program == self.args.program:
+                if evt.flags & nrsc5.AudioFlags.DECODING_ERROR:
+                    logging.warning("Audio decoding error")
                 if self.args.o:
                     if self.args.t == "wav":
                         try:

--- a/support/nrsc5.py
+++ b/support/nrsc5.py
@@ -194,13 +194,18 @@ class PacketFlags(enum.IntFlag):
     NONE = 0
     CRC_ERROR = 1 << 0
 
+class AudioFlags(enum.IntFlag):
+    NONE = 0
+    UNAVAILABLE = 1 << 0
+    DECODING_ERROR = 2 << 0
+
 
 IQ = collections.namedtuple("IQ", ["data"])
 Sync = collections.namedtuple("Sync", ["freq_offset", "psmi", "pli", "hppi", "aabi", "rdbi"])
 MER = collections.namedtuple("MER", ["lower", "upper"])
 BER = collections.namedtuple("BER", ["cber"])
 HDC = collections.namedtuple("HDC", ["program", "data", "flags"])
-Audio = collections.namedtuple("Audio", ["program", "data"])
+Audio = collections.namedtuple("Audio", ["program", "data", "flags"])
 Comment = collections.namedtuple("Comment", ["lang", "short_content_desc", "full_text"])
 UFID = collections.namedtuple("UFID", ["owner", "id"])
 XHDR = collections.namedtuple("XHDR", ["mime", "param", "lot"])
@@ -295,6 +300,7 @@ class _Audio(ctypes.Structure):
         ("program", ctypes.c_uint),
         ("data", ctypes.POINTER(ctypes.c_char)),
         ("count", ctypes.c_size_t),
+        ("flags", ctypes.c_uint),
     ]
 
 
@@ -744,7 +750,7 @@ class NRSC5:
             evt = HDC(hdc.program, hdc.data[:hdc.count], PacketFlags(hdc.flags))
         elif evt_type == EventType.AUDIO:
             audio = c_evt.u.audio
-            evt = Audio(audio.program, audio.data[:audio.count * 2])
+            evt = Audio(audio.program, audio.data[:audio.count * 2], audio.flags)
         elif evt_type == EventType.ID3:
             id3 = c_evt.u.id3
 

--- a/support/nrsc5.py
+++ b/support/nrsc5.py
@@ -197,7 +197,7 @@ class PacketFlags(enum.IntFlag):
 class AudioFlags(enum.IntFlag):
     NONE = 0
     UNAVAILABLE = 1 << 0
-    DECODING_ERROR = 2 << 0
+    DECODING_ERROR = 1 << 1
 
 
 IQ = collections.namedtuple("IQ", ["data"])


### PR DESCRIPTION
Adds #489 / #372

Since libnrsc5 defaults to no logging, there's no indication for audio errors if there are. This adds them to the API to at least give give an indication of an error to the C client user. 

It may be helpful for the API user to also display on their UI if silence was inserted. This PR also adds that to the API. This is defined as `NRSC5_AUDIO_FLAGS_UNAVAILABLE` (defined as when digital audio is unavailable) to hopefully make this more future-proof if any analog blending is added. 


